### PR TITLE
Editorial update of ja/privacy/index.lang

### DIFF
--- a/ja/privacy/index.lang
+++ b/ja/privacy/index.lang
@@ -2,7 +2,7 @@
 
 
 ;Mozilla Privacy
-Mozilla Privacy {ok}
+Mozilla Privacy{ok}
 
 
 ;Contact Mozilla
@@ -10,7 +10,7 @@ Mozilla Privacy {ok}
 
 
 ;If you want to make a correction to your information, or you have any questions about our privacy policies, please get in touch with:
-プライバシーポリシーに関する質問や、Mozillaが保持するユーザの個人情報の修正については以下の住所宛てにお問い合わせください。
+プライバシーポリシーに関する質問や、Mozilla が保持するユーザの個人情報の修正については以下の住所宛てにお問い合わせください。
 
 
 ;Data Privacy Principles
@@ -18,7 +18,7 @@ Mozilla Privacy {ok}
 
 
 ;Mozilla is an open source project with a mission to improve your Internet experience. This is a driving force behind our data privacy practices. <a href="%(link)s">Read More</a>
-MozillaはユーザのWebの体験をより良いものにすることをミッションに活動しているオープンソースのプロジェクトです。このミッションは、私たちがユーザのデータプライバシーを厳しく守る原動力となっています。<a href="%(link)s">詳しく見る</a>
+Mozilla はユーザの Web の体験をより良いものにすることをミッションに活動しているオープンソースのプロジェクトです。このミッションは、私たちがユーザのデータプライバシーを厳しく守る原動力となっています。<a href="%(link)s">詳しく見る</a>
 
 
 ;Our Privacy Notices
@@ -26,7 +26,7 @@ MozillaはユーザのWebの体験をより良いものにすることをミッ�
 
 
 ;We created short and clear Privacy Notices to describe how each of our products and services receives, shares, and uses data and what your choices are. Learn more:
-Mozillaが提供する製品やサービスのプライバシーに関する通知を用意しました。各通知には、それぞれの製品やサービスがどのようにデータを収取・共有・使用するかが簡潔にまとめられており、それに対してユーザが取れる行動が記されています。詳しくは以下のページをご覧ください。
+Mozilla が提供する製品やサービスのプライバシーに関する通知を用意しました。各通知には、それぞれの製品やサービスがどのようにデータを収取・共有・使用するかが簡潔にまとめられており、それに対してユーザが取れる行動が記されています。詳しくは以下のページをご覧ください。
 
 
 ;Mozilla Websites, Communications &amp; Cookies
@@ -34,7 +34,7 @@ Mozillaが提供する製品やサービスのプライバシーに関する通�
 
 
 ;Firefox Browser
-<a href="/ja/privacy/firefox/">Firefox ブラウザ</a>
+Firefox ブラウザ
 
 
 ;Firefox Cloud Services
@@ -42,11 +42,11 @@ Firefox クラウドサービス
 
 
 ;To review and comment on proposed changes to our privacy policies <a href="%(group)s"> subscribe to Mozilla’s Governance Group</a>.
-Mozillaの<a href="%(group)s"> ガバナンスグループ</a>に参加して、プライバシポリシーの変更案のレビューをしませんか。
+Mozilla の<a href="%(group)s">ガバナンスグループ</a>に参加して、プライバシポリシーの変更案のレビューをしませんか。
 
 
 ;Our ongoing work on privacy is covered by the <a href="%(blog)s">Privacy &amp; Data Safety Blog</a> and information about our ongoing work is available on <a href="%(wiki)s"> Mozilla’s privacy team wiki</a>.
-Mozillaのプライバシーに関する継続的な活動は<a href="%(blog)s">こちらのブログ</a>で知ることができます。また、Mozillaの<a href="%(wiki)s"> プライバシーチームの Wiki </a> にて詳しい情報を知ることもできます。
+Mozilla のプライバシーに関する継続的な活動は<a href="%(blog)s">こちらのブログ</a>でご覧になれます。また Mozilla の<a href="%(wiki)s">プライバシーチームの Wiki</a> にも詳しい情報があります。
 
 
 ;Outdated Policies
@@ -66,5 +66,3 @@ Mozillaのプライバシーに関する継続的な活動は<a href="%(blog)s">
 # Used in sub-pages to return to the main index https://www.mozilla.org/privacy
 ;Back to Mozilla Privacy Policy
 Mozilla プライバシーポリシーに戻る
-
-


### PR DESCRIPTION
Revised to conform Japanese editorial rules.
Remove link which causes a layout mess