### PR TITLE
DE: Update nightly_firstrun.html

### DIFF
--- a/de/templates/firefox/nightly_firstrun.html
+++ b/de/templates/firefox/nightly_firstrun.html
@@ -26,6 +26,7 @@
       <h4>Aktuelle Veranstaltungen</h4>
       <ul class="unstyled">
         <!--<li>&nbsp;<!- only text for us -></li> spacer line-->
+        <li>Open Mozilla Nights (Berlin) &ndash; jeden 2. Donnerstag &ndash; <a href="https://www.meetup.com/de-DE/Berlin-Mozilla-Meetup/">Meetup</a> &ndash; <a href="https://twitter.com/MozillaNight">Twitter</a></li>
       </ul>
     </div>
   </div>
@@ -47,7 +48,6 @@
 <h4>Aktuelle Veranstaltungen</h4>
 	<ul class="unstyled">
         <!--<li>&nbsp;<!- only text for us -></li> spacer line-->
-        <li>Mozilla Weekend Berlin &ndash; 11. und 12. Juli 2015 &ndash; <a href="http://www.mozweekend.de">www.mozweekend.de</a></li>
+        <li>Open Mozilla Nights (Berlin) &ndash; jeden 2. Donnerstag &ndash; <a href="https://www.meetup.com/de-DE/Berlin-Mozilla-Meetup/">Meetup</a> &ndash; <a href="https://twitter.com/MozillaNight">Twitter</a></li>
 	</ul>
 {% endl10n %}
-


### PR DESCRIPTION
Replace outdated Mozilla Weekend Berlin event with bi-weekly Open Mozilla Nights.