### PR TITLE
adding {ok} for non l10n ones

### DIFF
--- a/ro/mozorg/about/leadership.lang
+++ b/ro/mozorg/about/leadership.lang
@@ -51,7 +51,7 @@ Director general
 
 # Job title for David Bryant
 ;Interim CTO and VP, Platform Engineering
-Director tehnic interimar și VP, ingineria platformelor
+Director tehnic interimar și VP, Platform Engineering
 
 
 # Job title for Jim Cook
@@ -71,12 +71,12 @@ Vicepreședinte senior, Connected Devices
 
 # Job title for Katharina Borchert
 ;Chief Innovation Officer
-Chief Innovation Officer
+Chief Innovation Officer {ok}
 
 
 # Job title for David Slater
 ;Chief of Staff and SVP of Operations
-Director personal și SVP Operațiuni
+Director de personal și SVP Operațiuni
 
 
 # Job title for Allison Banks
@@ -86,7 +86,7 @@ VP, Personal
 
 # Job title for Susan Chen
 ;VP, Business Development
-VP, Business Development
+VP, Business Development {ok}
 
 
 # Job title for Jascha Kaykas-Wolff
@@ -96,12 +96,12 @@ Director de marketing
 
 # Job title for Mark Mayo
 ;Senior Vice President, Firefox
-Prim vice-președinte, Firefox
+Senior Vice President, Firefox {ok}
 
 
 # Job title for Mary Ellen Muckerman
 ;VP, Brand Engagement
-VP, angajament de marcă
+VP, Brand Engagement {ok}
 
 
 # Job title for Nick Nguyen
@@ -116,7 +116,7 @@ Fellow {ok}
 
 # Job title for Alex Salkever
 ;VP of Marketing Communications
-VP of Marketing Communications
+VP of Marketing Communications {ok}
 
 
 # Job title for Sylvie Veilleux
@@ -126,7 +126,7 @@ VP, tehnologia informației
 
 # Job title for Dr. Sean White
 ;VP, Technology Strategy
-VP, Technology Strategy
+VP, Technology Strategy {ok}
 
 
 ;Mozilla Foundation


### PR DESCRIPTION
localization not needed for some - adding {ok} for those that are not ok/doesn't sound ok to be l10n 

Changed back to English:
VP, angajament de marcă  -> ;VP, Brand Engagement 
// Brand translated as mark ( trademark) refers to the mark strickly and not the imagine of mozilla taht by brand is implied. 
// Marca in lb romana se refera strict la TM sau R si aici pentru minein engleaza brand e mai mult imaginea - dezvoltarea imaginii /director creativ ar fi apropiat. 

ingineria platformelor  - Platform Engineering

cc @cristisilaghi @jobava for review 
For mirroring - check Italian - there they keept all the titles of main leaders in english ( translated and only) https://www.mozilla.org/it/about/leadership/