### PR TITLE
Missing strings in thunderbird/start/release.lang

### DIFF
--- a/ar/thunderbird/start/release.lang
+++ b/ar/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Now is a great time for you to get involved: writing code, testing, support, loc
 هل تحتاج إلى مُساعدة؟
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 تتم الإجابة على أغلب الأسئلة المُتعلّقة بثندربرد على <a href="%s">قاعدة المعرفة</a>.
 

--- a/ast/thunderbird/start/release.lang
+++ b/ast/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Depriendi más
 ¿Precises sofitu?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 La mayoría d'entrugues del sofitu de Thunderbird tán respondíes na <a href="%s">Base de conocimientu</a>.
 

--- a/az/thunderbird/start/release.lang
+++ b/az/thunderbird/start/release.lang
@@ -73,6 +73,14 @@ We look forward to <a href="%s">hearing from you</a>.
 Dəstək Lazımdır?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Əksər Thunderbird dəstək sualları <a href="%s">Məlumat Bazasında</a> cavablanıb.
 

--- a/be/thunderbird/start/release.lang
+++ b/be/thunderbird/start/release.lang
@@ -73,6 +73,14 @@ We look forward to <a href="%s">hearing from you</a>.
 Need Support?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 

--- a/bg/thunderbird/start/release.lang
+++ b/bg/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Now is a great time for you to get involved: writing code, testing, support, loc
 Нужда от помощ?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Повечето въпроси относно Thunderbird  са вече отговорени в <a href="%s">Knowledge Base</a>.
 

--- a/bn-BD/thunderbird/start/release.lang
+++ b/bn-BD/thunderbird/start/release.lang
@@ -73,6 +73,14 @@ We look forward to <a href="%s">hearing from you</a>.
 Need Support?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 

--- a/br/thunderbird/start/release.lang
+++ b/br/thunderbird/start/release.lang
@@ -73,6 +73,14 @@ Gouzout muioc'h
 Need Support?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 

--- a/ca/thunderbird/start/release.lang
+++ b/ca/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Més informació
 Necessiteu ajuda?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 La majoria de preguntes d'assistència del Thunderbird tenen resposta a la <a href="%s">base de coneixements</a>.
 

--- a/cs/thunderbird/start/release.lang
+++ b/cs/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Dozvědět se více
 Potřebujete pomoc?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Většina dotazů k Thunderbirdu je zodpovězena v <a href="%s">Nápovědě k Thunderbirdu</a>.
 

--- a/cy/thunderbird/start/release.lang
+++ b/cy/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Dysgu rhagor
 Angen Cefnogaeth?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Mae'r rhan fwyaf o gwestiynau cefnogaeth Thunderbird yn cael eu hateb yn y <a href="%s">Knowledge Base</a>.
 

--- a/da/thunderbird/start/release.lang
+++ b/da/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Læs mere
 Har du brug for hjælp?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 De fleste spørgsmål om Thunderbird er allerede besvaret i vores <a href="%s">vidensbase</a>.
 

--- a/de/thunderbird/start/release.lang
+++ b/de/thunderbird/start/release.lang
@@ -75,6 +75,14 @@ Erfahren Sie mehr
 Benötigen Sie Hilfe?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Die meisten Fragen zu Thunderbird werden in der <a href="%s">Wissensdatenbank</a> behandelt.
 

--- a/dsb/thunderbird/start/release.lang
+++ b/dsb/thunderbird/start/release.lang
@@ -75,6 +75,14 @@ Dalšne informacije
 Trjebaśo pomoc?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Nejwěcej pšašanjow pomocy Thunderbird wótegranja se w <a href="%s">datowej bance wědy</a>.
 

--- a/el/thunderbird/start/release.lang
+++ b/el/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Now is a great time for you to get involved: writing code, testing, support, loc
 Χρειάζεστε υποστήριξη;
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Οι περισσότερες ερωτήσεις υποστήριξης για τον Thunderbird έχουν απαντηθεί στη <a href="%s">Γνωσιακή Βάση</a>.
 

--- a/en-GB/thunderbird/start/release.lang
+++ b/en-GB/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Learn more {ok}
 Need Support? {ok}
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>. {ok}
 

--- a/en-US/thunderbird/start/release.lang
+++ b/en-US/thunderbird/start/release.lang
@@ -85,6 +85,16 @@ Learn more
 Need Support?
 
 
+## TAG: thunderbird_startpage_donate_2016_06
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+## TAG: thunderbird_startpage_donate_2016_06
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 

--- a/es-AR/thunderbird/start/release.lang
+++ b/es-AR/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Conocé más
 ¿Necesitás ayuda?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 La mayoría de los pedidos de ayuda sobre Thunderbird tienen respuesta en la <a href="%s">base de conocimiento</a>.
 

--- a/es-ES/thunderbird/start/release.lang
+++ b/es-ES/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Más información
 ¿Necesitas ayuda?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 En la <a href="%s">base de conocimientos</a> puedes encontrar la respuesta a la mayoría de preguntas relacionadas con Thunderbird.
 

--- a/et/thunderbird/start/release.lang
+++ b/et/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Rohkem teavet
 Vajad abi?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Enamik Thunderbirdi kasutajatoe küsimusi saavad vastuse <a href="%s">Teadmusbaasist</a>.
 

--- a/eu/thunderbird/start/release.lang
+++ b/eu/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Argibide gehiago
 Laguntza bila?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Thunderbirdi buruzko galdera gehienak <a href="%s">jakintza-basean</a> erantzunda daude.
 

--- a/fi/thunderbird/start/release.lang
+++ b/fi/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Lue lisää
 Tarvitsetko tukea?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Useimpiin Thunderbird-kysymyksiin on vastaukset <a href="%s">tukikannassa</a>.
 

--- a/fr/thunderbird/start/release.lang
+++ b/fr/thunderbird/start/release.lang
@@ -75,6 +75,14 @@ En savoir plus
 Besoin d’aide&nbsp;?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 La plupart des questions sur l’assistance de Thunderbird trouvent une réponse dans la <a href="%s">base de connaissances</a>.
 

--- a/fy-NL/thunderbird/start/release.lang
+++ b/fy-NL/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Mear lêze
 Help nedich?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 De measte Thunderbird stipefragen wurde beantwurde yn de <a href="%s">Kennisbank</a>.
 

--- a/ga-IE/thunderbird/start/release.lang
+++ b/ga-IE/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Tuilleadh Eolais
 An bhfuil tacaíocht uait?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Freagraítear formhór na gceisteanna tacaíochta maidir le Thunderbird ar an <a href="%s">mBunachar Eolais</a>.
 

--- a/gd/thunderbird/start/release.lang
+++ b/gd/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Barrachd fiosrachaidh
 Taic a dhìth ort?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Gheibhear freagairtean air cuid mhòr dhe na ceistean a thaobh Thunderbird san <a href="%s">Knowledge Base</a>.
 

--- a/gl/thunderbird/start/release.lang
+++ b/gl/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Máis información
 Precisa axuda?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Na <a href="%s">base de coñecementos</a> pode atopar a resposta á maioría das preguntas relacionadas con Thunderbird.
 

--- a/he/thunderbird/start/release.lang
+++ b/he/thunderbird/start/release.lang
@@ -73,6 +73,14 @@ We look forward to <a href="%s">hearing from you</a>.
 Need Support?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 

--- a/hr/thunderbird/start/release.lang
+++ b/hr/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Saznajte više
 Trebate podršku?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Većina Thunderbird pitanja podrške su odgovorena u <a href="%s">bazi znanja</a>.
 

--- a/hsb/thunderbird/start/release.lang
+++ b/hsb/thunderbird/start/release.lang
@@ -75,6 +75,14 @@ Dalše informacije
 Trjebaće pomoc?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Najwjace prašenjow pomocy Thunderbird wotmołwja so w <a href="%s">datowej bance wědy</a>.
 

--- a/hu/thunderbird/start/release.lang
+++ b/hu/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Tudjon meg többet
 Segítségre van szüksége?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 A legtöbb Thunderbird támogatási kérésre választ talál a <a href="%s">Tudásbázisban</a>.
 

--- a/hy-AM/thunderbird/start/release.lang
+++ b/hy-AM/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Now is a great time for you to get involved: writing code, testing, support, loc
 Աջակցության կարի՞ք ունեք:
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Thunderbird-ի վերաբերյալ բազմաթիվ հարցերի պատասխաններ կգտնեք <a href="%s">Գիտելիքների շտեմարանում</a>:
 

--- a/id/thunderbird/start/release.lang
+++ b/id/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Pelajari lebih lanjut
 Butuh Dukungan?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Semua pertanyaan terkait dukungan Thunderbird telah dijawab di <a href="%s">Pundi Pengetahuan</a>.
 

--- a/is/thunderbird/start/release.lang
+++ b/is/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Fræðast meira
 Vantar þig hjálp?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Flestum Thunderbird spurningum hefur verið svarað í <a href="%s">þekkingargrunninum</a>.
 

--- a/it/thunderbird/start/release.lang
+++ b/it/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Ulteriori informazioni
 Hai bisogno d’aiuto?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 La maggior parte delle richieste di aiuto relative a Thunderbird trovano risposta nella <a href="%s">documentazione ufficiale</a>.
 

--- a/ja/thunderbird/start/release.lang
+++ b/ja/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Thunderbird に貢献しよう
 サポートが必要なときは
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 <a href="%s">ナレッジベース</a> には、Thunderbird に関する質問と答えが掲載されています。まずはそちらをご覧ください。
 

--- a/ko/thunderbird/start/release.lang
+++ b/ko/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Thunderbird 사용자 지원 및 제품 개선, 생태계 지원에 도움을 �
 고객 지원
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Thunderbird에 대한 주요한 질문에 대한 답변은 <a href="%s">지식 기반</a>에서 찾아볼 수 있습니다.
 

--- a/lt/thunderbird/start/release.lang
+++ b/lt/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Išsamiau
 Reikia pagalbos?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Dauguma su „Thunderbird“ programa susijusių klausimų yra atsakyti mūsų <a href="%s">Žinyne</a>.
 

--- a/nb-NO/thunderbird/start/release.lang
+++ b/nb-NO/thunderbird/start/release.lang
@@ -73,6 +73,14 @@ Les mer
 Need Support?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 

--- a/nl/thunderbird/start/release.lang
+++ b/nl/thunderbird/start/release.lang
@@ -75,6 +75,14 @@ Meer info
 Ondersteuning nodig?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 De meeste ondersteuningsvragen over Thunderbird worden beantwoord in de <a href="%s">Kennisbank</a>.
 

--- a/nn-NO/thunderbird/start/release.lang
+++ b/nn-NO/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Les meir
 Treng du hjelp?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Dei fleste brukarstøttespørsmåla om Thunderbird finn du svar på i <a href="%s">kunskapsbasen</a>.
 

--- a/pa-IN/thunderbird/start/release.lang
+++ b/pa-IN/thunderbird/start/release.lang
@@ -73,6 +73,14 @@ Please help us assist users of Thunderbird, and improve the Thunderbird product 
 ਸਹਾਇਤਾ ਚਾਹੀਦੀ ਹੈ?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 

--- a/pl/thunderbird/start/release.lang
+++ b/pl/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Dowiedz się więcej
 Potrzebujesz pomocy?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Na większość pytań o Thunderbirda została już udzielona odpowiedź w <a href="%s">bazie wiedzy</a>.
 

--- a/pt-BR/thunderbird/start/release.lang
+++ b/pt-BR/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Saiba mais
 Precisa de ajuda?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 A maioria das perguntas sobre o Thunderbird já foram respondidas na nossa <a href="%s">base de conhecimento</a>.
 

--- a/pt-PT/thunderbird/start/release.lang
+++ b/pt-PT/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Saber mais
 Precisa de apoio?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 A maioria das questões de apoio ao Thunderbird são respondidas na <a href="%s">Base de Conhecimento</a>.
 

--- a/rm/thunderbird/start/release.lang
+++ b/rm/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Emprenda dapli
 Dovras agid?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 La plipart da las dumondas d'agid da Thunderbird èn respundidas en la <a href="%s">Banca da savida</a>.
 

--- a/ro/thunderbird/start/release.lang
+++ b/ro/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Află mai multe
 Ai nevoie de ajutor?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Cele mai multe întrebări de suport Thunderbird sunt răspunse în <a href="%s">Baza de Cunoștințe</a>.
 

--- a/ru/thunderbird/start/release.lang
+++ b/ru/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Now is a great time for you to get involved: writing code, testing, support, loc
 Нужна поддержка?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Большинство ответов на вопросы по поддержке Thunderbird можно найти в <a href="%s">Базе знаний</a>.
 

--- a/si/thunderbird/start/release.lang
+++ b/si/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Thunderbird භාවිතා කරන්නන් හට සහාය වී�
 උදව් අවශ්‍යද?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 බොහොමයක් Thunderbird පැණ සඳහා පිළි්‍තුරු සපයා දෙනු ලබන්නේ  <a href="%s">දැනුම් කේන්ද්‍රය (Knowledge Base) </a> මඟිනි.
 

--- a/sk/thunderbird/start/release.lang
+++ b/sk/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Zapojte sa, <a href="%s">tešíme sa na vás</a>.
 Potrebujete pomoc?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Väčšina otázok ohľadne podpory pre Thunderbird je zodpovedaných v našej <a href="%s">databáze znalostí</a>.
 

--- a/sl/thunderbird/start/release.lang
+++ b/sl/thunderbird/start/release.lang
@@ -75,6 +75,14 @@ Več o tem
 Potrebujete pomoč?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Večino pomoči za Thunderbird najdete v <a href="%s">Zbirki znanja</a>.
 

--- a/sq/thunderbird/start/release.lang
+++ b/sq/thunderbird/start/release.lang
@@ -75,6 +75,14 @@ Mësoni Më Tepër
 Ju duhet Asistencë?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Shumica e pyetjeve lidhur me asistencë Thunderbird-i kanë marrë përgjigje te <a href="%s">Baza e Dijes</a>.
 

--- a/sr/thunderbird/start/release.lang
+++ b/sr/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Now is a great time for you to get involved: writing code, testing, support, loc
 Потребна подршка?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Већина питања за Thunderbird подршку се одговарају у <a href="%s">Бази знања</a>.
 

--- a/sv-SE/thunderbird/start/release.lang
+++ b/sv-SE/thunderbird/start/release.lang
@@ -75,6 +75,14 @@ Läs mer
 Behöver du hjälp?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 De flesta hjälpfrågorna om Thunderbird finns besvarade i <a href="%s">kunskapsbasen</a>.
 

--- a/tr/thunderbird/start/release.lang
+++ b/tr/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Devamını okuyun
 Desteğe mi ihtiyacınız var?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Thunderbird destek sorularının çoğu <a href="%s">Bilgi Bankası’nda</a> yanıtlanmıştır.
 

--- a/uk/thunderbird/start/release.lang
+++ b/uk/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Now is a great time for you to get involved: writing code, testing, support, loc
 Потрібна підтримка?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Більшість відповідей на питання щодо Thunderbird ви знайдете у <a href="%s">Базі знань</a>.
 

--- a/vi/thunderbird/start/release.lang
+++ b/vi/thunderbird/start/release.lang
@@ -73,6 +73,14 @@ Tìm hiểu thêm
 Need Support?
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 

--- a/zh-CN/thunderbird/start/release.lang
+++ b/zh-CN/thunderbird/start/release.lang
@@ -75,6 +75,14 @@ Thunderbird 是领先的开源、跨平台电子邮件和日历客户端，免�
 需要帮助？
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 大多数 Thunderbird 技术支持问题能够在<a href="%s">知识库</a>中找到答案。
 

--- a/zh-TW/thunderbird/start/release.lang
+++ b/zh-TW/thunderbird/start/release.lang
@@ -74,6 +74,14 @@ Now is a great time for you to get involved: writing code, testing, support, loc
 需要幫忙嗎？
 
 
+;Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+Most Thunderbird support questions are answered in the <a href="%s">Knowledge Base</a>.
+
+
+;If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+If you can’t find an answer, <a href="%s">ask your question in our support forum</a>.
+
+
 ;Most Thunderbird support questions are answered on the <a href="%s">Knowledge Base</a>.
 您能在<a href="%s">知識庫</a>找到 Thunderbird 大部分的問題解答。
 


### PR DESCRIPTION
Noticed missing strings on https://www-dev.allizom.org/fr/thunderbird/release/start/ (*in* vs. *on*)
@flodolo r?