### PR TITLE
Import translations from EOY take over from last year

### DIFF
--- a/ach/mozorg/home/index-2016.lang
+++ b/ach/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Imito kony?
 Get answers to your questions about Firefox and all Mozilla products from our support team.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/ach/mozorg/home/index-2016.lang
+++ b/ach/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continue to mozilla.org
 
 

--- a/af/mozorg/home/index-2016.lang
+++ b/af/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Benodig hulp?
 Antwoorde van ons steunspan op vrae oor Firefox en alle Mozilla-produkte.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Beter motiewe as wins. <br>Skenk voor 31 Des.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+Tik 'n eie bedrag
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Maandeliks
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Eenmalig
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Skenk nou
+
+

--- a/af/mozorg/home/index-2016.lang
+++ b/af/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Antwoorde van ons steunspan op vrae oor Firefox en alle Mozilla-produkte.
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Beter motiewe as wins. <br>Skenk voor 31 Des.
 
@@ -123,5 +125,10 @@ Eenmalig
 # Take over form: button to submit the donation form
 ;Donate Now
 Skenk nou
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Gaan voort na mozilla.org
 
 

--- a/an/mozorg/home/index-2016.lang
+++ b/an/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Obtiene respuestas a las tuyas qüestions sobre Firefox y totz os productos de M
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Con argüello, sin animo de lucro. <br>Dona antes d'o 31 d'aviento.
 
@@ -122,5 +124,10 @@ Una vegada
 # Take over form: button to submit the donation form
 ;Donate Now
 Dona agora
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Contina enta mozilla.org
 
 

--- a/an/mozorg/home/index-2016.lang
+++ b/an/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Te cal aduya?
 Obtiene respuestas a las tuyas qüestions sobre Firefox y totz os productos de Mozilla d'o nuestro equipo de soporte.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Con argüello, sin animo de lucro. <br>Dona antes d'o 31 d'aviento.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s EUR
+
+
+# Take over form
+;Enter your own amount
+Escribe la cantidat
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Mensualment
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Una vegada
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Dona agora
+
+

--- a/ar/mozorg/home/index-2016.lang
+++ b/ar/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Get Firefox today
 احصل على إجابات لتساؤلاتك المُتعلّقة بفَيَرفُكس وباقي مُنتجات موزيلا من فريق الدعم الفني.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/ar/mozorg/home/index-2016.lang
+++ b/ar/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get Firefox today
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+انتقل إلى mozilla.org
 
 

--- a/as/mozorg/home/index-2016.lang
+++ b/as/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Learn about the benefits of working at Mozilla and view open positions around th
 Get answers to your questions about Firefox and all Mozilla products from our support team.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/as/mozorg/home/index-2016.lang
+++ b/as/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continue to mozilla.org
 
 

--- a/ast/mozorg/home/index-2016.lang
+++ b/ast/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Consigui rempuestes a les tos entrugues tocante a Firefox y tolos productos de M
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continuar a mozilla.org
 
 

--- a/ast/mozorg/home/index-2016.lang
+++ b/ast/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Depriendi tocante a les ventayes de trabayar en Mozilla y mira les places dispon
 Consigui rempuestes a les tos entrugues tocante a Firefox y tolos productos de Mozilla dende'l nuesu equipu de sofitu.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/az/mozorg/home/index-2016.lang
+++ b/az/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Firefox və bütün Mozilla məhsulları haqqında sizi maraqlandıran suallara 
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Fəxrlə qeyri-kommersial. <br>31 Dekabradək ianə et.
 
@@ -122,5 +124,10 @@ Birdəfəlik
 # Take over form: button to submit the donation form
 ;Donate Now
 İndi İanə et
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+mozilla.org adresinə davam edin
 
 

--- a/az/mozorg/home/index-2016.lang
+++ b/az/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Kömək lazımdır?
 Firefox və bütün Mozilla məhsulları haqqında sizi maraqlandıran suallara bizim dəstək komandasından cavab alın.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Fəxrlə qeyri-kommersial. <br>31 Dekabradək ianə et.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+Öz miqdarınızı daxil edin
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Aylıq
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Birdəfəlik
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+İndi İanə et
+
+

--- a/bg/mozorg/home/index-2016.lang
+++ b/bg/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@
 Получете отговори на Вашите въпроси относно Firefox и всички продукти на Mozilla от нашия екип за поддръжка.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/bg/mozorg/home/index-2016.lang
+++ b/bg/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -123,5 +125,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Продължете към mozilla.org
 
 

--- a/bn-BD/mozorg/home/index-2016.lang
+++ b/bn-BD/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Lean Data Toolkit পরখ করুন
 ফায়ারফক্স এবং মজিলা পণ্য সম্পর্কে আপনার প্রশ্নের সকল উত্তর পাবেন আমাদের সাপোর্ট টিমের কাছে।
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+গর্বের সাথে একটি অবাণিজ্যিক প্রতিষ্ঠান। <br> ডিসেম্বর ৩১ এর আগেই দান করুন।
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+আপনার টাকার পরিমাণ লিখুন
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+মাসিক
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+একবার
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+এখনই দান করুন
+
+

--- a/bn-BD/mozorg/home/index-2016.lang
+++ b/bn-BD/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Lean Data Toolkit পরখ করুন
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 গর্বের সাথে একটি অবাণিজ্যিক প্রতিষ্ঠান। <br> ডিসেম্বর ৩১ এর আগেই দান করুন।
 
@@ -123,5 +125,10 @@ $%(sum)s {ok}
 # Take over form: button to submit the donation form
 ;Donate Now
 এখনই দান করুন
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+mozilla.org এ থাকুন
 
 

--- a/bn-IN/mozorg/home/index-2016.lang
+++ b/bn-IN/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Mozilla এর সাথে কাজ করার উপযোগীতাগ�
 Firefox সম্বন্ধে এবং অন্যান্য Mozilla প্রোডাক্টের সম্বন্ধে আপনার প্রশ্নের জবাব আমাদের সাপোর্ট দলের থেকে পান।
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+গর্বিতভাবে অলাভজনক। <br>ডিসেম্বর 31-এর আগে দান করুন।
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+আপনার নিজের পরিমাণ প্রবেশ করান
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+মাসিক
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+একবারে
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+এখনই দান করুন
+
+

--- a/bn-IN/mozorg/home/index-2016.lang
+++ b/bn-IN/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Firefox সম্বন্ধে এবং অন্যান্য Mozilla প�
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 গর্বিতভাবে অলাভজনক। <br>ডিসেম্বর 31-এর আগে দান করুন।
 
@@ -123,5 +125,10 @@ $%(sum)s {ok}
 # Take over form: button to submit the donation form
 ;Donate Now
 এখনই দান করুন
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+mozilla.org তে চালু থাকুন
 
 

--- a/br/mozorg/home/index-2016.lang
+++ b/br/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Kaout respontoù d'ar goulennoù hoc'h eus a-zivout Firefox ha diwar-benn an hol
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Kenderc'hel war mozilla.org
 
 

--- a/br/mozorg/home/index-2016.lang
+++ b/br/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Ezhomm skoazell ?
 Kaout respontoù d'ar goulennoù hoc'h eus a-zivout Firefox ha diwar-benn an holl genderc'hadoù savet gant Mozilla digant hor skipailh skorañ.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/bs/mozorg/home/index-2016.lang
+++ b/bs/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Need help?
 Get answers to your questions about Firefox and all Mozilla products from our support team.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/bs/mozorg/home/index-2016.lang
+++ b/bs/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continue to mozilla.org
 
 

--- a/ca/mozorg/home/index-2016.lang
+++ b/ca/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Necessiteu ajuda?
 Obteniu respostes a les vostres preguntes sobre el Firefox i tots els productes de Mozilla del nostre equip de suport.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Orgullosos de no tenir ànim de lucre. <br>Doneu abans del 31 de desembre.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s €
+
+
+# Take over form
+;Enter your own amount
+Trieu la vostra quantitat
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Cada mes
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Un sol cop
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Feu una donació ara
+
+

--- a/ca/mozorg/home/index-2016.lang
+++ b/ca/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Obteniu respostes a les vostres preguntes sobre el Firefox i tots els productes 
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Orgullosos de no tenir ànim de lucre. <br>Doneu abans del 31 de desembre.
 
@@ -123,5 +125,10 @@ Un sol cop
 # Take over form: button to submit the donation form
 ;Donate Now
 Feu una donació ara
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Vés a mozilla.org
 
 

--- a/cak/mozorg/home/index-2016.lang
+++ b/cak/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Tawetamaj ri rutzil yasamäj richin Mozilla chuqa' keb'e'atz'eta' achike chi sam
 Tak'ulu' tzolin ta tzij chi rij ri Firefox chuqa' chi kij ri taq rutikojil Mozilla kuma ri to'onel qamolaj.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/cak/mozorg/home/index-2016.lang
+++ b/cak/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Tak'ulu' tzolin ta tzij chi rij ri Firefox chuqa' chi kij ri taq rutikojil Mozil
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -123,5 +125,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Jät pa mozilla.org
 
 

--- a/cs/mozorg/home/index-2016.lang
+++ b/cs/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Získejte odpovědi na vaše otázky o&nbsp;Firefoxu a všech produktech Mozilly
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Čistě nezisková. <br>Darujte do 31. prosince.
 
@@ -123,5 +125,10 @@ Jednorázově
 # Take over form: button to submit the donation form
 ;Donate Now
 Chci přispět
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Pokračovat na mozilla.org
 
 

--- a/cs/mozorg/home/index-2016.lang
+++ b/cs/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Potřebujete pomoci?
 Získejte odpovědi na vaše otázky o&nbsp;Firefoxu a všech produktech Mozilly od&nbsp;našeho týmu podpory.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Čistě nezisková. <br>Darujte do 31. prosince.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+%(sum)s Kč
+
+
+# Take over form
+;Enter your own amount
+Zadejte vlastní částku
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Měsíčně
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Jednorázově
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Chci přispět
+
+

--- a/cy/mozorg/home/index-2016.lang
+++ b/cy/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Angen cymorth?
 Cael atebion i'ch cwestiynau am Firefox a holl gynnyrch Mozilla gan ein tîm cefnogi.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Yn falch o fod ddim er elw. <br>Rhowch cyn Rhag 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+Nodwch eich swm eich hun
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Misol
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Unwaith yn Unig
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Cyfrannwch Nawr
+
+

--- a/cy/mozorg/home/index-2016.lang
+++ b/cy/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Cael atebion i'ch cwestiynau am Firefox a holl gynnyrch Mozilla gan ein tîm cef
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Yn falch o fod ddim er elw. <br>Rhowch cyn Rhag 31.
 
@@ -123,5 +125,10 @@ Unwaith yn Unig
 # Take over form: button to submit the donation form
 ;Donate Now
 Cyfrannwch Nawr
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Ymlaen i mozilla.org
 
 

--- a/da/mozorg/home/index-2016.lang
+++ b/da/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Få svar på dine spørgsmål om Firefox og alle Mozillas produkter fra vores su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Non-profit og stolt af det. <br>Donér inden den 31. dec.
 
@@ -123,5 +125,10 @@ Månedligt
 # Take over form: button to submit the donation form
 ;Donate Now
 Donér nu
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Fortsæt til mozilla.org
 
 

--- a/da/mozorg/home/index-2016.lang
+++ b/da/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Har du brug for hjælp?
 Få svar på dine spørgsmål om Firefox og alle Mozillas produkter fra vores supportteam.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Non-profit og stolt af det. <br>Donér inden den 31. dec.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+Indtast dit eget beløb
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Månedligt
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Én gang
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donér nu
+
+

--- a/de/mozorg/home/index-2016.lang
+++ b/de/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Benötigen Sie Hilfe?
 Holen Sie sich Antworten auf Ihre Fragen zu Firefox und allen Mozilla-Produkten von unserem Hilfe-Team.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Gemeinnützig und stolz darauf. <br>Spenden Sie vor dem 31. Dezember.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+%(sum)s €
+
+
+# Take over form
+;Enter your own amount
+Eigenen Betrag eingeben
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monatlich
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Einmalig
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Jetzt spenden
+
+

--- a/de/mozorg/home/index-2016.lang
+++ b/de/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Holen Sie sich Antworten auf Ihre Fragen zu Firefox und allen Mozilla-Produkten 
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Gemeinnützig und stolz darauf. <br>Spenden Sie vor dem 31. Dezember.
 
@@ -123,5 +125,10 @@ Einmalig
 # Take over form: button to submit the donation form
 ;Donate Now
 Jetzt spenden
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Weiter zu mozilla.org
 
 

--- a/dsb/mozorg/home/index-2016.lang
+++ b/dsb/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Dostańśo wótegrona na swóje pšašanja wó Firefox a wšych produktach Mozil
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Z gjardosću za wše wužytny.<br>Pósććo do 31. decembra.
 
@@ -123,5 +125,10 @@ Jaden raz
 # Take over form: button to submit the donation form
 ;Donate Now
 Pósććo něnto
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Dalej k mozilla.org
 
 

--- a/dsb/mozorg/home/index-2016.lang
+++ b/dsb/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Trjebaśo pomoc?
 Dostańśo wótegrona na swóje pšašanja wó Firefox a wšych produktach Mozilla wót našogo teama pomocy.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Z gjardosću za wše wužytny.<br>Pósććo do 31. decembra.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+%(sum)s €
+
+
+# Take over form
+;Enter your own amount
+Zapódajśo swóju sumu
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Kuždy mjasec
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Jaden raz
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Pósććo něnto
+
+

--- a/el/mozorg/home/index-2016.lang
+++ b/el/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get Firefox today
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Υπερήφανα μη κερδοσκοπικός. <br>Κάντε μια δωρεά πριν τις 31 Δεκεμβρίου.
 
@@ -122,5 +124,10 @@ Get Firefox today
 # Take over form: button to submit the donation form
 ;Donate Now
 Δωρεά
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Συνέχεια στο mozilla.org
 
 

--- a/el/mozorg/home/index-2016.lang
+++ b/el/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Get Firefox today
 Λάβετε απαντήσεις για τις ερωτήσεις σας σχετικά με τον Firefox και όλα τα προϊόντα Mozilla από την ομάδα υποστήριξης.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Υπερήφανα μη κερδοσκοπικός. <br>Κάντε μια δωρεά πριν τις 31 Δεκεμβρίου.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+%(sum)s €
+
+
+# Take over form
+;Enter your own amount
+Εισάγετε το δικό σας ποσό
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Μηνιαία
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Μια φορά
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Δωρεά
+
+

--- a/en-GB/mozorg/home/index-2016.lang
+++ b/en-GB/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before 31st Dec.
 
@@ -123,5 +125,10 @@ One-time {ok}
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now {ok}
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continue to mozilla.org {ok}
 
 

--- a/en-GB/mozorg/home/index-2016.lang
+++ b/en-GB/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Need help? {ok}
 Get answers to your questions about Firefox and all Mozilla products from our support team. {ok}
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before 31st Dec.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+£%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount {ok}
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly {ok}
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time {ok}
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now {ok}
+
+

--- a/en-US/mozorg/home/index-2016.lang
+++ b/en-US/mozorg/home/index-2016.lang
@@ -1,3 +1,4 @@
+## eoy_fundraising_takeover ##
 ## NOTE: demo server at https://bedrock-demo-agibson.us-west.moz.works/
 ## URL: https://bedrock-demo-agibson.us-west.moz.works/%LOCALE%
 
@@ -91,3 +92,41 @@ Need help?
 
 ;Get answers to your questions about Firefox and all Mozilla products from our support team.
 Get answers to your questions about Firefox and all Mozilla products from our support team.
+
+
+## TAG: eoy_fundraising_takeover
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+## TAG: eoy_fundraising_takeover
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+## TAG: eoy_fundraising_takeover
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+## TAG: eoy_fundraising_takeover
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+## TAG: eoy_fundraising_takeover
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+## TAG: eoy_fundraising_takeover
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now

--- a/en-US/mozorg/home/index-2016.lang
+++ b/en-US/mozorg/home/index-2016.lang
@@ -96,7 +96,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 ## TAG: eoy_fundraising_takeover
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -130,3 +132,9 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+## TAG: eoy_fundraising_takeover
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continue to mozilla.org

--- a/en-ZA/mozorg/home/index-2016.lang
+++ b/en-ZA/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Need help? {ok}
 Get answers to your questions about Firefox and all Mozilla products from our support team.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/en-ZA/mozorg/home/index-2016.lang
+++ b/en-ZA/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continue to mozilla.org
 
 

--- a/eo/mozorg/home/index-2016.lang
+++ b/eo/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Ricevu de nia helpa teamo, respondojn por viaj demandoj pri Firefox kaj ĉiuj pr
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Fiere neprofitcela. <br>Donacu antaŭ la 31an de decembro.
 
@@ -123,5 +125,10 @@ Unu fojon
 # Take over form: button to submit the donation form
 ;Donate Now
 Donaci nun
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Daŭrigi al mozilla.org
 
 

--- a/eo/mozorg/home/index-2016.lang
+++ b/eo/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Lernu pri la avantaĝoj de laboro en Mozilla kaj vidu malfermitajn postenojn en 
 Ricevu de nia helpa teamo, respondojn por viaj demandoj pri Firefox kaj ĉiuj produktoj de Mozilla.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Fiere neprofitcela. <br>Donacu antaŭ la 31an de decembro.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s{ok}
+
+
+# Take over form
+;Enter your own amount
+Tajpu la kvanton
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monate
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Unu fojon
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donaci nun
+
+

--- a/es-AR/mozorg/home/index-2016.lang
+++ b/es-AR/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Conocé los beneficios de trabajar en Mozilla y mirá los puestos abiertos en to
 Conseguí las respuestas a tus preguntas acerca de Firefox y todos los productos de Mozilla, de la mano de nuestro equipo de ayuda.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Orgullosos de no tener fines de lucro. <br>Doná antes del 31 de Dic.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+Ingresá el monto que quieras
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Mensualmente
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Una vez
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Doná ahora
+
+

--- a/es-AR/mozorg/home/index-2016.lang
+++ b/es-AR/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Conseguí las respuestas a tus preguntas acerca de Firefox y todos los productos
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Orgullosos de no tener fines de lucro. <br>Doná antes del 31 de Dic.
 
@@ -123,5 +125,10 @@ Una vez
 # Take over form: button to submit the donation form
 ;Donate Now
 Doná ahora
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Ir a mozilla.org
 
 

--- a/es-CL/mozorg/home/index-2016.lang
+++ b/es-CL/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Recibe respuestas a tus preguntas sobre Firefox y todos los productos de Mozilla
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Orgullosamente sin lucro. <br>Dona antes del 31 de diciembre.
 
@@ -123,5 +125,10 @@ Una sola vez
 # Take over form: button to submit the donation form
 ;Donate Now
 Donar ahora
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continuar a mozilla.org
 
 

--- a/es-CL/mozorg/home/index-2016.lang
+++ b/es-CL/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Aprende acerca de los beneficios de trabajar en Mozilla y mira los puestos dispo
 Recibe respuestas a tus preguntas sobre Firefox y todos los productos de Mozilla por parte de nuestro equipo de soporte.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Orgullosamente sin lucro. <br>Dona antes del 31 de diciembre.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+Ingresa tu propio monto
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Mensualmente
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Una sola vez
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donar ahora
+
+

--- a/es-ES/mozorg/home/index-2016.lang
+++ b/es-ES/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Infórmate de las ventajas de trabajar en Mozilla y echa un vistazo a las vacant
 Obtén respuestas de nuestro equipo de ayuda a todas tus preguntas sobre Firefox y todos los productos Mozilla.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Sin fines de lucro y orgullosos de ello. <br>Dona antes del 31 de dic.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+%(sum)s&nbsp;€
+
+
+# Take over form
+;Enter your own amount
+Indicar tu propia cantidad
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Al mes
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Una vez
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donar ya
+
+

--- a/es-ES/mozorg/home/index-2016.lang
+++ b/es-ES/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Obtén respuestas de nuestro equipo de ayuda a todas tus preguntas sobre Firefox
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Sin fines de lucro y orgullosos de ello. <br>Dona antes del 31 de dic.
 
@@ -123,5 +125,10 @@ Una vez
 # Take over form: button to submit the donation form
 ;Donate Now
 Donar ya
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continuar a mozilla.org
 
 

--- a/es-MX/mozorg/home/index-2016.lang
+++ b/es-MX/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Nuestro equipo de soporte contestará tus preguntas sobre Firefox y todos los pr
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Orgullosamente sin fines de lucro. <br>Dona antes del 31 de diciembre.
 
@@ -123,5 +125,10 @@ Una sola vez
 # Take over form: button to submit the donation form
 ;Donate Now
 Dona ahora
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Ir a mozilla.org
 
 

--- a/es-MX/mozorg/home/index-2016.lang
+++ b/es-MX/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Conoce cuáles son los beneficios de trabajar para Mozilla, y mira que vacantes 
 Nuestro equipo de soporte contestará tus preguntas sobre Firefox y todos los productos de Mozilla.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Orgullosamente sin fines de lucro. <br>Dona antes del 31 de diciembre.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+Introduce la cantidad
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Mensualmente
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Una sola vez
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Dona ahora
+
+

--- a/et/mozorg/home/index-2016.lang
+++ b/et/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Leia vastused oma Firefoxi ja teiste Mozilla toodete küsimustele meie tugimeesk
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Uhkelt mittetulunduslik. <br>Anneta enne 31. detsembrit.
 
@@ -123,5 +125,10 @@ Igakuine
 # Take over form: button to submit the donation form
 ;Donate Now
 Annetan
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Liigu edasi mozilla.org lehele
 
 

--- a/et/mozorg/home/index-2016.lang
+++ b/et/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Otsid abi?
 Leia vastused oma Firefoxi ja teiste Mozilla toodete küsimustele meie tugimeeskonna abiga.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Uhkelt mittetulunduslik. <br>Anneta enne 31. detsembrit.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+%(sum)s €
+
+
+# Take over form
+;Enter your own amount
+Valin summa ise
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Igakuine
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Ühekordne
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Annetan
+
+

--- a/eu/mozorg/home/index-2016.lang
+++ b/eu/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Laguntza bila?
 Firefox eta Mozillaren produktu guztiei buruz dituzun galderei erantzungo die gure sostengu-taldeak.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Irabazi-asmorik gabekoak izateaz harro. <br>Egin dohaintza abe. 31 baino lehen.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+%(sum)s €
+
+
+# Take over form
+;Enter your own amount
+Aukeratu zure kopurua
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Hilero
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Behin
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Egin dohaintza orain
+
+

--- a/eu/mozorg/home/index-2016.lang
+++ b/eu/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Firefox eta Mozillaren produktu guztiei buruz dituzun galderei erantzungo die gu
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Irabazi-asmorik gabekoak izateaz harro. <br>Egin dohaintza abe. 31 baino lehen.
 
@@ -122,5 +124,10 @@ Behin
 # Take over form: button to submit the donation form
 ;Donate Now
 Egin dohaintza orain
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Jarraitu mozilla.org-era
 
 

--- a/fa/mozorg/home/index-2016.lang
+++ b/fa/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Lean Data Toolkit را بررسی کنید
 جواب سوال‌های خود را درباره فایرفاکس و تمام محصولات موزیلا از گروه پشتیبانی ما بگیرید.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+با افتخار، غیرانتفاعی. <br>قبل از ۳۱ دسامبر کمک کنید.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+مقدار خود را وارد کنید
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+ماهانه
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+یک بار
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+اکنون کمک کنید
+
+

--- a/fa/mozorg/home/index-2016.lang
+++ b/fa/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Lean Data Toolkit را بررسی کنید
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 با افتخار، غیرانتفاعی. <br>قبل از ۳۱ دسامبر کمک کنید.
 
@@ -123,5 +125,10 @@ $%(sum)s {ok}
 # Take over form: button to submit the donation form
 ;Donate Now
 اکنون کمک کنید
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+ادامه به mozilla.org
 
 

--- a/ff/mozorg/home/index-2016.lang
+++ b/ff/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Ɓennu to mozilla.org
 
 

--- a/ff/mozorg/home/index-2016.lang
+++ b/ff/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Aɗa sokli ballal?
 Get answers to your questions about Firefox and all Mozilla products from our support team.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/fi/mozorg/home/index-2016.lang
+++ b/fi/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Tarvitsetko apua?
 Löydät vastaukset kysymyksiisi Firefoxiin ja kaikkiin Mozillan tuotteisiin liittyen tukitiimiltämme.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/fi/mozorg/home/index-2016.lang
+++ b/fi/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Löydät vastaukset kysymyksiisi Firefoxiin ja kaikkiin Mozillan tuotteisiin lii
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -123,5 +125,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Jatka mozilla.orgiin
 
 

--- a/fr/mozorg/home/index-2016.lang
+++ b/fr/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Besoin d’aide&nbsp;?
 Obtenez des réponses à vos questions sur Firefox et tous les logiciels Mozilla grâce à notre équipe d’assistance.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Fiers d’être sans but lucratif. <br>Faites un don avant le 31&nbsp;décembre.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+%(sum)s&nbsp;€
+
+
+# Take over form
+;Enter your own amount
+Choisissez le montant de votre don
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Mensuel
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Ponctuel
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Faites un don
+
+

--- a/fr/mozorg/home/index-2016.lang
+++ b/fr/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Obtenez des réponses à vos questions sur Firefox et tous les logiciels Mozilla
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Fiers d’être sans but lucratif. <br>Faites un don avant le 31&nbsp;décembre.
 
@@ -123,5 +125,10 @@ Ponctuel
 # Take over form: button to submit the donation form
 ;Donate Now
 Faites un don
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Accéder à mozilla.org
 
 

--- a/fy-NL/mozorg/home/index-2016.lang
+++ b/fy-NL/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Krij antwurden op jo fragen oer Firefox en alle Mozilla-produkten fan ús stipet
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Grutsk non-profit. <br>Donearje foar 31 des.
 
@@ -123,5 +125,10 @@ Ien kear
 # Take over form: button to submit the donation form
 ;Donate Now
 No donearje
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Trochgean nei mozilla.org
 
 

--- a/fy-NL/mozorg/home/index-2016.lang
+++ b/fy-NL/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Help nedich?
 Krij antwurden op jo fragen oer Firefox en alle Mozilla-produkten fan ús stipeteam.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Grutsk non-profit. <br>Donearje foar 31 des.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+€ %(sum)s
+
+
+# Take over form
+;Enter your own amount
+Fier jo eigen bedrach yn
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Moanliks
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Ien kear
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+No donearje
+
+

--- a/ga-IE/mozorg/home/index-2016.lang
+++ b/ga-IE/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Tabharfaidh ár bhfoireann tacaíochta freagra ar do cheisteanna faoi Firefox ag
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Eagraíocht neamhbhrabúis. <br>Tabhair bronntanas roimh 31 Nollaig
 
@@ -122,5 +124,10 @@ Aon uair
 # Take over form: button to submit the donation form
 ;Donate Now
 Bronn Anois
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Ar aghaidh go dtí mozilla.org
 
 

--- a/ga-IE/mozorg/home/index-2016.lang
+++ b/ga-IE/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Cabhair uait?
 Tabharfaidh ár bhfoireann tacaíochta freagra ar do cheisteanna faoi Firefox agus faoi na táirgí eile atá againn.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Eagraíocht neamhbhrabúis. <br>Tabhair bronntanas roimh 31 Nollaig
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+Cuir do mhéid féin isteach
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Go Míosúil
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Aon uair
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Bronn Anois
+
+

--- a/gd/mozorg/home/index-2016.lang
+++ b/gd/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Cobhair a dhìth?
 Faigh freagairtean air do cheistean mu Firefox is bathar Mozilla air fad on sgioba taice againn.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Pròiseil nach ann a chum prothaid a tha sinn. <br>Thoir tabhartas ron 31 dhen Dùbhlachd.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s GBP
+
+
+# Take over form
+;Enter your own amount
+Cuir a-steach suim eile
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Gach mìos
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Aon turas
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Thoir tabhartas an-dràsta
+
+

--- a/gd/mozorg/home/index-2016.lang
+++ b/gd/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Faigh freagairtean air do cheistean mu Firefox is bathar Mozilla air fad on sgio
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Pròiseil nach ann a chum prothaid a tha sinn. <br>Thoir tabhartas ron 31 dhen Dùbhlachd.
 
@@ -122,5 +124,10 @@ Aon turas
 # Take over form: button to submit the donation form
 ;Donate Now
 Thoir tabhartas an-dràsta
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Lean air adhart gu mozilla.org
 
 

--- a/gl/mozorg/home/index-2016.lang
+++ b/gl/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Obteña respostas do noso equipo de asistencia a todas as súas cuestións sobre
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continuar en mozilla.org
 
 

--- a/gl/mozorg/home/index-2016.lang
+++ b/gl/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Precisa axuda?
 Obteña respostas do noso equipo de asistencia a todas as súas cuestións sobre Firefox e todos os produtos de Mozilla.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/gn/mozorg/home/index-2016.lang
+++ b/gn/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Eguereko mbohovái umi porandu ejapóva Firefox rehe ha opaite umi Mozilla ojapo
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Eimeve mozilla.org ndive
 
 

--- a/gn/mozorg/home/index-2016.lang
+++ b/gn/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Reikotevẽpa pytyvõ
 Eguereko mbohovái umi porandu ejapóva Firefox rehe ha opaite umi Mozilla ojapopyréva ñande mba'apohára pytyvõha rehegua.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/gu-IN/mozorg/home/index-2016.lang
+++ b/gu-IN/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Get Firefox today
 ફાયરફોક્સ અને અમારી સપોર્ટ ટીમ પાસેથી તમામ મોઝિલા ઉત્પાદનો વિશે તમારા પ્રશ્નોના જવાબો મેળવો.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/gu-IN/mozorg/home/index-2016.lang
+++ b/gu-IN/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get Firefox today
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+mozilla.org ચાલુ રાખો
 
 

--- a/he/mozorg/home/index-2016.lang
+++ b/he/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Get Firefox today
 קבלת תשובות לשאלות שלך על אודות Firefox וכל מוצרי Mozilla מצוות התמיכה שלנו.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/he/mozorg/home/index-2016.lang
+++ b/he/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get Firefox today
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+להמשיך אל mozilla.org
 
 

--- a/hi-IN/mozorg/home/index-2016.lang
+++ b/hi-IN/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Discover unlimited potential, endless possibility and a wide open Web.
 Firefox और हमारी सहायता टीम से सभी Mozilla उत्पादों के बारे में अपने प्रश्नों के उत्तर प्राप्त करें.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+गर्व से गैरलाभ. <br>३१ दिसम्बर से पहले दान करे.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+अपनी राशि दर्ज कीजिये
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+अभी दान करें
+
+

--- a/hi-IN/mozorg/home/index-2016.lang
+++ b/hi-IN/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Firefox और हमारी सहायता टीम से सभी Moz
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 गर्व से गैरलाभ. <br>३१ दिसम्बर से पहले दान करे.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 अभी दान करें
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+mozilla.org को जारी रखें
 
 

--- a/hr/mozorg/home/index-2016.lang
+++ b/hr/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Trebate pomoć?
 Get answers to your questions about Firefox and all Mozilla products from our support team.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/hr/mozorg/home/index-2016.lang
+++ b/hr/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continue to mozilla.org
 
 

--- a/hsb/mozorg/home/index-2016.lang
+++ b/hsb/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Dóstańće wotmołwy na swoje prašenja wo Firefox a wšěch produktach Mozilla
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Z hordosću powšitkownosći wužitny.<br>Darće do 31. decembra.
 
@@ -123,5 +125,10 @@ Jónkróć
 # Take over form: button to submit the donation form
 ;Donate Now
 Darće nětko
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Dale k mozilla.org
 
 

--- a/hsb/mozorg/home/index-2016.lang
+++ b/hsb/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Trjebaće pomoc?
 Dóstańće wotmołwy na swoje prašenja wo Firefox a wšěch produktach Mozilla wot našeho teama pomocy.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Z hordosću powšitkownosći wužitny.<br>Darće do 31. decembra.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+%(sum)s €
+
+
+# Take over form
+;Enter your own amount
+Zapodajće swoju sumu
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Kóždy měsac
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Jónkróć
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Darće nětko
+
+

--- a/hto/mozorg/home/index-2016.lang
+++ b/hto/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Need help?
 Get answers to your questions about Firefox and all Mozilla products from our support team.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/hto/mozorg/home/index-2016.lang
+++ b/hto/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continue to mozilla.org
 
 

--- a/hu/mozorg/home/index-2016.lang
+++ b/hu/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Segítségre van szüksége?
 Támogatói csapatunktól választ kaphat kérdéseire a Firefoxszal és minden Mozilla termékkel kapcsolatban.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Büszkén non profit. <br>Adományozzon december 31 előtt.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+%(sum)s HUF
+
+
+# Take over form
+;Enter your own amount
+Adjon meg saját összeget
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Havi
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Egyszeri
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Adományozzon most
+
+

--- a/hu/mozorg/home/index-2016.lang
+++ b/hu/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Támogatói csapatunktól választ kaphat kérdéseire a Firefoxszal és minden 
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Büszkén non profit. <br>Adományozzon december 31 előtt.
 
@@ -123,5 +125,10 @@ Egyszeri
 # Take over form: button to submit the donation form
 ;Donate Now
 Adományozzon most
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Tovább a mozilla.org-ra
 
 

--- a/hy-AM/mozorg/home/index-2016.lang
+++ b/hy-AM/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@
 Ստացեք ձեր հարցերի պատասխանները Firefox-ի և Mozilla-ի այլ ծրագրերի մասին աջակցող թիմից:
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Հպարտությամբ շահույթ չհետապնդող: <br>Կատարեք նվիրաբերել մինչև դեկտեմբերի 31-ը:
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+Մուտքագրեք գումար
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Ամեն ամիս
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Մեկ անգամ
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Նվիրաբերել
+
+

--- a/hy-AM/mozorg/home/index-2016.lang
+++ b/hy-AM/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Հպարտությամբ շահույթ չհետապնդող: <br>Կատարեք նվիրաբերել մինչև դեկտեմբերի 31-ը:
 
@@ -123,5 +125,10 @@ $%(sum)s {ok}
 # Take over form: button to submit the donation form
 ;Donate Now
 Նվիրաբերել
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Անցնել mozilla.org-ին
 
 

--- a/id/mozorg/home/index-2016.lang
+++ b/id/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Butuh bantuan?
 Dapatkan jawaban atas pertanyaan Anda tentang Firefox dan semua produk Mozilla dari tim dukungan kami.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/id/mozorg/home/index-2016.lang
+++ b/id/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Dapatkan jawaban atas pertanyaan Anda tentang Firefox dan semua produk Mozilla d
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Lanjutkan ke mozilla.org
 
 

--- a/is/mozorg/home/index-2016.lang
+++ b/is/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Vantar þig hjálp?
 Fáðu svör við öllum þínum spurningum um Firefox og önnur Mozilla forrit frá hjálparteyminu okkar.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Við erum stolt af því að vera rekin án hagnaðar. <br>Gefðu styrk fyrir 31. des.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+Sláðu inn þína eigin upphæð
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Mánaðarlega
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Einu sinni
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Styrkja núna
+
+

--- a/is/mozorg/home/index-2016.lang
+++ b/is/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Fáðu svör við öllum þínum spurningum um Firefox og önnur Mozilla forrit 
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Við erum stolt af því að vera rekin án hagnaðar. <br>Gefðu styrk fyrir 31. des.
 
@@ -123,5 +125,10 @@ Einu sinni
 # Take over form: button to submit the donation form
 ;Donate Now
 Styrkja núna
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Halda áfram til mozilla.org
 
 

--- a/it/mozorg/home/index-2016.lang
+++ b/it/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Ricevi risposta alle tue domande su Firefox e sugli altri prodotti Mozilla dal n
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Orgogliosamente non profit. <br>Fai una donazione prima del 31 dicembre.
 
@@ -123,5 +125,10 @@ Una tantum
 # Take over form: button to submit the donation form
 ;Donate Now
 Fai subito una donazione
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Vai a mozilla.org
 
 

--- a/it/mozorg/home/index-2016.lang
+++ b/it/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Hai bisogno d’aiuto?
 Ricevi risposta alle tue domande su Firefox e sugli altri prodotti Mozilla dal nostro team di supporto.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Orgogliosamente non profit. <br>Fai una donazione prima del 31 dicembre.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+%(sum)s €
+
+
+# Take over form
+;Enter your own amount
+Altro importo
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Mensile
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Una tantum
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Fai subito una donazione
+
+

--- a/ja/mozorg/home/index-2016.lang
+++ b/ja/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Firefox やすべての Mozilla 製品に関する質問に、私たちのサポ
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -123,5 +125,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+mozilla.org へ移動
 
 

--- a/ja/mozorg/home/index-2016.lang
+++ b/ja/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Mozilla で働くメリットを知って、全世界で募集中の職種を確
 Firefox やすべての Mozilla 製品に関する質問に、私たちのサポートチームがお答えします。
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/ka/mozorg/home/index-2016.lang
+++ b/ka/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get Firefox today
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+mozilla.org-ზე გადასვლა
 
 

--- a/ka/mozorg/home/index-2016.lang
+++ b/ka/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Get Firefox today
 მიიღეთ პასუხები Firefox-სთან და Mozilla-სთან დაკავშირებულ ყველა კითხვაზე ჩვენი მხარდაჭერის გუნდისგან.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/kab/mozorg/home/index-2016.lang
+++ b/kab/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Awi-d tiririt i yesteqsiyen inek ɣef Firefox akked iseɣẓanen n Mozilla si te
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -123,5 +125,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Kcem ɣer mozilla.org
 
 

--- a/kab/mozorg/home/index-2016.lang
+++ b/kab/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Tesriḍ tallalt?
 Awi-d tiririt i yesteqsiyen inek ɣef Firefox akked iseɣẓanen n Mozilla si terbeɛt n tallalt.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/kk/mozorg/home/index-2016.lang
+++ b/kk/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Firefox және барлық Mozilla өнімдері туралы барлық
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Коммерциялық еместігін мақтан тұтады.<br>31-ші желтоқсанға дейін ақшалай көмектесіңіз.
 
@@ -123,5 +125,10 @@ $%(sum)s {ok}
 # Take over form: button to submit the donation form
 ;Donate Now
 Қазір ақшалай көмектесу
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+mozilla.org сайтына жалғастыру
 
 

--- a/kk/mozorg/home/index-2016.lang
+++ b/kk/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Mozilla-да жұмыс істеудің артықшылықтарын білі
 Firefox және барлық Mozilla өнімдері туралы барлық сұрақтарыңызға біздің қолдау көрсету тобынан жауаптарды алыңыз.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Коммерциялық еместігін мақтан тұтады.<br>31-ші желтоқсанға дейін ақшалай көмектесіңіз.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+Өз сомаңызды енгізіңіз
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Ай сайын
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Бір рет
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Қазір ақшалай көмектесу
+
+

--- a/km/mozorg/home/index-2016.lang
+++ b/km/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Learn about the benefits of working at Mozilla and view open positions around th
 Get answers to your questions about Firefox and all Mozilla products from our support team.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/km/mozorg/home/index-2016.lang
+++ b/km/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+បន្ត​ទៅ​កាន់ mozilla.org
 
 

--- a/kn/mozorg/home/index-2016.lang
+++ b/kn/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Firefox ಮತ್ತು Mozilla ಉತ್ಪನ್ನಗಳ ಬಗ್ಗೆ ನ�
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 ಹೆಮ್ಮೆಯ ಲಾಭರಹಿತ ಸಂಸ್ಥೆ. <br>31 ಡಿಸೆಂಬರ್ ಒಳಗೆ ದೇಣಿಗೆ ನೀಡಿ.
 
@@ -122,5 +124,10 @@ $%(sum)s {ok}
 # Take over form: button to submit the donation form
 ;Donate Now
 ದೇಣಿಗೆ ನೀಡಿ
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+mozilla.org ಗೆ ಮುಂದುವರೆ
 
 

--- a/kn/mozorg/home/index-2016.lang
+++ b/kn/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Mozilla ದಲ್ಲಿ ಕೆಲಸ ಮಾಡುವುದರ ಲಾಭಗಳ �
 Firefox ಮತ್ತು Mozilla ಉತ್ಪನ್ನಗಳ ಬಗ್ಗೆ ನಿಮ್ಮಲ್ಲಿರುವ ಎಲ್ಲ ಪ್ರಶ್ನೆಗಳಿಗೆ ನಮ್ಮ ಬೆಂಬಲದ ತಂಡದಿಂದ ಉತ್ತರ ಪಡೆಯಿರಿ.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+ಹೆಮ್ಮೆಯ ಲಾಭರಹಿತ ಸಂಸ್ಥೆ. <br>31 ಡಿಸೆಂಬರ್ ಒಳಗೆ ದೇಣಿಗೆ ನೀಡಿ.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+ನಿಮ್ಮ ಇಚ್ಛೆಯ ಮೊತ್ತ ನಮೂದಿಸಿ
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+ಮಾಸಿಕ
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+ಒಂದು ಬಾರಿ
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+ದೇಣಿಗೆ ನೀಡಿ
+
+

--- a/ko/mozorg/home/index-2016.lang
+++ b/ko/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Mozilla에서 근무하는 장점을 살펴보고 전세계에 열려있는 구�
 고객 지원 봉사자로 부터 Firefox와 Mozilla에 대한 질문에 대한 답을 받을 수 있습니다.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+비영리 기부하기 <br>12월 31일까지
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+기부액 입력
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+매월
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+한번
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+기부하기
+
+

--- a/ko/mozorg/home/index-2016.lang
+++ b/ko/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Mozilla에서 근무하는 장점을 살펴보고 전세계에 열려있는 구�
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 비영리 기부하기 <br>12월 31일까지
 
@@ -123,5 +125,10 @@ $%(sum)s {ok}
 # Take over form: button to submit the donation form
 ;Donate Now
 기부하기
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+mozilla.org 사이트 이동
 
 

--- a/lij/mozorg/home/index-2016.lang
+++ b/lij/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Riçeivi risposte a-e teu domande in sce Firefox e in sce tutti i produti Mozill
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Feamente sensa fin de goagno. <br>Fanni 'na donaçion primma do 31 de Dexembre.
 
@@ -122,5 +124,10 @@ Scrivi quanto t'eu donâ
 # Take over form: button to submit the donation form
 ;Donate Now
 Döna oua
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Vanni in sce mozilla.org
 
 

--- a/lij/mozorg/home/index-2016.lang
+++ b/lij/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Bezeugno d'agiutto?
 Riçeivi risposte a-e teu domande in sce Firefox e in sce tutti i produti Mozilla da-o nòstro gruppo de sopòrto.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Feamente sensa fin de goagno. <br>Fanni 'na donaçion primma do 31 de Dexembre.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+Scrivi quanto t'eu donâ
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Ògni meize
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+'Na vòtta sola
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Döna oua
+
+

--- a/lo/mozorg/home/index-2016.lang
+++ b/lo/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Need help?
 Get answers to your questions about Firefox and all Mozilla products from our support team.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/lo/mozorg/home/index-2016.lang
+++ b/lo/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continue to mozilla.org
 
 

--- a/lt/mozorg/home/index-2016.lang
+++ b/lt/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Reikia pagalbos?
 Turite klausimų apie „Firefox“ ir kitus „Mozillos“ produktus? Mūsų pagalbininkai visuomet pasirengę į juos atsakyti.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/lt/mozorg/home/index-2016.lang
+++ b/lt/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Turite klausimų apie „Firefox“ ir kitus „Mozillos“ produktus? Mūsų pa
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Eiti į mozilla.org
 
 

--- a/ltg/mozorg/home/index-2016.lang
+++ b/ltg/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Vajag paleidzeibu?
 Sajam atsaciejumus uz sovim vaicojumim par Firefox un Mozilla produktim pi myusu atbolsta komandas.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/ltg/mozorg/home/index-2016.lang
+++ b/ltg/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Sajam atsaciejumus uz sovim vaicojumim par Firefox un Mozilla produktim pi myusu
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Tōļōk uz mozilla.org
 
 

--- a/lv/mozorg/home/index-2016.lang
+++ b/lv/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Nepieciešama palīdzība?
 Iegūstiet atbildes saviem jautājumiem no mūsu atbalsta komandas par Firefox un visiem Mozilla produktiem.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/lv/mozorg/home/index-2016.lang
+++ b/lv/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Iegūstiet atbildes saviem jautājumiem no mūsu atbalsta komandas par Firefox u
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Turpināt uz mozilla.org
 
 

--- a/mai/mozorg/home/index-2016.lang
+++ b/mai/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Need help?
 Get answers to your questions about Firefox and all Mozilla products from our support team.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/mai/mozorg/home/index-2016.lang
+++ b/mai/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continue to mozilla.org
 
 

--- a/mk/mozorg/home/index-2016.lang
+++ b/mk/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get Firefox today
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Продолжете кон mozilla.org
 
 

--- a/mk/mozorg/home/index-2016.lang
+++ b/mk/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Get Firefox today
 Добијте одговори за Firefox и сите производи на Mozilla од нашиот тим за поддршка.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/ml/mozorg/home/index-2016.lang
+++ b/ml/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Get Firefox today
 ഫയര്‍ഫോക്സിനെക്കുറിച്ചും എല്ലാ മോസില്ല ഉല്‍പ്പന്നങ്ങളെക്കുറിച്ചുമുള്ള നിങ്ങളുടെ സംശയങ്ങള്‍ക്കുള്ള ഉത്തരം ഞങ്ങളുടെ സപ്പോര്‍ട്ട് ടീമിന്റെ അടുക്കല്‍ ലഭ്യമാണു്.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/ml/mozorg/home/index-2016.lang
+++ b/ml/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get Firefox today
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+mozilla.orgലേക്ക് പോകുക
 
 

--- a/mr/mozorg/home/index-2016.lang
+++ b/mr/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Learn about the benefits of working at Mozilla and view open positions around th
 Get answers to your questions about Firefox and all Mozilla products from our support team.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/mr/mozorg/home/index-2016.lang
+++ b/mr/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continue to mozilla.org
 
 

--- a/ms/mozorg/home/index-2016.lang
+++ b/ms/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Dapatkan jawapan untuk soalan anda perihal Firefox dan semua produk Mozilla dari
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -123,5 +125,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Teruskan ke mozilla.org
 
 

--- a/ms/mozorg/home/index-2016.lang
+++ b/ms/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Perlukan bantuan?
 Dapatkan jawapan untuk soalan anda perihal Firefox dan semua produk Mozilla daripada pasukan sokongan kami.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/my/mozorg/home/index-2016.lang
+++ b/my/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get Firefox today
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+mozilla.org သို့ ဆက်ပါ
 
 

--- a/my/mozorg/home/index-2016.lang
+++ b/my/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Get Firefox today
 မီးမြေခွေး နှင့် မိုဇီလာ ထုတ်ကုန်များအတွက် သင့်မေးခွန်းများအတွက် အဖြေများကို ထောက်ပံ့အသင်းဆီ မှ တောင်းခံပါ
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/nb-NO/mozorg/home/index-2016.lang
+++ b/nb-NO/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Få svar på spørsmålene dine om Firefox og alle Mozilla-produkter fra brukers
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Fortsett til mozilla.org
 
 

--- a/nb-NO/mozorg/home/index-2016.lang
+++ b/nb-NO/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Trenger du hjelp?
 Få svar på spørsmålene dine om Firefox og alle Mozilla-produkter fra brukerstøtteteamet.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/ne-NP/mozorg/home/index-2016.lang
+++ b/ne-NP/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Learn about the benefits of working at Mozilla and view open positions around th
 Get answers to your questions about Firefox and all Mozilla products from our support team.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/ne-NP/mozorg/home/index-2016.lang
+++ b/ne-NP/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continue to mozilla.org
 
 

--- a/nl/mozorg/home/index-2016.lang
+++ b/nl/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Hulp nodig?
 Verkrijg antwoorden op uw vragen over Firefox en alle Mozilla-producten van ons ondersteuningsteam.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Trots non-profit. <br>Doneer voor 31 dec.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+€ %(sum)s
+
+
+# Take over form
+;Enter your own amount
+Voer uw eigen bedrag in
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Maandelijks
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Eenmalig
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Nu doneren
+
+

--- a/nl/mozorg/home/index-2016.lang
+++ b/nl/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Verkrijg antwoorden op uw vragen over Firefox en alle Mozilla-producten van ons 
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Trots non-profit. <br>Doneer voor 31 dec.
 
@@ -123,5 +125,10 @@ Eenmalig
 # Take over form: button to submit the donation form
 ;Donate Now
 Nu doneren
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Doorgaan naar mozilla.org
 
 

--- a/nn-NO/mozorg/home/index-2016.lang
+++ b/nn-NO/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Treng du hjelp?
 Brukarstøttegruppa vår svarar på spørsmåla dine om Firefox og alle andre Mozilla-produkt.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/nn-NO/mozorg/home/index-2016.lang
+++ b/nn-NO/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Brukarstøttegruppa vår svarar på spørsmåla dine om Firefox og alle andre Mo
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Hald fram til mozilla.org
 
 

--- a/nv/mozorg/home/index-2016.lang
+++ b/nv/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Need help?
 Get answers to your questions about Firefox and all Mozilla products from our support team.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/nv/mozorg/home/index-2016.lang
+++ b/nv/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continue to mozilla.org
 
 

--- a/oc/mozorg/home/index-2016.lang
+++ b/oc/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Besonh d'ajuda&nbsp;?
 Obtenez des réponses à vos questions sur Firefox et tous les logiciels Mozilla grâce à notre équipe d’assistance.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/oc/mozorg/home/index-2016.lang
+++ b/oc/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Obtenez des réponses à vos questions sur Firefox et tous les logiciels Mozilla
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Accéder à mozilla.org
 
 

--- a/or/mozorg/home/index-2016.lang
+++ b/or/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Learn about the benefits of working at Mozilla and view open positions around th
 Get answers to your questions about Firefox and all Mozilla products from our support team.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/or/mozorg/home/index-2016.lang
+++ b/or/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continue to mozilla.org
 
 

--- a/pa-IN/mozorg/home/index-2016.lang
+++ b/pa-IN/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Virtual Reality Platform
 ਫਾਇਰਫਾਕਸ ਦੇ ਬਾਰੇ ਅਤੇ ਸਭ ਮੋਜ਼ੀਲਾ ਉਤਪਾਦਾਂ ਦੇ ਬਾਰੇ ਆਪਣੇ ਸਵਾਲਾਂ ਦੇ ਜਵਾਬ ਸਾਡੀ ਸਹਾਇਤਾ ਟੀਮ ਤੋਂ ਲਵੋ।
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/pa-IN/mozorg/home/index-2016.lang
+++ b/pa-IN/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Virtual Reality Platform
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+mozilla.org ਨਾਲ ਜਾਰੀ ਰੱਖੋ
 
 

--- a/pbb/mozorg/home/index-2016.lang
+++ b/pbb/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Need help?
 Get answers to your questions about Firefox and all Mozilla products from our support team.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/pbb/mozorg/home/index-2016.lang
+++ b/pbb/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continue to mozilla.org
 
 

--- a/pl/mozorg/home/index-2016.lang
+++ b/pl/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Odpowiedzi na pytania dotyczące Firefoksa i wszystkich produktów Mozilli zna
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -123,5 +125,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Przejdź do strony mozilla.org
 
 

--- a/pl/mozorg/home/index-2016.lang
+++ b/pl/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Potrzebujesz pomocy?
 Odpowiedzi na pytania dotyczące Firefoksa i wszystkich produktów Mozilli znajdziesz w naszym centrum pomocy.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/pt-BR/mozorg/home/index-2016.lang
+++ b/pt-BR/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Tire suas dúvidas sobre o Firefox ou qualquer produto da Mozilla com a nossa eq
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Orgulhosamente sem fins lucrativos. <br>Doe antes de 31 de dezembro.
 
@@ -123,5 +125,10 @@ Uma vez
 # Take over form: button to submit the donation form
 ;Donate Now
 Doar agora
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Agora não, abra o mozilla.org
 
 

--- a/pt-BR/mozorg/home/index-2016.lang
+++ b/pt-BR/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Precisa de ajuda?
 Tire suas dúvidas sobre o Firefox ou qualquer produto da Mozilla com a nossa equipe de suporte.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Orgulhosamente sem fins lucrativos. <br>Doe antes de 31 de dezembro.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+R$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Introduza o valor
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Mensalmente
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Uma vez
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Doar agora
+
+

--- a/pt-PT/mozorg/home/index-2016.lang
+++ b/pt-PT/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Precisa de ajuda?
 Obtenha respostas da nossa equipa de apoio para as suas questões sobre o Firefox e todos os produtos da Mozilla.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Orgulhosamente sem fins lucrativos. <br>Faça um donativo antes de 31 de dezembro.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+%(sum)s€
+
+
+# Take over form
+;Enter your own amount
+Introduza o valor
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Mensalmente
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Uma vez
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Doar agora
+
+

--- a/pt-PT/mozorg/home/index-2016.lang
+++ b/pt-PT/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Obtenha respostas da nossa equipa de apoio para as suas questões sobre o Firefo
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Orgulhosamente sem fins lucrativos. <br>Faça um donativo antes de 31 de dezembro.
 
@@ -123,5 +125,10 @@ Uma vez
 # Take over form: button to submit the donation form
 ;Donate Now
 Doar agora
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continuar para mozilla.org
 
 

--- a/qvi/mozorg/home/index-2016.lang
+++ b/qvi/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Need help?
 Get answers to your questions about Firefox and all Mozilla products from our support team.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/qvi/mozorg/home/index-2016.lang
+++ b/qvi/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continue to mozilla.org
 
 

--- a/rm/mozorg/home/index-2016.lang
+++ b/rm/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Respostas a tias dumondas davart Firefox e tut ils products da Mozilla - da noss
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Superbi dad esser senza finamira da profit. <br>Sustegnair avant ils 31 da december.
 
@@ -122,5 +124,10 @@ Ina giada
 # Take over form: button to submit the donation form
 ;Donate Now
 Sustegnair ussa
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Visitar mozilla.org
 
 

--- a/rm/mozorg/home/index-2016.lang
+++ b/rm/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Dovras agid?
 Respostas a tias dumondas davart Firefox e tut ils products da Mozilla - da noss team d'agid.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Superbi dad esser senza finamira da profit. <br>Sustegnair avant ils 31 da december.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+Endatescha la summa giavischada
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Mintga mais
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Ina giada
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Sustegnair ussa
+
+

--- a/ro/mozorg/home/index-2016.lang
+++ b/ro/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Primește răspunsuri la întrebările cu privire la Firefox și toate produsele
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Mândri că suntem nonprofit. <br>Donează până pe 31 decembrie.
 
@@ -123,5 +125,10 @@ O singură dată
 # Take over form: button to submit the donation form
 ;Donate Now
 Donează acum
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continuă pe mozilla.org
 
 

--- a/ro/mozorg/home/index-2016.lang
+++ b/ro/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Ai nevoie de ajutor?
 Primește răspunsuri la întrebările cu privire la Firefox și toate produsele Mozilla de la echipa noastră de suport.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Mândri că suntem nonprofit. <br>Donează până pe 31 decembrie.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+Introdu suma dorită
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Lunar
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+O singură dată
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donează acum
+
+

--- a/ru/mozorg/home/index-2016.lang
+++ b/ru/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Некоммерческая организация. <br>Пожертвуйте до 31 декабря.
 
@@ -123,5 +125,10 @@
 # Take over form: button to submit the donation form
 ;Donate Now
 Пожертвовать
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Продолжить на mozilla.org
 
 

--- a/ru/mozorg/home/index-2016.lang
+++ b/ru/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@
 Получите ответы на вопросы о Firefox и всех продуктах Mozilla от нашей команды поддержки.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Некоммерческая организация. <br>Пожертвуйте до 31 декабря.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+%(sum)s&nbsp;RUB
+
+
+# Take over form
+;Enter your own amount
+Введите свою сумму
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Ежемесячно
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Единовременно
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Пожертвовать
+
+

--- a/si/mozorg/home/index-2016.lang
+++ b/si/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Learn about the benefits of working at Mozilla and view open positions around th
 Get answers to your questions about Firefox and all Mozilla products from our support team.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/si/mozorg/home/index-2016.lang
+++ b/si/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+mozilla.org වෙත යන්න
 
 

--- a/sk/mozorg/home/index-2016.lang
+++ b/sk/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Získajte odpovede na vaše otázky o Firefoxe a všetkých Mozilla produktoch o
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 S hrdosťou neziskovo. <br>Prispieť pred 31. decembrom.
 
@@ -123,5 +125,10 @@ Jednorázovo
 # Take over form: button to submit the donation form
 ;Donate Now
 Prispieť teraz
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Pokračujte na mozilla.org
 
 

--- a/sk/mozorg/home/index-2016.lang
+++ b/sk/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Potrebujete pomoc?
 Získajte odpovede na vaše otázky o Firefoxe a všetkých Mozilla produktoch od nášho tímu podpory.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+S hrdosťou neziskovo. <br>Prispieť pred 31. decembrom.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+%(sum)s €
+
+
+# Take over form
+;Enter your own amount
+Zadajte vlastnú sumu
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Mesačne
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Jednorázovo
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Prispieť teraz
+
+

--- a/sl/mozorg/home/index-2016.lang
+++ b/sl/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Naj vam naša skupina za podporo odgovori na vaša vprašanja o Firefoxu in vseh
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Ponosno neprofitni. <br>Prispevajte do 31. decembra.
 
@@ -123,5 +125,10 @@ Enkratno
 # Take over form: button to submit the donation form
 ;Donate Now
 Prispevaj zdaj
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Nadaljuj na mozilla.org
 
 

--- a/sl/mozorg/home/index-2016.lang
+++ b/sl/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Potrebujete pomoč?
 Naj vam naša skupina za podporo odgovori na vaša vprašanja o Firefoxu in vseh Mozillinih izdelkih.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Ponosno neprofitni. <br>Prispevajte do 31. decembra.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+%(sum)s €
+
+
+# Take over form
+;Enter your own amount
+Vnesite vaš znesek
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Mesečno
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Enkratno
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Prispevaj zdaj
+
+

--- a/son/mozorg/home/index-2016.lang
+++ b/son/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Ga baa faaba?
 Ir gaakašinay kondaa ga war hãayaney zaabi Firefox nda Mozilla jinawey kul ga.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/son/mozorg/home/index-2016.lang
+++ b/son/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Ir gaakašinay kondaa ga war hãayaney zaabi Firefox nda Mozilla jinawey kul ga.
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Koy jine mozilla.org do
 
 

--- a/sq/mozorg/home/index-2016.lang
+++ b/sq/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Merrni prej ekipit tonë të asistencës përgjigje për pyetjet tuaja rreth Fir
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Krenarë që jemi jofitimprurës. <br>Dhuroni përpara 31 Dhjetorit.
 
@@ -123,5 +125,10 @@ Një herë
 # Take over form: button to submit the donation form
 ;Donate Now
 Dhuroni Tani
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Vazhdoni te mozilla.org
 
 

--- a/sq/mozorg/home/index-2016.lang
+++ b/sq/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Ju duhet ndihmë?
 Merrni prej ekipit tonë të asistencës përgjigje për pyetjet tuaja rreth Firefox-it dhe krejt produkteve të Mozilla-s.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Krenarë që jemi jofitimprurës. <br>Dhuroni përpara 31 Dhjetorit.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s{ok}
+
+
+# Take over form
+;Enter your own amount
+Jepni sasinë tuaj
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Çdo muaj
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Një herë
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Dhuroni Tani
+
+

--- a/sr/mozorg/home/index-2016.lang
+++ b/sr/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Discover unlimited potential, endless possibility and a wide open Web.
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Поносно непрофитна. <br>Донирајте пре 31-ог децембра.
 
@@ -122,5 +124,10 @@ Discover unlimited potential, endless possibility and a wide open Web.
 # Take over form: button to submit the donation form
 ;Donate Now
 Донирај
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Наставите на mozilla.org
 
 

--- a/sr/mozorg/home/index-2016.lang
+++ b/sr/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Discover unlimited potential, endless possibility and a wide open Web.
 Нађите одговоре на ваша питања о Firefox-у и свим Mozilla производима од нашег тима подршке.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Поносно непрофитна. <br>Донирајте пре 31-ог децембра.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+%(sum)s €
+
+
+# Take over form
+;Enter your own amount
+Унесите своју суму
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Месечно
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Једном
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Донирај
+
+

--- a/sv-SE/mozorg/home/index-2016.lang
+++ b/sv-SE/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Vår supportgrupp svarar på dina frågor om Firefox och alla andra Mozillaprodu
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Stolt ideell. <br>Donera före 31 december.
 
@@ -123,5 +125,10 @@ En gång
 # Take over form: button to submit the donation form
 ;Donate Now
 Donera nu
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Fortsätt till mozilla.org
 
 

--- a/sv-SE/mozorg/home/index-2016.lang
+++ b/sv-SE/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Behöver du hjälp?
 Vår supportgrupp svarar på dina frågor om Firefox och alla andra Mozillaprodukter.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Stolt ideell. <br>Donera före 31 december.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+Ange ditt egna belopp
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Månadsvis
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+En gång
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donera nu
+
+

--- a/ta/mozorg/home/index-2016.lang
+++ b/ta/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Mozilla வில் வேலை செய்வதால் கிடைக்
 Firefox பற்றிய உங்களின் கேள்விகளுக்கான பதிலையும் ஆதரவு அணியில் உள்ள மொசில்லா தயாரிப்புகளையும் பெறுங்கள்.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/ta/mozorg/home/index-2016.lang
+++ b/ta/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Firefox பற்றிய உங்களின் கேள்விகளு�
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+mozilla.org வுக்கு தொடருங்கள்
 
 

--- a/te/mozorg/home/index-2016.lang
+++ b/te/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Firefox గురించీ ఇతర Mozilla ఉత్పత్తుల గ�
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -123,5 +125,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+mozilla.org కొనసాగించు
 
 

--- a/te/mozorg/home/index-2016.lang
+++ b/te/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Mozilla లో పనిచేయడంలో ప్రయోజనాల గు
 Firefox గురించీ ఇతర Mozilla ఉత్పత్తుల గురించీ మీ సందేహాలకు సమాధానాలను మా తోడ్పాటు జట్టు నుండి పొందండి.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/th/mozorg/home/index-2016.lang
+++ b/th/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@
 รับคำตอบสำหรับคำถามของคุณเกี่ยวกับ Firefox และผลิตภัณฑ์ทั้งหมดของ Mozilla จากทีมสนับสนุนของเรา
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/th/mozorg/home/index-2016.lang
+++ b/th/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -123,5 +125,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continue to mozilla.org
 
 

--- a/tl/mozorg/home/index-2016.lang
+++ b/tl/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Need help?
 Get answers to your questions about Firefox and all Mozilla products from our support team.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/tl/mozorg/home/index-2016.lang
+++ b/tl/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Magpatuloy sa mozilla.org
 
 

--- a/tr/mozorg/home/index-2016.lang
+++ b/tr/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Firefox ve tüm Mozilla ürünleriyle ilgili sorularınızı destek ekibimiz yan
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Kâr amacı gütmemekten gurur duyuyoruz. 31 Aralık’a kadar bağış yapabilirsiniz.
 
@@ -123,5 +125,10 @@ Bir kere
 # Take over form: button to submit the donation form
 ;Donate Now
 Şimdi bağış yap
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+mozilla.org’a devam et
 
 

--- a/tr/mozorg/home/index-2016.lang
+++ b/tr/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Yardım mı lazım?
 Firefox ve tüm Mozilla ürünleriyle ilgili sorularınızı destek ekibimiz yanıtlasın.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Kâr amacı gütmemekten gurur duyuyoruz. 31 Aralık’a kadar bağış yapabilirsiniz.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+%(sum)s $
+
+
+# Take over form
+;Enter your own amount
+Kendi tutarınızı girin
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Her ay
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Bir kere
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Şimdi bağış yap
+
+

--- a/trs/mozorg/home/index-2016.lang
+++ b/trs/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Need help?
 Get answers to your questions about Firefox and all Mozilla products from our support team.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/trs/mozorg/home/index-2016.lang
+++ b/trs/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continue to mozilla.org
 
 

--- a/uk/mozorg/home/index-2016.lang
+++ b/uk/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@
 Отримайте відповіді на свої питання про Firefox та всі продукти Mozilla від нашої команди підтримки.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+З гордістю, некомерційна. <br>Зробіть внесок до 31 грудня.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+Введіть власну суму
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Щомісяця
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+Одноразово
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Зробити внесок
+
+

--- a/uk/mozorg/home/index-2016.lang
+++ b/uk/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 З гордістю, некомерційна. <br>Зробіть внесок до 31 грудня.
 
@@ -123,5 +125,10 @@ $%(sum)s {ok}
 # Take over form: button to submit the donation form
 ;Donate Now
 Зробити внесок
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Продовжити на mozilla.org
 
 

--- a/ur/mozorg/home/index-2016.lang
+++ b/ur/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Learn about the benefits of working at Mozilla and view open positions around th
 Get answers to your questions about Firefox and all Mozilla products from our support team.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/ur/mozorg/home/index-2016.lang
+++ b/ur/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Get answers to your questions about Firefox and all Mozilla products from our su
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Continue to mozilla.org
 
 

--- a/uz/mozorg/home/index-2016.lang
+++ b/uz/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Bizning yordam guruhimizdan Firefox va Mozilla mahsulotlari haqida savollaringiz
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+mozilla.org’ga davom etish
 
 

--- a/uz/mozorg/home/index-2016.lang
+++ b/uz/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Yordam kerakmi?
 Bizning yordam guruhimizdan Firefox va Mozilla mahsulotlari haqida savollaringizga javoblar olishingiz mumkin.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/vi/mozorg/home/index-2016.lang
+++ b/vi/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Cần trợ giúp?
 Nhận được những câu trả lời về Firefox và tất cả những sản phẩm của Mozilla từ đội ngũ hỗ trợ kỹ thuật của chúng tôi.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/vi/mozorg/home/index-2016.lang
+++ b/vi/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Nhận được những câu trả lời về Firefox và tất cả những s�
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Tiếp tục tới mozilla.org
 
 

--- a/xh/mozorg/home/index-2016.lang
+++ b/xh/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Fumana iimpendulo zakho malunga i-FireFox futhi nazo zonke iimveliso zika-Mozill
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Nkqubela phambili uye kwi-mozzila.org
 
 

--- a/xh/mozorg/home/index-2016.lang
+++ b/xh/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Ufuna uncedo?
 Fumana iimpendulo zakho malunga i-FireFox futhi nazo zonke iimveliso zika-Mozilla kusukela kwiqhela elixasayo.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/zh-CN/mozorg/home/index-2016.lang
+++ b/zh-CN/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Web 上的游戏
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 自豪的非营利。<br>在12月31日前捐款。
 
@@ -123,5 +125,10 @@ $%(sum)s {ok}
 # Take over form: button to submit the donation form
 ;Donate Now
 立即捐款
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+继续访问 mozilla.org
 
 

--- a/zh-CN/mozorg/home/index-2016.lang
+++ b/zh-CN/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Web 上的游戏
 我们的支持团队可以回答您关于 Firefox 及所有 Mozilla 产品的疑问。
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+自豪的非营利。<br>在12月31日前捐款。
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+输入您自定的金额
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+每月
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+一次
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+立即捐款
+
+

--- a/zh-TW/mozorg/home/index-2016.lang
+++ b/zh-TW/mozorg/home/index-2016.lang
@@ -94,7 +94,9 @@ Teach The Web {ok}
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 年終捐款，<br>以非營利為榮。
 
@@ -123,5 +125,10 @@ $%(sum)s {ok}
 # Take over form: button to submit the donation form
 ;Donate Now
 立刻捐款
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+繼續前往 mozilla.org
 
 

--- a/zh-TW/mozorg/home/index-2016.lang
+++ b/zh-TW/mozorg/home/index-2016.lang
@@ -93,3 +93,35 @@ Teach The Web {ok}
 尋找您對 Firefox 與所有 Mozilla 產品的疑問的解答。
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+年終捐款，<br>以非營利為榮。
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s {ok}
+
+
+# Take over form
+;Enter your own amount
+輸入您的捐款金額
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+每月
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+單次
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+立刻捐款
+
+

--- a/zu/mozorg/home/index-2016.lang
+++ b/zu/mozorg/home/index-2016.lang
@@ -92,3 +92,35 @@ Udinga usizo?
 Thola izimpendulo zemibuzo yakho mayelana ne-Firefox kanye nemikhiqizo yakwa-Mozilla ethimbeni lethu eleseka abathengi.
 
 
+# This will be used on a home page takeover starting from Dec 1st.
+# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+;Proudly non-profit. <br>Donate before Dec 31.
+Proudly non-profit. <br>Donate before Dec 31.
+
+
+# This is a sum in US dollars, e.g. '$100'. You can change the way it's displayed, e.g. '%(sum)s USD' will display '100 USD'
+# You can also localize the currency (e.g. to use € instead of $), but only if your currency is available on https://donate.mozilla.org (check the currency dropdown)
+;$%(sum)s
+$%(sum)s
+
+
+# Take over form
+;Enter your own amount
+Enter your own amount
+
+
+# Take over form: radio button for monthly contributions
+;Monthly
+Monthly
+
+
+# Take over form: radio button for one-time contributions
+;One-time
+One-time
+
+
+# Take over form: button to submit the donation form
+;Donate Now
+Donate Now
+
+

--- a/zu/mozorg/home/index-2016.lang
+++ b/zu/mozorg/home/index-2016.lang
@@ -93,7 +93,9 @@ Thola izimpendulo zemibuzo yakho mayelana ne-Firefox kanye nemikhiqizo yakwa-Moz
 
 
 # This will be used on a home page takeover starting from Dec 1st.
-# Screenshot for reference while the page is implemented: https://bug1214038.bmoattachments.org/attachment.cgi?id=8691488
+# Screenshots for reference while the page is implemented:
+# https://drive.google.com/file/d/0B8po55rC8WGXeFVuSWo5SDZlOG8/view?usp=sharing
+# https://drive.google.com/file/d/0B8po55rC8WGXY0JWakp0Z1dlYXc/view?usp=sharing
 ;Proudly non-profit. <br>Donate before Dec 31.
 Proudly non-profit. <br>Donate before Dec 31.
 
@@ -122,5 +124,10 @@ One-time
 # Take over form: button to submit the donation form
 ;Donate Now
 Donate Now
+
+
+# This is used as a link to dismiss the fundraising take over and continue to mozilla.org website
+;Continue to mozilla.org
+Qhubekela ku-mozilla.org
 
 


### PR DESCRIPTION
Strings + translations for bug 1316375.
Haven’t tested locally yet, because the takeover branch on bedrock is broken

@flodolo does that look good? Here’s what I did:

- checkout then revert the commit where the translations have been deleted (6f0e4831865eda01fb334800ef32c301e2918488)
- move the translations into fundraising.lang
- cherry-pick this commit on a branch up-to-date against current master
- import “Continue to www.mozilla.org” into index-2016.lang from index.lang
- delete fundraising.lang files
- rebase the branch to remove the first and last commits (creating & deleting fundraising.lang files)