### PR TITLE
Update geolocation.lang

### DIFF
--- a/en-US/firefox/geolocation.lang
+++ b/en-US/firefox/geolocation.lang
@@ -139,20 +139,20 @@ Navigate to the site to which you’ve given permission
 Go to the <em>Tools</em> menu, then select <em>Page Info</em>
 
 
-;Select the <em>Permissions</em> tab
-Select the <em>Permissions</em> tab
+;Select the <em>Permissions</em> panel
+Select the <em>Permissions</em> panel
 
 
-;Change the setting for <em>Share Location</em>
-Change the setting for <em>Share Location</em>
+;Change the setting for <em>Access Your Location</em>
+Change the setting for <em>Access Your Location</em>
 
 
 ;How do I clear the “random client identification number”?
 How do I clear the “random client identification number”?
 
 
-;Go to the <em>Tools</em> menu, then select <em>Clear Recent History</em>
-Go to the <em>Tools</em> menu, then select <em>Clear Recent History</em>
+;Go to the <em>History</em> menu, then select <em>Clear Recent History</em>
+Go to the <em>History</em> menu, then select <em>Clear Recent History…</em>
 
 
 ;Click the <em>Details</em> arrow

--- a/en-US/firefox/geolocation.lang
+++ b/en-US/firefox/geolocation.lang
@@ -151,7 +151,7 @@ Change the setting for <em>Access Your Location</em>
 How do I clear the “random client identification number”?
 
 
-;Go to the <em>History</em> menu, then select <em>Clear Recent History</em>
+;Go to the <em>History</em> menu, then select <em>Clear Recent History…</em>
 Go to the <em>History</em> menu, then select <em>Clear Recent History…</em>
 
 


### PR DESCRIPTION
"Share your Location" in Page Info was renamed to "Access Your Location", presumably by bug 885366. Also change "tab" wording to "panel".
"Clear Recent History…" menu item moved to "History" menu earlier.