### PR TITLE
Add a length limit on tweet

### DIFF
--- a/ach/firefox/all.lang
+++ b/ach/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly {ok}
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/af/firefox/all.lang
+++ b/af/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/am/firefox/all.lang
+++ b/am/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/an/firefox/all.lang
+++ b/an/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/ar/firefox/all.lang
+++ b/ar/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/as/firefox/all.lang
+++ b/as/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/ast/firefox/all.lang
+++ b/ast/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/az/firefox/all.lang
+++ b/az/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/be/firefox/all.lang
+++ b/be/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/bg/firefox/all.lang
+++ b/bg/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/bn-BD/firefox/all.lang
+++ b/bn-BD/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly {ok}
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/bn-IN/firefox/all.lang
+++ b/bn-IN/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/br/firefox/all.lang
+++ b/br/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/bs/firefox/all.lang
+++ b/bs/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/ca/firefox/all.lang
+++ b/ca/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/cak/firefox/all.lang
+++ b/cak/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly {ok}
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/cs/firefox/all.lang
+++ b/cs/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/cy/firefox/all.lang
+++ b/cy/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Datblygwyr
 Firefox Nightly {ok}
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/da/firefox/all.lang
+++ b/da/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/de/firefox/all.lang
+++ b/de/firefox/all.lang
@@ -55,6 +55,7 @@ Firefox Developer Edition {ok}
 Firefox Nightly {ok}
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Dank der Hilfe von Mitgliedern der Mozilla-Gemeinschaft auf der ganzen Welt gibt es Firefox in 90 Sprachen:
 

--- a/dsb/firefox/all.lang
+++ b/dsb/firefox/all.lang
@@ -55,6 +55,7 @@ Firefox Developer Edition {ok}
 Firefox Nightly {ok}
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Źěk pśinoskam cłonkow zgromaźeństwa Mozilla z cełego swěta, jo Firefox w 90 rěcach k dispoziciji:
 

--- a/el/firefox/all.lang
+++ b/el/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/en-GB/firefox/all.lang
+++ b/en-GB/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/en-US/firefox/all.lang
+++ b/en-US/firefox/all.lang
@@ -55,6 +55,8 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+## MAX_LENGTH: 116 characters
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/en-ZA/firefox/all.lang
+++ b/en-ZA/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/eo/firefox/all.lang
+++ b/eo/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/es-AR/firefox/all.lang
+++ b/es-AR/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/es-CL/firefox/all.lang
+++ b/es-CL/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/es-ES/firefox/all.lang
+++ b/es-ES/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/es-MX/firefox/all.lang
+++ b/es-MX/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/et/firefox/all.lang
+++ b/et/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/eu/firefox/all.lang
+++ b/eu/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/fa/firefox/all.lang
+++ b/fa/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/ff/firefox/all.lang
+++ b/ff/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/fi/firefox/all.lang
+++ b/fi/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/fr/firefox/all.lang
+++ b/fr/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/fy-NL/firefox/all.lang
+++ b/fy-NL/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/ga-IE/firefox/all.lang
+++ b/ga-IE/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/gd/firefox/all.lang
+++ b/gd/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/gl/firefox/all.lang
+++ b/gl/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/gn/firefox/all.lang
+++ b/gn/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/gu-IN/firefox/all.lang
+++ b/gu-IN/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/he/firefox/all.lang
+++ b/he/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/hi-IN/firefox/all.lang
+++ b/hi-IN/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly {ok}
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/hr/firefox/all.lang
+++ b/hr/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/hsb/firefox/all.lang
+++ b/hsb/firefox/all.lang
@@ -55,6 +55,7 @@ Firefox Developer Edition {ok}
 Firefox Nightly {ok}
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Dźak přinoškam čłonow zhromadźenstwa Mozilla z cyłeho swěta, je Firefox w 90 rěčach k dispoziciji:
 

--- a/hto/firefox/all.lang
+++ b/hto/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/hu/firefox/all.lang
+++ b/hu/firefox/all.lang
@@ -55,6 +55,7 @@ Firefox Developer Edition {ok}
 Firefox Nightly {ok}
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 A Mozilla közösség tagjainak közreműködésének köszönhetően, a Firefox 90 nyelven érhető el:
 

--- a/hy-AM/firefox/all.lang
+++ b/hy-AM/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/id/firefox/all.lang
+++ b/id/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/is/firefox/all.lang
+++ b/is/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/it/firefox/all.lang
+++ b/it/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/ja/firefox/all.lang
+++ b/ja/firefox/all.lang
@@ -55,6 +55,7 @@ Firefox Developer Edition {ok}
 Firefox Nightly {ok}
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 世界中のコミュニティメンバーによる貢献のおかげで、Firefox は次の 90 言語で利用できます：
 

--- a/ka/firefox/all.lang
+++ b/ka/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/kab/firefox/all.lang
+++ b/kab/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/kk/firefox/all.lang
+++ b/kk/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/km/firefox/all.lang
+++ b/km/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/kn/firefox/all.lang
+++ b/kn/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/ko/firefox/all.lang
+++ b/ko/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/lij/firefox/all.lang
+++ b/lij/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/lo/firefox/all.lang
+++ b/lo/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/lt/firefox/all.lang
+++ b/lt/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/ltg/firefox/all.lang
+++ b/ltg/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/lv/firefox/all.lang
+++ b/lv/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/mai/firefox/all.lang
+++ b/mai/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/mk/firefox/all.lang
+++ b/mk/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/ml/firefox/all.lang
+++ b/ml/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/mr/firefox/all.lang
+++ b/mr/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/ms/firefox/all.lang
+++ b/ms/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/my/firefox/all.lang
+++ b/my/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/nb-NO/firefox/all.lang
+++ b/nb-NO/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/ncj/firefox/all.lang
+++ b/ncj/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/ne-NP/firefox/all.lang
+++ b/ne-NP/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/nl/firefox/all.lang
+++ b/nl/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/nn-NO/firefox/all.lang
+++ b/nn-NO/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/nv/firefox/all.lang
+++ b/nv/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/oc/firefox/all.lang
+++ b/oc/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/or/firefox/all.lang
+++ b/or/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/pa-IN/firefox/all.lang
+++ b/pa-IN/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/pbb/firefox/all.lang
+++ b/pbb/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/pl/firefox/all.lang
+++ b/pl/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/pt-BR/firefox/all.lang
+++ b/pt-BR/firefox/all.lang
@@ -55,6 +55,7 @@ Firefox Developer Edition {ok}
 Firefox Nightly {ok}
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Graças às contribuições dos membros da comunidade da Mozilla à volta do mundo, o Firefox está disponível em 90 idiomas:
 

--- a/pt-PT/firefox/all.lang
+++ b/pt-PT/firefox/all.lang
@@ -55,6 +55,7 @@ Firefox Developer Edition {ok}
 Firefox Nightly {ok}
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Graças às contribuições dos membros da comunidade da Mozilla à volta do mundo, o Firefox está disponível em 90 idiomas:
 

--- a/qvi/firefox/all.lang
+++ b/qvi/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/rm/firefox/all.lang
+++ b/rm/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/ro/firefox/all.lang
+++ b/ro/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/ru/firefox/all.lang
+++ b/ru/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/si/firefox/all.lang
+++ b/si/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/sk/firefox/all.lang
+++ b/sk/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/sl/firefox/all.lang
+++ b/sl/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/son/firefox/all.lang
+++ b/son/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/sq/firefox/all.lang
+++ b/sq/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/sr/firefox/all.lang
+++ b/sr/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/sv-SE/firefox/all.lang
+++ b/sv-SE/firefox/all.lang
@@ -55,6 +55,7 @@ Firefox Developer Edition {ok}
 Firefox Nightly {ok}
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Tack vare bidrag från Mozilla community-medlemmar runt om i världen finns Firefox på 90 språk:
 

--- a/ta/firefox/all.lang
+++ b/ta/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/te/firefox/all.lang
+++ b/te/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/th/firefox/all.lang
+++ b/th/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/tl/firefox/all.lang
+++ b/tl/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/tr/firefox/all.lang
+++ b/tr/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/trs/firefox/all.lang
+++ b/trs/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/uk/firefox/all.lang
+++ b/uk/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/ur/firefox/all.lang
+++ b/ur/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly {ok}
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/uz/firefox/all.lang
+++ b/uz/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/vi/firefox/all.lang
+++ b/vi/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/xh/firefox/all.lang
+++ b/xh/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/zam/firefox/all.lang
+++ b/zam/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/zh-CN/firefox/all.lang
+++ b/zh-CN/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition {ok}
 Firefox Nightly {ok}
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 感谢 Mozilla 社区的成员在世界各地作出的贡献。Firefox 目前提供90种语言：
 

--- a/zh-TW/firefox/all.lang
+++ b/zh-TW/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 

--- a/zu/firefox/all.lang
+++ b/zu/firefox/all.lang
@@ -54,6 +54,7 @@ Firefox Developer Edition
 Firefox Nightly
 
 
+# Used as a tweet, make sure to keep it under 116 characters
 ;Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 Thanks to contributions of Mozilla community members around the world, Firefox is available in 90 languages:
 


### PR DESCRIPTION
Added an actual limit in the en-US file.

pt-BR/pt-PT are too long for instance: https://twitter.com/intent/tweet?url=http%3A%2F%2Fmzl.la%2F1IMdR5T&text=Gra%C3%A7as+%C3%A0s+contribui%C3%A7%C3%B5es+dos+membros+da+comunidade+da+Mozilla+%C3%A0+volta+do+mundo%2C+o+Firefox+est%C3%A1+dispon%C3%ADvel+em+90+idiomas%3A