### PR TITLE
Add missing strings in footer

### DIFF
--- a/ach/main.lang
+++ b/ach/main.lang
@@ -114,6 +114,11 @@ Dii Dyere
 Kube kwed Wa
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Leb mapatpat:
 
@@ -294,7 +299,12 @@ Yil rwom ne kombedi
 I mung pa dano
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 

--- a/ach/main.lang
+++ b/ach/main.lang
@@ -301,7 +301,7 @@ I mung pa dano
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/ach/main.lang
+++ b/ach/main.lang
@@ -301,7 +301,7 @@ I mung pa dano
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/af/main.lang
+++ b/af/main.lang
@@ -301,7 +301,7 @@ Privaatheid
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Dele van dié inhoud is ©1998–%(current_year)s deur individuele bydraers tot mozilla.org. Inhoud is beskikbaar onder 'n <a href="%(url)s">Creative Commons-lisensie</a>.
+Dele van dié inhoud is ©1998–%(current_year)s deur individuele bydraers tot mozilla.org. Inhoud is beskikbaar onder 'n <a rel="license" href="%(url)s">Creative Commons-lisensie</a>.
 
 
 # Previous footer string

--- a/af/main.lang
+++ b/af/main.lang
@@ -114,6 +114,11 @@ Perssentrum
 Kontak ons
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Ander tale:
 
@@ -294,7 +299,12 @@ Werk nou by
 Privaatheid
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Dele van dié inhoud is ©1998–%(current_year)s deur individuele bydraers tot mozilla.org. Inhoud is beskikbaar onder 'n <a href="%(url)s">Creative Commons-lisensie</a>.
 

--- a/af/main.lang
+++ b/af/main.lang
@@ -301,7 +301,7 @@ Privaatheid
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Dele van dié inhoud is ©1998–%(current_year)s deur individuele bydraers tot mozilla.org. Inhoud is beskikbaar onder 'n <a href="%(url)s">Creative Commons-lisensie</a>.
 
 
 # Previous footer string

--- a/am/main.lang
+++ b/am/main.lang
@@ -114,6 +114,11 @@ Press Center
 Contact Us
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Other languages:
 
@@ -294,7 +299,12 @@ Update now
 ግላዊነት
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 

--- a/am/main.lang
+++ b/am/main.lang
@@ -301,7 +301,7 @@ Update now
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/am/main.lang
+++ b/am/main.lang
@@ -301,7 +301,7 @@ Update now
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/an/main.lang
+++ b/an/main.lang
@@ -114,6 +114,11 @@ Centro de prensa
 Mete-te en contacto con nusatros
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Atras luengas:
 
@@ -294,7 +299,12 @@ Actualizar agora
 Privacidat
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Bellas partes d'iste conteniu tienen dreitos ©1998–%(current_year)s de colaboradors individuals de mozilla.org. Conteniu disponible baixo licencia <a href="%(url)s">Creative Commons</a>.
 

--- a/an/main.lang
+++ b/an/main.lang
@@ -301,7 +301,7 @@ Privacidat
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Bellas partes d'iste conteniu tienen dreitos ©1998–%(current_year)s de colaboradors individuals de mozilla.org. Conteniu disponible baixo licencia <a href="%(url)s">Creative Commons</a>.
+Bellas partes d'iste conteniu tienen dreitos ©1998–%(current_year)s de colaboradors individuals de mozilla.org. Conteniu disponible baixo licencia <a rel="license" href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/an/main.lang
+++ b/an/main.lang
@@ -301,7 +301,7 @@ Privacidat
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Bellas partes d'iste conteniu tienen dreitos ©1998–%(current_year)s de colaboradors individuals de mozilla.org. Conteniu disponible baixo licencia <a href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/ar/main.lang
+++ b/ar/main.lang
@@ -114,6 +114,11 @@
 الاتصال بنا
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 لغات أخرى:
 
@@ -294,7 +299,12 @@
 الخصوصية
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 حقوق بعض هذا المحتوى محفوظة لمساهمي موزيلا ©1998–%(current_year)s. المحتوى منشور تحت <a href="%(url)s">رخصة المشاع الإبداعي</a>.
 

--- a/ar/main.lang
+++ b/ar/main.lang
@@ -301,7 +301,7 @@ Language
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+حقوق بعض هذا المحتوى محفوظة لمساهمي موزيلا ©1998–%(current_year)s. المحتوى منشور تحت <a href="%(url)s">رخصة المشاع الإبداعي</a>.
 
 
 # Previous footer string

--- a/ar/main.lang
+++ b/ar/main.lang
@@ -301,7 +301,7 @@ Language
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-حقوق بعض هذا المحتوى محفوظة لمساهمي موزيلا ©1998–%(current_year)s. المحتوى منشور تحت <a href="%(url)s">رخصة المشاع الإبداعي</a>.
+حقوق بعض هذا المحتوى محفوظة لمساهمي موزيلا ©1998–%(current_year)s. المحتوى منشور تحت <a rel="license" href="%(url)s">رخصة المشاع الإبداعي</a>.
 
 
 # Previous footer string

--- a/as/main.lang
+++ b/as/main.lang
@@ -301,7 +301,7 @@ MPEG-4 বিন্যাস
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+এই সমলৰ কিছু অংশ ©1998–%(current_year)s ৰ সূকীয়া  mozilla.org অৱদানকাৰীসকলৰ অৱদান।  সমল এটা <a href="%(url)s">Creative Commons license</a> ৰ অন্তৰ্গত উপলব্ধ।
 
 
 # Previous footer string

--- a/as/main.lang
+++ b/as/main.lang
@@ -301,7 +301,7 @@ MPEG-4 বিন্যাস
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-এই সমলৰ কিছু অংশ ©1998–%(current_year)s ৰ সূকীয়া  mozilla.org অৱদানকাৰীসকলৰ অৱদান।  সমল এটা <a href="%(url)s">Creative Commons license</a> ৰ অন্তৰ্গত উপলব্ধ।
+এই সমলৰ কিছু অংশ ©1998–%(current_year)s ৰ সূকীয়া  mozilla.org অৱদানকাৰীসকলৰ অৱদান।  সমল এটা <a rel="license" href="%(url)s">Creative Commons license</a> ৰ অন্তৰ্গত উপলব্ধ।
 
 
 # Previous footer string

--- a/as/main.lang
+++ b/as/main.lang
@@ -114,6 +114,11 @@ Mozilla ৰ বিষয়ে
 আমাক যোগাযোগ কৰক
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 অন্য ভাষাসমূহ:
 
@@ -294,7 +299,12 @@ MPEG-4 বিন্যাস
 গোপনীয়তা
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 এই সমলৰ কিছু অংশ ©1998–%(current_year)s ৰ সূকীয়া  mozilla.org অৱদানকাৰীসকলৰ অৱদান।  সমল এটা <a href="%(url)s">Creative Commons license</a> ৰ অন্তৰ্গত উপলব্ধ।
 

--- a/ast/main.lang
+++ b/ast/main.lang
@@ -301,7 +301,7 @@ Privacidá
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Dalgunos conteníos tán protexíos polos drechos d'autor ©1998–%(current_year)s de determinaos collaboradores en mozilla.org. El restu del conteníu ta disponible baxo una llicencia <a href="%(url)s">Creative Commons</a>.
+Dalgunos conteníos tán protexíos polos drechos d'autor ©1998–%(current_year)s de determinaos collaboradores en mozilla.org. El restu del conteníu ta disponible baxo una llicencia <a rel="license" href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/ast/main.lang
+++ b/ast/main.lang
@@ -301,7 +301,7 @@ Privacidá
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Dalgunos conteníos tán protexíos polos drechos d'autor ©1998–%(current_year)s de determinaos collaboradores en mozilla.org. El restu del conteníu ta disponible baxo una llicencia <a href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/ast/main.lang
+++ b/ast/main.lang
@@ -114,6 +114,11 @@ Centru de prensa
 Contautu
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Otres llingües:
 
@@ -294,7 +299,12 @@ Anovar agora
 Privacidá
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Dalgunos conteníos tán protexíos polos drechos d'autor ©1998–%(current_year)s de determinaos collaboradores en mozilla.org. El restu del conteníu ta disponible baxo una llicencia <a href="%(url)s">Creative Commons</a>.
 

--- a/az/main.lang
+++ b/az/main.lang
@@ -114,6 +114,11 @@ Mətbuat Mərkəzi
 Bizimlə Əlaqə
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Başqa dillər:
 
@@ -294,7 +299,12 @@ E-poçt
 Məxfilik
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Bu məzmunun bir hissəsi ©1998–%(current_year)s mozilla.org proyektinin iştirakçıları tərəfindən yaradılıb. Məzmun <a href="%(url)s">Creative Commons lisenziyası</a> ilə mövcuddur.
 

--- a/az/main.lang
+++ b/az/main.lang
@@ -301,7 +301,7 @@ Məxfilik
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Bu məzmunun bir hissəsi ©1998–%(current_year)s mozilla.org proyektinin iştirakçıları tərəfindən yaradılıb. Məzmun <a href="%(url)s">Creative Commons lisenziyası</a> ilə mövcuddur.
+Bu məzmunun bir hissəsi ©1998–%(current_year)s mozilla.org proyektinin iştirakçıları tərəfindən yaradılıb. Məzmun <a rel="license" href="%(url)s">Creative Commons lisenziyası</a> ilə mövcuddur.
 
 
 # Previous footer string

--- a/az/main.lang
+++ b/az/main.lang
@@ -301,7 +301,7 @@ Məxfilik
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Bu məzmunun bir hissəsi ©1998–%(current_year)s mozilla.org proyektinin iştirakçıları tərəfindən yaradılıb. Məzmun <a href="%(url)s">Creative Commons lisenziyası</a> ilə mövcuddur.
 
 
 # Previous footer string

--- a/be/main.lang
+++ b/be/main.lang
@@ -301,7 +301,7 @@ Language
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Часткі змесціва створаны індывідуальна ўкладчыкамі mozilla.org ©1998–%(current_year)s. Змесціва даступна згодна <a href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/be/main.lang
+++ b/be/main.lang
@@ -301,7 +301,7 @@ Language
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Часткі змесціва створаны індывідуальна ўкладчыкамі mozilla.org ©1998–%(current_year)s. Змесціва даступна згодна <a href="%(url)s">Creative Commons license</a>.
+Часткі змесціва створаны індывідуальна ўкладчыкамі mozilla.org ©1998–%(current_year)s. Змесціва даступна згодна <a rel="license" href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/be/main.lang
+++ b/be/main.lang
@@ -114,6 +114,11 @@ Firefox - некамерцыйны, некарпаратыўны і нескам
 Сувязь з намі
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Іншыя мовы:
 
@@ -294,7 +299,12 @@ Firefox - некамерцыйны, некарпаратыўны і нескам
 Прыватнасць
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Часткі змесціва створаны індывідуальна ўкладчыкамі mozilla.org ©1998–%(current_year)s. Змесціва даступна згодна <a href="%(url)s">Creative Commons license</a>.
 

--- a/bg/main.lang
+++ b/bg/main.lang
@@ -114,6 +114,11 @@ Firefox остана не-комерсиален, не-корпоративен,
 Връзка с нас
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Други езици:
 
@@ -294,7 +299,12 @@ Firefox за мобилни телефони
 Лични данни
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Части от това съдържание са ©1998–%(current_year)s на индивидуални сътрудници на mozilla.org. Съдържанието е достъпно под <a href="%(url)s">Creative Commons license</a>.
 

--- a/bg/main.lang
+++ b/bg/main.lang
@@ -301,7 +301,7 @@ Firefox за мобилни телефони
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Части от това съдържание са ©1998–%(current_year)s на индивидуални сътрудници на mozilla.org. Съдържанието е достъпно под <a href="%(url)s">Creative Commons license</a>.
+Части от това съдържание са ©1998–%(current_year)s на индивидуални сътрудници на mozilla.org. Съдържанието е достъпно под <a rel="license" href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/bg/main.lang
+++ b/bg/main.lang
@@ -301,7 +301,7 @@ Firefox за мобилни телефони
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Части от това съдържание са ©1998–%(current_year)s на индивидуални сътрудници на mozilla.org. Съдържанието е достъпно под <a href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/bn-BD/main.lang
+++ b/bn-BD/main.lang
@@ -114,6 +114,11 @@
 যোগাযোগ
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 অন্যান্য ভাষা:
 
@@ -294,7 +299,12 @@ MPEG-4 ফরম্যাট
 গোপনীয়তা
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 এই বিষয়বস্তুর অংশসমূহ হল পৃথক mozilla.org অবদানকারীর দ্বারা ©1998–%(current_year)s। বিষয়বস্তু ক্রিয়েটিভ কমনস লাইসেন্সের <a href="%(url)s"> অধীনে নেওয়া হয়েছে</a>।
 

--- a/bn-BD/main.lang
+++ b/bn-BD/main.lang
@@ -301,7 +301,7 @@ MPEG-4 ফরম্যাট
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+এই বিষয়বস্তুর অংশসমূহ হল পৃথক mozilla.org অবদানকারীর দ্বারা ©1998–%(current_year)s। বিষয়বস্তু ক্রিয়েটিভ কমনস লাইসেন্সের <a href="%(url)s"> অধীনে নেওয়া হয়েছে</a>।
 
 
 # Previous footer string

--- a/bn-BD/main.lang
+++ b/bn-BD/main.lang
@@ -301,7 +301,7 @@ MPEG-4 ফরম্যাট
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-এই বিষয়বস্তুর অংশসমূহ হল পৃথক mozilla.org অবদানকারীর দ্বারা ©1998–%(current_year)s। বিষয়বস্তু ক্রিয়েটিভ কমনস লাইসেন্সের <a href="%(url)s"> অধীনে নেওয়া হয়েছে</a>।
+এই বিষয়বস্তুর অংশসমূহ হল পৃথক mozilla.org অবদানকারীর দ্বারা ©1998–%(current_year)s। বিষয়বস্তু ক্রিয়েটিভ কমনস লাইসেন্সের <a rel="license" href="%(url)s"> অধীনে নেওয়া হয়েছে</a>।
 
 
 # Previous footer string

--- a/bn-IN/main.lang
+++ b/bn-IN/main.lang
@@ -114,6 +114,11 @@ Mozilla পরিচিতি
 যোগাযোগ করুন
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 অন্যান্য ভাষা:
 
@@ -294,7 +299,12 @@ MPEG-4 বিন্যাস
 গোপনীয়তা
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 এই বিষয়বস্তুর অংশ ©1998–%(current_year)sঅাছে mozilla.org-র অনুদানকারীদের দ্বারা. সামগ্রী উপলব্ধ অাছে <a href="%(url)s">Creative Commons license</a> অধীনে.
 

--- a/bn-IN/main.lang
+++ b/bn-IN/main.lang
@@ -301,7 +301,7 @@ MPEG-4 বিন্যাস
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-এই বিষয়বস্তুর অংশ ©1998–%(current_year)sঅাছে mozilla.org-র অনুদানকারীদের দ্বারা. সামগ্রী উপলব্ধ অাছে <a href="%(url)s">Creative Commons license</a> অধীনে.
+এই বিষয়বস্তুর অংশ ©1998–%(current_year)sঅাছে mozilla.org-র অনুদানকারীদের দ্বারা. সামগ্রী উপলব্ধ অাছে <a rel="license" href="%(url)s">Creative Commons license</a> অধীনে.
 
 
 # Previous footer string

--- a/bn-IN/main.lang
+++ b/bn-IN/main.lang
@@ -301,7 +301,7 @@ MPEG-4 বিন্যাস
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+এই বিষয়বস্তুর অংশ ©1998–%(current_year)sঅাছে mozilla.org-র অনুদানকারীদের দ্বারা. সামগ্রী উপলব্ধ অাছে <a href="%(url)s">Creative Commons license</a> অধীনে.
 
 
 # Previous footer string

--- a/br/main.lang
+++ b/br/main.lang
@@ -301,7 +301,7 @@ Buhez prevez
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Lodennoù an endalc'had-mañ zo ©1998–%(current_year)s gant perzhidi hiniennel eus mozilla.org. Endalc'had hegerz dindan termenoù al <a href="%(url)s">lañvaz Creative Commons</a>.
+Lodennoù an endalc'had-mañ zo ©1998–%(current_year)s gant perzhidi hiniennel eus mozilla.org. Endalc'had hegerz dindan termenoù al <a rel="license" href="%(url)s">lañvaz Creative Commons</a>.
 
 
 # Previous footer string

--- a/br/main.lang
+++ b/br/main.lang
@@ -114,6 +114,11 @@ Kreizenn ar Gwask
 Kit e darempred ganeomp
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Yezhoù all :
 
@@ -294,7 +299,12 @@ Hizivaat diouzhtu
 Buhez prevez
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Lodennoù an endalc'had-mañ zo ©1998–%(current_year)s gant perzhidi hiniennel eus mozilla.org. Endalc'had hegerz dindan termenoù al <a href="%(url)s">lañvaz Creative Commons</a>.
 

--- a/br/main.lang
+++ b/br/main.lang
@@ -301,7 +301,7 @@ Buhez prevez
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Lodennoù an endalc'had-mañ zo ©1998–%(current_year)s gant perzhidi hiniennel eus mozilla.org. Endalc'had hegerz dindan termenoù al <a href="%(url)s">lañvaz Creative Commons</a>.
 
 
 # Previous footer string

--- a/bs/main.lang
+++ b/bs/main.lang
@@ -301,7 +301,7 @@ Privatnost
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Dijelovi ovog sadržaja su ©1998 –%(current_year)s pojedinačnim mozilla.org saradnicima. Sadržaj je dostupan pod <a href="%(url)s">Creative Commons licencom</a>.
+Dijelovi ovog sadržaja su ©1998 –%(current_year)s pojedinačnim mozilla.org saradnicima. Sadržaj je dostupan pod <a rel="license" href="%(url)s">Creative Commons licencom</a>.
 
 
 # Previous footer string

--- a/bs/main.lang
+++ b/bs/main.lang
@@ -301,7 +301,7 @@ Privatnost
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Dijelovi ovog sadržaja su ©1998 –%(current_year)s pojedinačnim mozilla.org saradnicima. Sadržaj je dostupan pod <a href="%(url)s">Creative Commons licencom</a>.
 
 
 # Previous footer string

--- a/bs/main.lang
+++ b/bs/main.lang
@@ -114,6 +114,11 @@ Centar za medije
 Kontaktirajte nas
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Drugi jezici:
 
@@ -294,7 +299,12 @@ Ažurirajte sada
 Privatnost
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Dijelovi ovog sadržaja su ©1998 –%(current_year)s pojedinačnim mozilla.org saradnicima. Sadržaj je dostupan pod <a href="%(url)s">Creative Commons licencom</a>.
 

--- a/ca/main.lang
+++ b/ca/main.lang
@@ -114,6 +114,11 @@ Centre de premsa
 Contacteu-nos
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Altres llengües:
 
@@ -294,7 +299,12 @@ Actualitzeu-vos ara
 Privadesa
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Parts d'aquest contingut són ©1998–%(current_year)s de col·laboradors de mozilla.org. El contingut està subjecte a la <a href="%(url)s">llicència Creative Commons</a>.
 

--- a/ca/main.lang
+++ b/ca/main.lang
@@ -301,7 +301,7 @@ Privadesa
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Parts d'aquest contingut són ©1998–%(current_year)s de col·laboradors de mozilla.org. El contingut està subjecte a la <a href="%(url)s">llicència Creative Commons</a>.
 
 
 # Previous footer string

--- a/ca/main.lang
+++ b/ca/main.lang
@@ -301,7 +301,7 @@ Privadesa
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Parts d'aquest contingut són ©1998–%(current_year)s de col·laboradors de mozilla.org. El contingut està subjecte a la <a href="%(url)s">llicència Creative Commons</a>.
+Parts d'aquest contingut són ©1998–%(current_year)s de col·laboradors de mozilla.org. El contingut està subjecte a la <a rel="license" href="%(url)s">llicència Creative Commons</a>.
 
 
 # Previous footer string

--- a/cak/main.lang
+++ b/cak/main.lang
@@ -114,6 +114,11 @@ Ruk'ojlib'al laq'apub'äl
 Rub'i' achib'il
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Ch'aqa' chik ch'ab'äl:
 
@@ -294,7 +299,12 @@ Tak'exa' ruwäch wakami
 Ichinanem
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Jujun kipam etamab'äl chajin ruma kich'ojib'al b'anel ©1998–%(current_year)s kuma to'onela' pa mozilla.org. Ri ch'aqa' chik rupam, ya'on q'ij chi yeq'alajin pe ruma ri <a href="%(url)s">Creative Commons</a>.
 

--- a/cak/main.lang
+++ b/cak/main.lang
@@ -301,7 +301,7 @@ Ichinanem
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Jujun kipam etamab'äl chajin ruma kich'ojib'al b'anel ©1998–%(current_year)s kuma to'onela' pa mozilla.org. Ri ch'aqa' chik rupam, ya'on q'ij chi yeq'alajin pe ruma ri <a href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/cak/main.lang
+++ b/cak/main.lang
@@ -301,7 +301,7 @@ Ichinanem
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Jujun kipam etamab'äl chajin ruma kich'ojib'al b'anel ©1998–%(current_year)s kuma to'onela' pa mozilla.org. Ri ch'aqa' chik rupam, ya'on q'ij chi yeq'alajin pe ruma ri <a href="%(url)s">Creative Commons</a>.
+Jujun kipam etamab'äl chajin ruma kich'ojib'al b'anel ©1998–%(current_year)s kuma to'onela' pa mozilla.org. Ri ch'aqa' chik rupam, ya'on q'ij chi yeq'alajin pe ruma ri <a rel="license" href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/cs/main.lang
+++ b/cs/main.lang
@@ -114,6 +114,11 @@ Tiskové centrum
 Kontaktujte nás
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Další jazyky:
 
@@ -294,7 +299,12 @@ Aktualizujte
 Soukromí
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Části tohoto obsahu jsou ©1998–%(current_year)s jednotlivými přispěvateli mozilla.org. Obsah je dostupný pod <a href="%(url)s">licencí Creative Commons</a>.
 

--- a/cs/main.lang
+++ b/cs/main.lang
@@ -301,7 +301,7 @@ Soukromí
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Části tohoto obsahu jsou ©1998–%(current_year)s jednotlivými přispěvateli mozilla.org. Obsah je dostupný pod <a href="%(url)s">licencí Creative Commons</a>.
 
 
 # Previous footer string

--- a/cs/main.lang
+++ b/cs/main.lang
@@ -301,7 +301,7 @@ Soukromí
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Části tohoto obsahu jsou ©1998–%(current_year)s jednotlivými přispěvateli mozilla.org. Obsah je dostupný pod <a href="%(url)s">licencí Creative Commons</a>.
+Části tohoto obsahu jsou ©1998–%(current_year)s jednotlivými přispěvateli mozilla.org. Obsah je dostupný pod <a rel="license" href="%(url)s">licencí Creative Commons</a>.
 
 
 # Previous footer string

--- a/cy/main.lang
+++ b/cy/main.lang
@@ -301,7 +301,7 @@ Preifatrwydd
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Mae darnau o'r cynnwys yn ©1998–%(current_year)s gan gyfranwyr unigol mozilla.org. Mae'r cynnwys ar gael o dan <a href="%(url)s">drwydded Creative Commons</a>.
+Mae darnau o'r cynnwys yn ©1998–%(current_year)s gan gyfranwyr unigol mozilla.org. Mae'r cynnwys ar gael o dan <a rel="license" href="%(url)s">drwydded Creative Commons</a>.
 
 
 # Previous footer string

--- a/cy/main.lang
+++ b/cy/main.lang
@@ -301,7 +301,7 @@ Preifatrwydd
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Mae darnau o'r cynnwys yn ©1998–%(current_year)s gan gyfranwyr unigol mozilla.org. Mae'r cynnwys ar gael o dan <a href="%(url)s">drwydded Creative Commons</a>.
 
 
 # Previous footer string

--- a/cy/main.lang
+++ b/cy/main.lang
@@ -114,6 +114,11 @@ Canolfan y Wasg
 Cysylltu â ni
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Ieithoedd eraill:
 
@@ -294,7 +299,12 @@ Diweddarwch yn awr
 Preifatrwydd
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Mae darnau o'r cynnwys yn ©1998–%(current_year)s gan gyfranwyr unigol mozilla.org. Mae'r cynnwys ar gael o dan <a href="%(url)s">drwydded Creative Commons</a>.
 

--- a/da/main.lang
+++ b/da/main.lang
@@ -301,7 +301,7 @@ Privatliv
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Dele af dette indhold er ©1998–%(current_year)s af individuelle mozilla.org-bidragsydere. Indholdet er tilgængelig under en <a href="%(url)s">Creative Commons licens</a>.
 
 
 # Previous footer string

--- a/da/main.lang
+++ b/da/main.lang
@@ -301,7 +301,7 @@ Privatliv
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Dele af dette indhold er ©1998–%(current_year)s af individuelle mozilla.org-bidragsydere. Indholdet er tilgængelig under en <a href="%(url)s">Creative Commons licens</a>.
+Dele af dette indhold er ©1998–%(current_year)s af individuelle mozilla.org-bidragsydere. Indholdet er tilgængelig under en <a rel="license" href="%(url)s">Creative Commons licens</a>.
 
 
 # Previous footer string

--- a/da/main.lang
+++ b/da/main.lang
@@ -114,6 +114,11 @@ Pressecenter
 Kontakt os
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Andre sprog:
 
@@ -294,7 +299,12 @@ Opdater nu
 Privatliv
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Dele af dette indhold er ©1998–%(current_year)s af individuelle mozilla.org-bidragsydere. Indholdet er tilgængelig under en <a href="%(url)s">Creative Commons licens</a>.
 

--- a/de/main.lang
+++ b/de/main.lang
@@ -301,7 +301,7 @@ Datenschutz
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Teile dieses Inhalts stehen unter einem ©1998–%(current_year)s von einzelnen Mitwirkenden an mozilla.org. Der Inhalt steht unter einer <a href="%(url)s">Creative-Commons-Lizenz</a>.
 
 
 # Previous footer string

--- a/de/main.lang
+++ b/de/main.lang
@@ -301,7 +301,7 @@ Datenschutz
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Teile dieses Inhalts stehen unter einem ©1998–%(current_year)s von einzelnen Mitwirkenden an mozilla.org. Der Inhalt steht unter einer <a href="%(url)s">Creative-Commons-Lizenz</a>.
+Teile dieses Inhalts stehen unter einem ©1998–%(current_year)s von einzelnen Mitwirkenden an mozilla.org. Der Inhalt steht unter einer <a rel="license" href="%(url)s">Creative-Commons-Lizenz</a>.
 
 
 # Previous footer string

--- a/de/main.lang
+++ b/de/main.lang
@@ -114,6 +114,11 @@ Presse
 Kontakt
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Andere Sprachen:
 
@@ -294,7 +299,12 @@ Aktualisieren Sie jetzt
 Datenschutz
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Teile dieses Inhalts stehen unter einem ©1998–%(current_year)s von einzelnen Mitwirkenden an mozilla.org. Der Inhalt steht unter einer <a href="%(url)s">Creative-Commons-Lizenz</a>.
 

--- a/dsb/main.lang
+++ b/dsb/main.lang
@@ -114,6 +114,11 @@ Casnikarski centrum
 Stajśo se z nami do zwiska
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Druge rěcy:
 
@@ -294,7 +299,12 @@ Něnto aktualizěrowaś
 Priwatnosć
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Źěle toś togo wopśimjeśa wót jadnotliwych sobuskutkujucych mozilla.org napórane ©1998–%(current_year)s. Wopśimjeśe stoj pód licencu <a href="%(url)s">Creative Commons license</a> k dispoziciji.
 

--- a/dsb/main.lang
+++ b/dsb/main.lang
@@ -301,7 +301,7 @@ Priwatnosć
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Źěle toś togo wopśimjeśa wót jadnotliwych sobuskutkujucych mozilla.org napórane ©1998–%(current_year)s. Wopśimjeśe stoj pód licencu <a href="%(url)s">Creative Commons license</a> k dispoziciji.
+Źěle toś togo wopśimjeśa wót jadnotliwych sobuskutkujucych mozilla.org napórane ©1998–%(current_year)s. Wopśimjeśe stoj pód licencu <a rel="license" href="%(url)s">Creative Commons license</a> k dispoziciji.
 
 
 # Previous footer string

--- a/dsb/main.lang
+++ b/dsb/main.lang
@@ -301,7 +301,7 @@ Priwatnosć
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Źěle toś togo wopśimjeśa wót jadnotliwych sobuskutkujucych mozilla.org napórane ©1998–%(current_year)s. Wopśimjeśe stoj pód licencu <a href="%(url)s">Creative Commons license</a> k dispoziciji.
 
 
 # Previous footer string

--- a/el/main.lang
+++ b/el/main.lang
@@ -301,7 +301,7 @@ Firefox για κινητά
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Τμήματα αυτού του περιεχομένου ανήκουν σε μεμονωμένους εθελοντές του mozilla.org ©1998–%(current_year)s. Το περιεχόμενο διατίθεται υπό την <a href="%(url)s">άδεια Creative Commons</a>.
+Τμήματα αυτού του περιεχομένου ανήκουν σε μεμονωμένους εθελοντές του mozilla.org ©1998–%(current_year)s. Το περιεχόμενο διατίθεται υπό την <a rel="license" href="%(url)s">άδεια Creative Commons</a>.
 
 
 # Previous footer string

--- a/el/main.lang
+++ b/el/main.lang
@@ -301,7 +301,7 @@ Firefox για κινητά
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Τμήματα αυτού του περιεχομένου ανήκουν σε μεμονωμένους εθελοντές του mozilla.org ©1998–%(current_year)s. Το περιεχόμενο διατίθεται υπό την <a href="%(url)s">άδεια Creative Commons</a>.
 
 
 # Previous footer string

--- a/el/main.lang
+++ b/el/main.lang
@@ -114,6 +114,11 @@ Developer Edition {ok}
 Επικοινωνία
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Άλλες γλώσσες:
 
@@ -294,7 +299,12 @@ Firefox για κινητά
 Απόρρητο
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Τμήματα αυτού του περιεχομένου ανήκουν σε μεμονωμένους εθελοντές του mozilla.org ©1998–%(current_year)s. Το περιεχόμενο διατίθεται υπό την <a href="%(url)s">άδεια Creative Commons</a>.
 

--- a/en-GB/main.lang
+++ b/en-GB/main.lang
@@ -301,7 +301,7 @@ Privacy {ok}
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons licence</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons licence</a>.
 
 
 # Previous footer string

--- a/en-GB/main.lang
+++ b/en-GB/main.lang
@@ -301,7 +301,7 @@ Privacy {ok}
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons licence</a>.
 
 
 # Previous footer string

--- a/en-GB/main.lang
+++ b/en-GB/main.lang
@@ -114,6 +114,11 @@ Press Centre
 Contact Us {ok}
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Other languages: {ok}
 
@@ -294,7 +299,12 @@ Update now {ok}
 Privacy {ok}
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons licence</a>.
 

--- a/en-US/main.lang
+++ b/en-US/main.lang
@@ -114,6 +114,11 @@ Press Center
 Contact Us
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Other languages:
 
@@ -294,7 +299,12 @@ Update now
 Privacy
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 

--- a/en-ZA/main.lang
+++ b/en-ZA/main.lang
@@ -301,7 +301,7 @@ Privacy {ok}
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>. {ok}
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>. {ok}
 
 
 # Previous footer string

--- a/en-ZA/main.lang
+++ b/en-ZA/main.lang
@@ -301,7 +301,7 @@ Privacy {ok}
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>. {ok}
 
 
 # Previous footer string

--- a/en-ZA/main.lang
+++ b/en-ZA/main.lang
@@ -114,6 +114,11 @@ Press Centre
 Contact Us {ok}
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Other languages: {ok}
 
@@ -294,7 +299,12 @@ Update now {ok}
 Privacy {ok}
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>. {ok}
 

--- a/eo/main.lang
+++ b/eo/main.lang
@@ -301,7 +301,7 @@ Privateco
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Partoj de tiu ĉi enhavo estas ©1998–%(current_year)s kopirajtitaj de individuaj kontribuantoj de  mozilla.org. La enhavo estas disponebla laŭ la kondiĉoj de <a href="%(url)s">permesilo de Creative Commons</a>.
 
 
 # Previous footer string

--- a/eo/main.lang
+++ b/eo/main.lang
@@ -301,7 +301,7 @@ Privateco
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Partoj de tiu ĉi enhavo estas ©1998–%(current_year)s kopirajtitaj de individuaj kontribuantoj de  mozilla.org. La enhavo estas disponebla laŭ la kondiĉoj de <a href="%(url)s">permesilo de Creative Commons</a>.
+Partoj de tiu ĉi enhavo estas ©1998–%(current_year)s kopirajtitaj de individuaj kontribuantoj de  mozilla.org. La enhavo estas disponebla laŭ la kondiĉoj de <a rel="license" href="%(url)s">permesilo de Creative Commons</a>.
 
 
 # Previous footer string

--- a/eo/main.lang
+++ b/eo/main.lang
@@ -114,6 +114,11 @@ Centro de gazetaro
 Kontakti nin
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Aliaj lingvoj:
 
@@ -294,7 +299,12 @@ Retpoŝto
 Privateco
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Partoj de tiu ĉi enhavo estas ©1998–%(current_year)s kopirajtitaj de individuaj kontribuantoj de  mozilla.org. La enhavo estas disponebla laŭ la kondiĉoj de <a href="%(url)s">permesilo de Creative Commons</a>.
 

--- a/es-AR/main.lang
+++ b/es-AR/main.lang
@@ -301,7 +301,7 @@ Privacidad
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Partes de este contenido son ©1998–%(current_year)s de contribuyentes individuales de mozilla.org. El contenido se encuentra disponible bajo una <a href="%(url)s">licencia Creative Commons</a>.
 
 
 # Previous footer string

--- a/es-AR/main.lang
+++ b/es-AR/main.lang
@@ -114,6 +114,11 @@ Empleos
 Contactanos
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Otros idiomas:
 
@@ -294,7 +299,12 @@ Actualizá ahora
 Privacidad
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Partes de este contenido son ©1998–%(current_year)s de contribuyentes individuales de mozilla.org. El contenido se encuentra disponible bajo una <a href="%(url)s">licencia Creative Commons</a>.
 

--- a/es-AR/main.lang
+++ b/es-AR/main.lang
@@ -301,7 +301,7 @@ Privacidad
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Partes de este contenido son ©1998–%(current_year)s de contribuyentes individuales de mozilla.org. El contenido se encuentra disponible bajo una <a href="%(url)s">licencia Creative Commons</a>.
+Partes de este contenido son ©1998–%(current_year)s de contribuyentes individuales de mozilla.org. El contenido se encuentra disponible bajo una <a rel="license" href="%(url)s">licencia Creative Commons</a>.
 
 
 # Previous footer string

--- a/es-CL/main.lang
+++ b/es-CL/main.lang
@@ -114,6 +114,11 @@ Centro de prensa
 Contáctanos
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Otros idiomas:
 
@@ -294,7 +299,12 @@ Actualiza ahora
 Privacidad
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Algunos de estos contenidos están protegidos por derechos de autor ©1998–%(current_year)s de determinados colaboradores en mozilla.org. Contenido disponible bajo una <a href="%(url)s">licencia Creative Commons</a>.
 

--- a/es-CL/main.lang
+++ b/es-CL/main.lang
@@ -301,7 +301,7 @@ Privacidad
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Algunos de estos contenidos están protegidos por derechos de autor ©1998–%(current_year)s de determinados colaboradores en mozilla.org. Contenido disponible bajo una <a href="%(url)s">licencia Creative Commons</a>.
 
 
 # Previous footer string

--- a/es-CL/main.lang
+++ b/es-CL/main.lang
@@ -301,7 +301,7 @@ Privacidad
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Algunos de estos contenidos están protegidos por derechos de autor ©1998–%(current_year)s de determinados colaboradores en mozilla.org. Contenido disponible bajo una <a href="%(url)s">licencia Creative Commons</a>.
+Algunos de estos contenidos están protegidos por derechos de autor ©1998–%(current_year)s de determinados colaboradores en mozilla.org. Contenido disponible bajo una <a rel="license" href="%(url)s">licencia Creative Commons</a>.
 
 
 # Previous footer string

--- a/es-ES/main.lang
+++ b/es-ES/main.lang
@@ -301,7 +301,7 @@ Privacidad
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Algunos contenidos están protegidos por los derechos de autor ©1998–%(current_year)s de determinados colaboradores en mozilla.org. El resto de contenidos están disponibles bajo una licencia <a href="%(url)s">Creative Commons</a>.
+Algunos contenidos están protegidos por los derechos de autor ©1998–%(current_year)s de determinados colaboradores en mozilla.org. El resto de contenidos están disponibles bajo una licencia <a rel="license" href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/es-ES/main.lang
+++ b/es-ES/main.lang
@@ -301,7 +301,7 @@ Privacidad
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Algunos contenidos están protegidos por los derechos de autor ©1998–%(current_year)s de determinados colaboradores en mozilla.org. El resto de contenidos están disponibles bajo una licencia <a href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/es-ES/main.lang
+++ b/es-ES/main.lang
@@ -114,6 +114,11 @@ Empleo
 Contacta con nosotros
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Otros idiomas:
 
@@ -294,7 +299,12 @@ Actualizar ahora
 Privacidad
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Algunos contenidos están protegidos por los derechos de autor ©1998–%(current_year)s de determinados colaboradores en mozilla.org. El resto de contenidos están disponibles bajo una licencia <a href="%(url)s">Creative Commons</a>.
 

--- a/es-MX/main.lang
+++ b/es-MX/main.lang
@@ -301,7 +301,7 @@ Privacidad
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Algunos contenidos son ©1998–%(current_year)s por determinados colaboradores de mozilla.org. Contenido disponible bajo una licencia <a href="%(url)s">Creative Commons</a>.
+Algunos contenidos son ©1998–%(current_year)s por determinados colaboradores de mozilla.org. Contenido disponible bajo una licencia <a rel="license" href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/es-MX/main.lang
+++ b/es-MX/main.lang
@@ -114,6 +114,11 @@ Empleos
 Contacto
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Otros idiomas:
 
@@ -294,7 +299,12 @@ Actualiza ahora
 Privacidad
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Algunos contenidos son ©1998–%(current_year)s por determinados colaboradores de mozilla.org. Contenido disponible bajo una licencia <a href="%(url)s">Creative Commons</a>.
 

--- a/es-MX/main.lang
+++ b/es-MX/main.lang
@@ -301,7 +301,7 @@ Privacidad
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Algunos contenidos son ©1998–%(current_year)s por determinados colaboradores de mozilla.org. Contenido disponible bajo una licencia <a href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/et/main.lang
+++ b/et/main.lang
@@ -301,7 +301,7 @@ Privaatsusest
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Osa sisu autoriõigused kuuluvad 1998–%(current_year)s mozilla.org kaastöötajatele. Sisu on avaldatud <a href="%(url)s">Creative Commonsi litsentsi</a> all.
 
 
 # Previous footer string

--- a/et/main.lang
+++ b/et/main.lang
@@ -301,7 +301,7 @@ Privaatsusest
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Osa sisu autoriõigused kuuluvad 1998–%(current_year)s mozilla.org kaastöötajatele. Sisu on avaldatud <a href="%(url)s">Creative Commonsi litsentsi</a> all.
+Osa sisu autoriõigused kuuluvad 1998–%(current_year)s mozilla.org kaastöötajatele. Sisu on avaldatud <a rel="license" href="%(url)s">Creative Commonsi litsentsi</a> all.
 
 
 # Previous footer string

--- a/et/main.lang
+++ b/et/main.lang
@@ -114,6 +114,11 @@ Pressikeskus
 Kontakt
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Teistes keeltes:
 
@@ -294,7 +299,12 @@ Uuenda kohe
 Privaatsusest
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Osa sisu autoriõigused kuuluvad 1998–%(current_year)s mozilla.org kaastöötajatele. Sisu on avaldatud <a href="%(url)s">Creative Commonsi litsentsi</a> all.
 

--- a/eu/main.lang
+++ b/eu/main.lang
@@ -301,7 +301,7 @@ Pribatutasuna
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Eduki honen zati batzuk mozilla.org-en laguntzaile indibidualenak dira, ©1998–%(current_year)s. Edukia <a href="%(url)s">Creative Commons lizentzia</a>pean dago erabilgarri.
+Eduki honen zati batzuk mozilla.org-en laguntzaile indibidualenak dira, ©1998–%(current_year)s. Edukia <a rel="license" href="%(url)s">Creative Commons lizentzia</a>pean dago erabilgarri.
 
 
 # Previous footer string

--- a/eu/main.lang
+++ b/eu/main.lang
@@ -114,6 +114,11 @@ Prentsagunea
 Jarri gurekin harremanetan
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Beste hizkuntzetan:
 
@@ -294,7 +299,12 @@ Eguneratu orain
 Pribatutasuna
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Eduki honen zati batzuk mozilla.org-en laguntzaile indibidualenak dira, ©1998–%(current_year)s. Edukia <a href="%(url)s">Creative Commons lizentzia</a>pean dago erabilgarri.
 

--- a/eu/main.lang
+++ b/eu/main.lang
@@ -301,7 +301,7 @@ Pribatutasuna
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Eduki honen zati batzuk mozilla.org-en laguntzaile indibidualenak dira, ©1998–%(current_year)s. Edukia <a href="%(url)s">Creative Commons lizentzia</a>pean dago erabilgarri.
 
 
 # Previous footer string

--- a/fa/main.lang
+++ b/fa/main.lang
@@ -301,7 +301,7 @@ Language
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+بخشی از این محتویات ©1998–%(current_year)s توسط مشارکت‌کنندگان انفرادی mozilla.org ایجاد شده است. محتویات براساس <a href="%(url)s">گواهینامه Creative Commons</a> موجود است.
 
 
 # Previous footer string

--- a/fa/main.lang
+++ b/fa/main.lang
@@ -301,7 +301,7 @@ Language
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-بخشی از این محتویات ©1998–%(current_year)s توسط مشارکت‌کنندگان انفرادی mozilla.org ایجاد شده است. محتویات براساس <a href="%(url)s">گواهینامه Creative Commons</a> موجود است.
+بخشی از این محتویات ©1998–%(current_year)s توسط مشارکت‌کنندگان انفرادی mozilla.org ایجاد شده است. محتویات براساس <a rel="license" href="%(url)s">گواهینامه Creative Commons</a> موجود است.
 
 
 # Previous footer string

--- a/fa/main.lang
+++ b/fa/main.lang
@@ -114,6 +114,11 @@
 تماس با ما
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 زبان‌های دیگر:
 
@@ -294,7 +299,12 @@
 حریم خصوصی
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 بخشی از این محتویات ©1998–%(current_year)s توسط مشارکت‌کنندگان انفرادی mozilla.org ایجاد شده است. محتویات براساس <a href="%(url)s">گواهینامه Creative Commons</a> موجود است.
 

--- a/ff/main.lang
+++ b/ff/main.lang
@@ -301,7 +301,7 @@ Suturo
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Bannge e ndii loowdi ko ©1998–%(current_year)s wallitooɓe Mozilla.org heeriiɓe. Loowdi ngoodndi e jamirol <a href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/ff/main.lang
+++ b/ff/main.lang
@@ -114,6 +114,11 @@ Nokku Jaaynde
 Jokkondir e amen
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Ɗemɗe goɗɗe:
 
@@ -294,7 +299,12 @@ Hesɗitin jooni
 Suturo
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Bannge e ndii loowdi ko ©1998–%(current_year)s wallitooɓe Mozilla.org heeriiɓe. Loowdi ngoodndi e jamirol <a href="%(url)s">Creative Commons license</a>.
 

--- a/ff/main.lang
+++ b/ff/main.lang
@@ -301,7 +301,7 @@ Suturo
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Bannge e ndii loowdi ko ©1998–%(current_year)s wallitooɓe Mozilla.org heeriiɓe. Loowdi ngoodndi e jamirol <a href="%(url)s">Creative Commons license</a>.
+Bannge e ndii loowdi ko ©1998–%(current_year)s wallitooɓe Mozilla.org heeriiɓe. Loowdi ngoodndi e jamirol <a rel="license" href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/fi/main.lang
+++ b/fi/main.lang
@@ -114,6 +114,11 @@ Lehdistökeskus
 Ota yhteyttä
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Muut kielet:
 
@@ -294,7 +299,12 @@ Päivitä heti
 Tietosuoja
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Tämän sisällön tietyt osat ovat ©1998–%(current_year)s yksittäisten mozilla.org:n tukijoiden omaisuutta. Sisältö on saatavilla <a href="%(url)s">Creative Commons -lisenssillä</a>.
 

--- a/fi/main.lang
+++ b/fi/main.lang
@@ -301,7 +301,7 @@ Tietosuoja
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Tämän sisällön tietyt osat ovat ©1998–%(current_year)s yksittäisten mozilla.org:n tukijoiden omaisuutta. Sisältö on saatavilla <a href="%(url)s">Creative Commons -lisenssillä</a>.
 
 
 # Previous footer string

--- a/fi/main.lang
+++ b/fi/main.lang
@@ -301,7 +301,7 @@ Tietosuoja
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Tämän sisällön tietyt osat ovat ©1998–%(current_year)s yksittäisten mozilla.org:n tukijoiden omaisuutta. Sisältö on saatavilla <a href="%(url)s">Creative Commons -lisenssillä</a>.
+Tämän sisällön tietyt osat ovat ©1998–%(current_year)s yksittäisten mozilla.org:n tukijoiden omaisuutta. Sisältö on saatavilla <a rel="license" href="%(url)s">Creative Commons -lisenssillä</a>.
 
 
 # Previous footer string

--- a/fr/main.lang
+++ b/fr/main.lang
@@ -301,7 +301,7 @@ Vie privée
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Certaines parties de ce contenu sont ©1998–%(current_year)s par les contributeurs individuels de mozilla.org. Le contenu est disponible sous <a href="%(url)s">licence Creative Commons</a>.
+Certaines parties de ce contenu sont ©1998–%(current_year)s par les contributeurs individuels de mozilla.org. Le contenu est disponible sous <a rel="license" href="%(url)s">licence Creative Commons</a>.
 
 
 # Previous footer string

--- a/fr/main.lang
+++ b/fr/main.lang
@@ -301,7 +301,7 @@ Vie privée
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Certaines parties de ce contenu sont ©1998–%(current_year)s par les contributeurs individuels de mozilla.org. Le contenu est disponible sous <a href="%(url)s">licence Creative Commons</a>.
 
 
 # Previous footer string

--- a/fr/main.lang
+++ b/fr/main.lang
@@ -114,6 +114,11 @@ Centre de presse
 Nous contacter
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Autres langues&nbsp;:
 
@@ -294,7 +299,12 @@ Mettez-vous à jour maintenant
 Vie privée
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Certaines parties de ce contenu sont ©1998–%(current_year)s par les contributeurs individuels de mozilla.org. Le contenu est disponible sous <a href="%(url)s">licence Creative Commons</a>.
 

--- a/fy-NL/main.lang
+++ b/fy-NL/main.lang
@@ -114,6 +114,11 @@ Parsesintrum
 Kontakt
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Oare talen:
 
@@ -294,7 +299,12 @@ Fernij no
 Privacy {ok}
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Dielen fan dizze ynhâld binne ©1998–%(current_year)s troch yndividuele mozilla.org-meiwurkers. Ynhâld is beskikber ûnder in <a href="%(url)s">Creative Commons-lisinsje</a>.
 

--- a/fy-NL/main.lang
+++ b/fy-NL/main.lang
@@ -301,7 +301,7 @@ Privacy {ok}
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Dielen fan dizze ynhâld binne ©1998–%(current_year)s troch yndividuele mozilla.org-meiwurkers. Ynhâld is beskikber ûnder in <a href="%(url)s">Creative Commons-lisinsje</a>.
 
 
 # Previous footer string

--- a/fy-NL/main.lang
+++ b/fy-NL/main.lang
@@ -301,7 +301,7 @@ Privacy {ok}
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Dielen fan dizze ynhâld binne ©1998–%(current_year)s troch yndividuele mozilla.org-meiwurkers. Ynhâld is beskikber ûnder in <a href="%(url)s">Creative Commons-lisinsje</a>.
+Dielen fan dizze ynhâld binne ©1998–%(current_year)s troch yndividuele mozilla.org-meiwurkers. Ynhâld is beskikber ûnder in <a rel="license" href="%(url)s">Creative Commons-lisinsje</a>.
 
 
 # Previous footer string

--- a/ga-IE/main.lang
+++ b/ga-IE/main.lang
@@ -301,7 +301,7 @@ Príobháideachas
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Cóipcheart ©1998–%(current_year)s Rannpháirtithe Mhozilla. Tá an t-ábhar seo ar fáil de réir téarmaí <a href="%(url)s">Cheadúnas Creative Commons</a>.
+Cóipcheart ©1998–%(current_year)s Rannpháirtithe Mhozilla. Tá an t-ábhar seo ar fáil de réir téarmaí <a rel="license" href="%(url)s">Cheadúnas Creative Commons</a>.
 
 
 # Previous footer string

--- a/ga-IE/main.lang
+++ b/ga-IE/main.lang
@@ -301,7 +301,7 @@ Príobháideachas
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Cóipcheart ©1998–%(current_year)s Rannpháirtithe Mhozilla. Tá an t-ábhar seo ar fáil de réir téarmaí <a href="%(url)s">Cheadúnas Creative Commons</a>.
 
 
 # Previous footer string

--- a/ga-IE/main.lang
+++ b/ga-IE/main.lang
@@ -114,6 +114,11 @@ Ionad na Meán Cumarsáide
 Déan teagmháil linn
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Teangacha eile:
 
@@ -294,7 +299,12 @@ Nuashonraigh anois
 Príobháideachas
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Cóipcheart ©1998–%(current_year)s Rannpháirtithe Mhozilla. Tá an t-ábhar seo ar fáil de réir téarmaí <a href="%(url)s">Cheadúnas Creative Commons</a>.
 

--- a/gd/main.lang
+++ b/gd/main.lang
@@ -301,7 +301,7 @@ Prìobhaideachd
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Tha cuid dhen t-susbaint seo fo ©1998–%(current_year)s le com-pàirtichean mozilla.org. Tha an t-susbaint ri fhaighinn fo cheadachas <a href="%(url)s">Creative Commons</a>.
+Tha cuid dhen t-susbaint seo fo ©1998–%(current_year)s le com-pàirtichean mozilla.org. Tha an t-susbaint ri fhaighinn fo cheadachas <a rel="license" href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/gd/main.lang
+++ b/gd/main.lang
@@ -114,6 +114,11 @@ Ionadh an luchd-naidheachd
 Leig fios thugainn
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Cànain eile:
 
@@ -294,7 +299,12 @@ Post-d
 Prìobhaideachd
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Tha cuid dhen t-susbaint seo fo ©1998–%(current_year)s le com-pàirtichean mozilla.org. Tha an t-susbaint ri fhaighinn fo cheadachas <a href="%(url)s">Creative Commons</a>.
 

--- a/gd/main.lang
+++ b/gd/main.lang
@@ -301,7 +301,7 @@ Prìobhaideachd
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Tha cuid dhen t-susbaint seo fo ©1998–%(current_year)s le com-pàirtichean mozilla.org. Tha an t-susbaint ri fhaighinn fo cheadachas <a href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/gl/main.lang
+++ b/gl/main.lang
@@ -301,7 +301,7 @@ Privacidade
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Algúns contidos están protexidos polos dereitos de autor ©1998–%(current_year)s de determinados colaboradores en mozilla.org. O resto do contido está dispoñíbel con licenza <a href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/gl/main.lang
+++ b/gl/main.lang
@@ -301,7 +301,7 @@ Privacidade
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Algúns contidos están protexidos polos dereitos de autor ©1998–%(current_year)s de determinados colaboradores en mozilla.org. O resto do contido está dispoñíbel con licenza <a href="%(url)s">Creative Commons</a>.
+Algúns contidos están protexidos polos dereitos de autor ©1998–%(current_year)s de determinados colaboradores en mozilla.org. O resto do contido está dispoñíbel con licenza <a rel="license" href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/gl/main.lang
+++ b/gl/main.lang
@@ -114,6 +114,11 @@ Centro de prensa
 Contacta connosco
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Outros idiomas:
 
@@ -294,7 +299,12 @@ Actualice agora
 Privacidade
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Algúns contidos están protexidos polos dereitos de autor ©1998–%(current_year)s de determinados colaboradores en mozilla.org. O resto do contido está dispoñíbel con licenza <a href="%(url)s">Creative Commons</a>.
 

--- a/gn/main.lang
+++ b/gn/main.lang
@@ -301,7 +301,7 @@ Embohekopyahu ko'ág̃a
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Heta tetepy oĩ omo'ãva chupe apohára mba'eteéva ©1998–%(current_year)s pytyvõhára mozilla.org.-pe. Hembýva tetepy ehechakuaa <a href="%(url)s">Creative Commons</a> ñemoneĩ rupi.
+Heta tetepy oĩ omo'ãva chupe apohára mba'eteéva ©1998–%(current_year)s pytyvõhára mozilla.org.-pe. Hembýva tetepy ehechakuaa <a rel="license" href="%(url)s">Creative Commons</a> ñemoneĩ rupi.
 
 
 # Previous footer string

--- a/gn/main.lang
+++ b/gn/main.lang
@@ -114,6 +114,11 @@ Kuatiahaiha rendaite
 Eñe'ẽ orendive
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Ambue ñe'ẽnguéra:
 
@@ -294,7 +299,12 @@ Embohekopyahu ko'ág̃a
 Ñemigua
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Heta tetepy oĩ omo'ãva chupe apohára mba'eteéva ©1998–%(current_year)s pytyvõhára mozilla.org.-pe. Hembýva tetepy ehechakuaa <a href="%(url)s">Creative Commons</a> ñemoneĩ rupi.
 

--- a/gn/main.lang
+++ b/gn/main.lang
@@ -301,7 +301,7 @@ Embohekopyahu ko'ág̃a
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Heta tetepy oĩ omo'ãva chupe apohára mba'eteéva ©1998–%(current_year)s pytyvõhára mozilla.org.-pe. Hembýva tetepy ehechakuaa <a href="%(url)s">Creative Commons</a> ñemoneĩ rupi.
 
 
 # Previous footer string

--- a/gu-IN/main.lang
+++ b/gu-IN/main.lang
@@ -114,6 +114,11 @@ Mozilla વિશે
 અમારો સંપર્ક કરો
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 અન્ય ભાષાઓ
 
@@ -294,7 +299,12 @@ MPEG-4 બંધારણ
 ખાનગીપણું
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 આમાંના સમાવિષ્ટોના ભાગ ©1998–%(current_year)s માં mozilla.org ના વ્યક્તિગત ફાળો આપનારાઓના છે. સમાવિષ્ટો <a href="%(url)s">Creative Commons license</a> હેઠળ ઉપલબ્ધ છે.
 

--- a/gu-IN/main.lang
+++ b/gu-IN/main.lang
@@ -301,7 +301,7 @@ MPEG-4 બંધારણ
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+આમાંના સમાવિષ્ટોના ભાગ ©1998–%(current_year)s માં mozilla.org ના વ્યક્તિગત ફાળો આપનારાઓના છે. સમાવિષ્ટો <a href="%(url)s">Creative Commons license</a> હેઠળ ઉપલબ્ધ છે.
 
 
 # Previous footer string

--- a/gu-IN/main.lang
+++ b/gu-IN/main.lang
@@ -301,7 +301,7 @@ MPEG-4 બંધારણ
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-આમાંના સમાવિષ્ટોના ભાગ ©1998–%(current_year)s માં mozilla.org ના વ્યક્તિગત ફાળો આપનારાઓના છે. સમાવિષ્ટો <a href="%(url)s">Creative Commons license</a> હેઠળ ઉપલબ્ધ છે.
+આમાંના સમાવિષ્ટોના ભાગ ©1998–%(current_year)s માં mozilla.org ના વ્યક્તિગત ફાળો આપનારાઓના છે. સમાવિષ્ટો <a rel="license" href="%(url)s">Creative Commons license</a> હેઠળ ઉપલબ્ધ છે.
 
 
 # Previous footer string

--- a/he/main.lang
+++ b/he/main.lang
@@ -114,6 +114,11 @@ Firefox הוא דפדפן שלא למטרות רווח, לא מסחרי וללא
 יצירת קשר
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 שפות אחרות:
 
@@ -294,7 +299,12 @@ Firefox לנייד
 פרטיות
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 הזכויות של חלקים מתוכן זה שמורות ©1998–%(current_year)s לתורמים של mozilla.org. התוכן זמין תחת <a href="%(url)s">רישיון Creative Commons</a>.
 

--- a/he/main.lang
+++ b/he/main.lang
@@ -301,7 +301,7 @@ Firefox לנייד
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-הזכויות של חלקים מתוכן זה שמורות ©1998–%(current_year)s לתורמים של mozilla.org. התוכן זמין תחת <a href="%(url)s">רישיון Creative Commons</a>.
+הזכויות של חלקים מתוכן זה שמורות ©1998–%(current_year)s לתורמים של mozilla.org. התוכן זמין תחת <a rel="license" href="%(url)s">רישיון Creative Commons</a>.
 
 
 # Previous footer string

--- a/he/main.lang
+++ b/he/main.lang
@@ -301,7 +301,7 @@ Firefox לנייד
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+הזכויות של חלקים מתוכן זה שמורות ©1998–%(current_year)s לתורמים של mozilla.org. התוכן זמין תחת <a href="%(url)s">רישיון Creative Commons</a>.
 
 
 # Previous footer string

--- a/hi-IN/main.lang
+++ b/hi-IN/main.lang
@@ -301,7 +301,7 @@ Ogg थियोरा प्रारूप
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+इस सामग्री के कुछ हिस्से ©1998–%(current_year)s अलग-अलग mozilla.org योगदानकर्ताओं के द्वारा दिए गए हैं. यह सामग्री <a href="%(url)s">क्रियेटिव कॉमन्स लाइसेंस</a> के अंतर्गत उपलब्ध हैं.
 
 
 # Previous footer string

--- a/hi-IN/main.lang
+++ b/hi-IN/main.lang
@@ -114,6 +114,11 @@
 संपर्क करें
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 अन्य भाषाएँ:
 
@@ -294,7 +299,12 @@ Ogg थियोरा प्रारूप
 गोपनीयता
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 इस सामग्री के कुछ हिस्से ©1998–%(current_year)s अलग-अलग mozilla.org योगदानकर्ताओं के द्वारा दिए गए हैं. यह सामग्री <a href="%(url)s">क्रियेटिव कॉमन्स लाइसेंस</a> के अंतर्गत उपलब्ध हैं.
 

--- a/hi-IN/main.lang
+++ b/hi-IN/main.lang
@@ -301,7 +301,7 @@ Ogg थियोरा प्रारूप
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-इस सामग्री के कुछ हिस्से ©1998–%(current_year)s अलग-अलग mozilla.org योगदानकर्ताओं के द्वारा दिए गए हैं. यह सामग्री <a href="%(url)s">क्रियेटिव कॉमन्स लाइसेंस</a> के अंतर्गत उपलब्ध हैं.
+इस सामग्री के कुछ हिस्से ©1998–%(current_year)s अलग-अलग mozilla.org योगदानकर्ताओं के द्वारा दिए गए हैं. यह सामग्री <a rel="license" href="%(url)s">क्रियेटिव कॉमन्स लाइसेंस</a> के अंतर्गत उपलब्ध हैं.
 
 
 # Previous footer string

--- a/hr/main.lang
+++ b/hr/main.lang
@@ -114,6 +114,11 @@ Press centar
 Kontaktirajte nas
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Drugi jezici:
 
@@ -294,7 +299,12 @@ Ažuriraj sada
 Privatnost
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Prava nad dijelovima ovog sadržaja (©1998–%(current_year)s) zadržali su individualni doprinositelji mozilla.org projekta. Sadržaj je dostupan pod <a href="%(url)s">Creative Commons licencom</a>.
 

--- a/hr/main.lang
+++ b/hr/main.lang
@@ -301,7 +301,7 @@ Privatnost
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Prava nad dijelovima ovog sadržaja (©1998–%(current_year)s) zadržali su individualni doprinositelji mozilla.org projekta. Sadržaj je dostupan pod <a href="%(url)s">Creative Commons licencom</a>.
+Prava nad dijelovima ovog sadržaja (©1998–%(current_year)s) zadržali su individualni doprinositelji mozilla.org projekta. Sadržaj je dostupan pod <a rel="license" href="%(url)s">Creative Commons licencom</a>.
 
 
 # Previous footer string

--- a/hr/main.lang
+++ b/hr/main.lang
@@ -301,7 +301,7 @@ Privatnost
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Prava nad dijelovima ovog sadržaja (©1998–%(current_year)s) zadržali su individualni doprinositelji mozilla.org projekta. Sadržaj je dostupan pod <a href="%(url)s">Creative Commons licencom</a>.
 
 
 # Previous footer string

--- a/hsb/main.lang
+++ b/hsb/main.lang
@@ -301,7 +301,7 @@ Priwatnosć
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Dźěle tutoho wobsaha wot jednotliwych sobuskutkowacych mozilla.org wutworjene ©1998–%(current_year)s. Wobsah steji pod licencu <a href="%(url)s">Creative Commons license</a> k dispoziciji.
+Dźěle tutoho wobsaha wot jednotliwych sobuskutkowacych mozilla.org wutworjene ©1998–%(current_year)s. Wobsah steji pod licencu <a rel="license" href="%(url)s">Creative Commons license</a> k dispoziciji.
 
 
 # Previous footer string

--- a/hsb/main.lang
+++ b/hsb/main.lang
@@ -114,6 +114,11 @@ Nowinski centrum
 Stajće so z nami do zwiska
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Druhe rěče:
 
@@ -294,7 +299,12 @@ Nětko aktualizować
 Priwatnosć
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Dźěle tutoho wobsaha wot jednotliwych sobuskutkowacych mozilla.org wutworjene ©1998–%(current_year)s. Wobsah steji pod licencu <a href="%(url)s">Creative Commons license</a> k dispoziciji.
 

--- a/hsb/main.lang
+++ b/hsb/main.lang
@@ -301,7 +301,7 @@ Priwatnosć
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Dźěle tutoho wobsaha wot jednotliwych sobuskutkowacych mozilla.org wutworjene ©1998–%(current_year)s. Wobsah steji pod licencu <a href="%(url)s">Creative Commons license</a> k dispoziciji.
 
 
 # Previous footer string

--- a/hto/main.lang
+++ b/hto/main.lang
@@ -114,6 +114,11 @@ Press Center
 Contact Us
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Other languages:
 
@@ -294,7 +299,12 @@ Update now
 Privacy
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 

--- a/hto/main.lang
+++ b/hto/main.lang
@@ -301,7 +301,7 @@ Privacy
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/hto/main.lang
+++ b/hto/main.lang
@@ -301,7 +301,7 @@ Privacy
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/hu/main.lang
+++ b/hu/main.lang
@@ -301,7 +301,7 @@ Adatvédelem
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-A tartalom egy részét ©1998–%(current_year)s mozilla.org közreműködők készítették. A tartalom <a href="%(url)s">Creative Commons licenc</a> alatt érhető el.
+A tartalom egy részét ©1998–%(current_year)s mozilla.org közreműködők készítették. A tartalom <a rel="license" href="%(url)s">Creative Commons licenc</a> alatt érhető el.
 
 
 # Previous footer string

--- a/hu/main.lang
+++ b/hu/main.lang
@@ -114,6 +114,11 @@ Sajtóoldal
 Kapcsolat
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Más nyelvek:
 
@@ -294,7 +299,12 @@ Frissítsen most
 Adatvédelem
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 A tartalom egy részét ©1998–%(current_year)s mozilla.org közreműködők készítették. A tartalom <a href="%(url)s">Creative Commons licenc</a> alatt érhető el.
 

--- a/hu/main.lang
+++ b/hu/main.lang
@@ -301,7 +301,7 @@ Adatvédelem
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+A tartalom egy részét ©1998–%(current_year)s mozilla.org közreműködők készítették. A tartalom <a href="%(url)s">Creative Commons licenc</a> alatt érhető el.
 
 
 # Previous footer string

--- a/hy-AM/main.lang
+++ b/hy-AM/main.lang
@@ -301,7 +301,7 @@ Firefox-ը բջջայինի համար
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Այս բովանդակության մի մասը ©1998–%(current_year)s mozilla.org անհատական կամավորների կողմից է։ Բովանդակությունը հասանելի է <a href="%(url)s">Creative Commons license</a>-ով։
+Այս բովանդակության մի մասը ©1998–%(current_year)s mozilla.org անհատական կամավորների կողմից է։ Բովանդակությունը հասանելի է <a rel="license" href="%(url)s">Creative Commons license</a>-ով։
 
 
 # Previous footer string

--- a/hy-AM/main.lang
+++ b/hy-AM/main.lang
@@ -114,6 +114,11 @@ Mozilla-ի մասին
 Կապը մեզ հետ
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Այլ լեզուներ.
 
@@ -294,7 +299,12 @@ Firefox-ը բջջայինի համար
 Անվտանգությունը
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Այս բովանդակության մի մասը ©1998–%(current_year)s mozilla.org անհատական կամավորների կողմից է։ Բովանդակությունը հասանելի է <a href="%(url)s">Creative Commons license</a>-ով։
 

--- a/hy-AM/main.lang
+++ b/hy-AM/main.lang
@@ -301,7 +301,7 @@ Firefox-ը բջջայինի համար
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Այս բովանդակության մի մասը ©1998–%(current_year)s mozilla.org անհատական կամավորների կողմից է։ Բովանդակությունը հասանելի է <a href="%(url)s">Creative Commons license</a>-ով։
 
 
 # Previous footer string

--- a/id/main.lang
+++ b/id/main.lang
@@ -301,7 +301,7 @@ Privasi
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Hak cipta ©1998–%(current_year)s oleh kontributor individual mozilla.org untuk bagian konten ini. Konten tersedia di bawah <a href="%(url)s">lisensi Creative Commons</a>.
+Hak cipta ©1998–%(current_year)s oleh kontributor individual mozilla.org untuk bagian konten ini. Konten tersedia di bawah <a rel="license" href="%(url)s">lisensi Creative Commons</a>.
 
 
 # Previous footer string

--- a/id/main.lang
+++ b/id/main.lang
@@ -114,6 +114,11 @@ Pers &amp; Media
 Kontak Kami
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Bahasa Lainnya
 
@@ -294,7 +299,12 @@ Perbarui sekarang
 Privasi
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Hak cipta ©1998–%(current_year)s oleh kontributor individual mozilla.org untuk bagian konten ini. Konten tersedia di bawah <a href="%(url)s">lisensi Creative Commons</a>.
 

--- a/id/main.lang
+++ b/id/main.lang
@@ -301,7 +301,7 @@ Privasi
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Hak cipta ©1998–%(current_year)s oleh kontributor individual mozilla.org untuk bagian konten ini. Konten tersedia di bawah <a href="%(url)s">lisensi Creative Commons</a>.
 
 
 # Previous footer string

--- a/is/main.lang
+++ b/is/main.lang
@@ -301,7 +301,7 @@ Friðhelgi
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Hlutar innihalds eru ©1998–%(current_year)s af einstökum mozilla.org þátttakendum. Efnið er aðgengilegt undir <a href="%(url)s">Creative Commons leyfi</a>.
 
 
 # Previous footer string

--- a/is/main.lang
+++ b/is/main.lang
@@ -114,6 +114,11 @@ Fréttir
 Hafa samband
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Önnur tungumál:
 
@@ -294,7 +299,12 @@ Uppfæra núna
 Friðhelgi
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Hlutar innihalds eru ©1998–%(current_year)s af einstökum mozilla.org þátttakendum. Efnið er aðgengilegt undir <a href="%(url)s">Creative Commons leyfi</a>.
 

--- a/is/main.lang
+++ b/is/main.lang
@@ -301,7 +301,7 @@ Friðhelgi
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Hlutar innihalds eru ©1998–%(current_year)s af einstökum mozilla.org þátttakendum. Efnið er aðgengilegt undir <a href="%(url)s">Creative Commons leyfi</a>.
+Hlutar innihalds eru ©1998–%(current_year)s af einstökum mozilla.org þátttakendum. Efnið er aðgengilegt undir <a rel="license" href="%(url)s">Creative Commons leyfi</a>.
 
 
 # Previous footer string

--- a/it/main.lang
+++ b/it/main.lang
@@ -114,6 +114,11 @@ Sala stampa
 Contattaci
 
 
+# Used in new footer to switch the language of the page
+;Language
+Lingua
+
+
 ;Other languages:
 Altre lingue:
 
@@ -294,7 +299,12 @@ Aggiorna adesso
 Privacy {ok}
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Parte di questi contenuti sono ©1998–%(current_year)s di singoli collaboratori di mozilla.org. I contenuti sono disponibili secondo la <a href="%(url)s">licenza Creative Commons</a>.
 

--- a/it/main.lang
+++ b/it/main.lang
@@ -301,7 +301,7 @@ Privacy {ok}
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Parte di questi contenuti sono ©1998–%(current_year)s di singoli collaboratori di mozilla.org. I contenuti sono disponibili secondo la <a href="%(url)s">licenza Creative Commons</a>.
+Parte di questi contenuti sono ©1998–%(current_year)s di singoli collaboratori di mozilla.org. I contenuti sono disponibili secondo la <a rel="license" href="%(url)s">licenza Creative Commons</a>.
 
 
 # Previous footer string

--- a/it/main.lang
+++ b/it/main.lang
@@ -301,7 +301,7 @@ Privacy {ok}
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Parte di questi contenuti sono ©1998–%(current_year)s di singoli collaboratori di mozilla.org. I contenuti sono disponibili secondo la <a href="%(url)s">licenza Creative Commons</a>.
 
 
 # Previous footer string

--- a/ja/main.lang
+++ b/ja/main.lang
@@ -301,7 +301,7 @@ Android 版 Firefox
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+コンテンツの一部は mozilla.org への個人的な貢献によるものです。(©1998–%(current_year)s). コンテンツは <a href="%(url)s">Creative Commons license</a> に基づいた利用が可能です。
 
 
 # Previous footer string

--- a/ja/main.lang
+++ b/ja/main.lang
@@ -114,6 +114,11 @@ Mozilla に参加しよう
 連絡先
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 他の言語 :
 
@@ -294,7 +299,12 @@ Android 版 Firefox
 プライバシー
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 コンテンツの一部は mozilla.org への個人的な貢献によるものです。(©1998–%(current_year)s). コンテンツは <a href="%(url)s">Creative Commons license</a> に基づいた利用が可能です。
 

--- a/ja/main.lang
+++ b/ja/main.lang
@@ -301,7 +301,7 @@ Android 版 Firefox
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-コンテンツの一部は mozilla.org への個人的な貢献によるものです。(©1998–%(current_year)s). コンテンツは <a href="%(url)s">Creative Commons license</a> に基づいた利用が可能です。
+コンテンツの一部は mozilla.org への個人的な貢献によるものです。(©1998–%(current_year)s). コンテンツは <a rel="license" href="%(url)s">Creative Commons license</a> に基づいた利用が可能です。
 
 
 # Previous footer string

--- a/ka/main.lang
+++ b/ka/main.lang
@@ -114,6 +114,11 @@ Mozilla-ს შესახებ
 დაგვიკავშირდით
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 სხვა ენები:
 
@@ -294,7 +299,12 @@ Firefox მობილურისთვის
 კონფიდენციალობა
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 ამ მასალის ნაწილი შექმნილია mozilla.org პროექტის მონაწილეების მიერ ©1998–%(current_year)s. მასალა ვრცელდება <a href="%(url)s">Creative Commons ლიცენზიით</a>.
 

--- a/ka/main.lang
+++ b/ka/main.lang
@@ -301,7 +301,7 @@ Firefox მობილურისთვის
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-ამ მასალის ნაწილი შექმნილია mozilla.org პროექტის მონაწილეების მიერ ©1998–%(current_year)s. მასალა ვრცელდება <a href="%(url)s">Creative Commons ლიცენზიით</a>.
+ამ მასალის ნაწილი შექმნილია mozilla.org პროექტის მონაწილეების მიერ ©1998–%(current_year)s. მასალა ვრცელდება <a rel="license" href="%(url)s">Creative Commons ლიცენზიით</a>.
 
 
 # Previous footer string

--- a/ka/main.lang
+++ b/ka/main.lang
@@ -301,7 +301,7 @@ Firefox მობილურისთვის
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+ამ მასალის ნაწილი შექმნილია mozilla.org პროექტის მონაწილეების მიერ ©1998–%(current_year)s. მასალა ვრცელდება <a href="%(url)s">Creative Commons ლიცენზიით</a>.
 
 
 # Previous footer string

--- a/kab/main.lang
+++ b/kab/main.lang
@@ -114,6 +114,11 @@ Axxam n tɣamsa
 Nermes-aɣ-d
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Tutlayin-nniḍen:
 
@@ -294,7 +299,12 @@ Leqqem tura
 Tudert tabaḍnit
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Kra n yeḥricen n ugbur-a d ©1998–%(current_year)s sɣur imttekkiyen n mozilla.org. Agbur yella ddaw n <a  href="%(url)s"> turagt Creative Commons</a>.
 

--- a/kab/main.lang
+++ b/kab/main.lang
@@ -301,7 +301,7 @@ Tudert tabaḍnit
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Kra n yeḥricen n ugbur-a d ©1998–%(current_year)s sɣur imttekkiyen n mozilla.org. Agbur yella ddaw n <a  href="%(url)s"> turagt Creative Commons</a>.
 
 
 # Previous footer string

--- a/kk/main.lang
+++ b/kk/main.lang
@@ -301,7 +301,7 @@ MPEG-4 пішімі
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Құрама бөліктері ©1998–%(current_year)s жеке mozilla.org үлес қосушыларымен иеленуде. Құрама <a href="%(url)s">Creative Commons лицензиясы</a> аясында қолжетерлік.
 
 
 # Previous footer string

--- a/kk/main.lang
+++ b/kk/main.lang
@@ -114,6 +114,11 @@ Mozilla туралы
 Кері байланыс
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Басқа тілдер:
 
@@ -294,7 +299,12 @@ MPEG-4 пішімі
 Жекелік
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Құрама бөліктері ©1998–%(current_year)s жеке mozilla.org үлес қосушыларымен иеленуде. Құрама <a href="%(url)s">Creative Commons лицензиясы</a> аясында қолжетерлік.
 

--- a/kk/main.lang
+++ b/kk/main.lang
@@ -301,7 +301,7 @@ MPEG-4 пішімі
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Құрама бөліктері ©1998–%(current_year)s жеке mozilla.org үлес қосушыларымен иеленуде. Құрама <a href="%(url)s">Creative Commons лицензиясы</a> аясында қолжетерлік.
+Құрама бөліктері ©1998–%(current_year)s жеке mozilla.org үлес қосушыларымен иеленуде. Құрама <a rel="license" href="%(url)s">Creative Commons лицензиясы</a> аясында қолжетерлік.
 
 
 # Previous footer string

--- a/km/main.lang
+++ b/km/main.lang
@@ -114,6 +114,11 @@ Firefox មិន​រក​ប្រាក់​ចំណេញ មិន​�
 ទាក់ទង​​យើង
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 ភាសា​ផ្សេង​ទៀត ៖
 
@@ -294,7 +299,12 @@ Firefox សម្រាប់​ទូរស័ព្ទចល័ត
 ភាព​ឯកជន
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 ផ្នែក​នៃ​មាតិកា​នេះ​​​នៅ​អំឡុង ©1998–%(current_year)s បង្កើត​ដោយ​​អ្នក​ចូលរួម​ចំណែក mozilla.org ។ មាតិកា​អាច​​ប្រើ​បាន​ក្រោម <a href="%(url)s">អាជ្ញាប័ណ្ណ Creative Commons</a>។
 

--- a/km/main.lang
+++ b/km/main.lang
@@ -301,7 +301,7 @@ Firefox សម្រាប់​ទូរស័ព្ទចល័ត
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-ផ្នែក​នៃ​មាតិកា​នេះ​​​នៅ​អំឡុង ©1998–%(current_year)s បង្កើត​ដោយ​​អ្នក​ចូលរួម​ចំណែក mozilla.org ។ មាតិកា​អាច​​ប្រើ​បាន​ក្រោម <a href="%(url)s">អាជ្ញាប័ណ្ណ Creative Commons</a>។
+ផ្នែក​នៃ​មាតិកា​នេះ​​​នៅ​អំឡុង ©1998–%(current_year)s បង្កើត​ដោយ​​អ្នក​ចូលរួម​ចំណែក mozilla.org ។ មាតិកា​អាច​​ប្រើ​បាន​ក្រោម <a rel="license" href="%(url)s">អាជ្ញាប័ណ្ណ Creative Commons</a>។
 
 
 # Previous footer string

--- a/km/main.lang
+++ b/km/main.lang
@@ -301,7 +301,7 @@ Firefox សម្រាប់​ទូរស័ព្ទចល័ត
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+ផ្នែក​នៃ​មាតិកា​នេះ​​​នៅ​អំឡុង ©1998–%(current_year)s បង្កើត​ដោយ​​អ្នក​ចូលរួម​ចំណែក mozilla.org ។ មាតិកា​អាច​​ប្រើ​បាន​ក្រោម <a href="%(url)s">អាជ្ញាប័ណ្ណ Creative Commons</a>។
 
 
 # Previous footer string

--- a/kn/main.lang
+++ b/kn/main.lang
@@ -301,7 +301,7 @@ MPEG-4 ವಿನ್ಯಾಸ
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+ಈ ವಸ್ತುವಿಷಯದ ಭಾಗಗಳು ©1998–%(current_year)s ಮೊಝಿಲ್ಲಾ ವ್ಯಕ್ತಿಗತ ಕೊಡುಗೆದಾರರಿಗೆ ಸೇರಿವೆ. ವಸ್ತುವಿಷಯವು <a href="%(url)s">ಕ್ರಿಯೇಟಿವ್ ಕಾಮನ್ಸ್ ಪರವಾನಿಗೆ</a> ಯ ಅಡಿಯಲ್ಲಿ ಲಭ್ಯವಿದೆ.
 
 
 # Previous footer string

--- a/kn/main.lang
+++ b/kn/main.lang
@@ -114,6 +114,11 @@ Firefox ಲಾಭರಹಿತ, ಖಾಸಗಿಯಲ್ಲದ, ರಾಜಿಗ�
 ನಮ್ಮನ್ನು ಸಂಪರ್ಕಿಸಿ
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 ಇತರೆ ಭಾಷೆಗಳು:
 
@@ -294,7 +299,12 @@ MPEG-4 ವಿನ್ಯಾಸ
 ಗೌಪ್ಯತೆ
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 ಈ ವಸ್ತುವಿಷಯದ ಭಾಗಗಳು ©1998–%(current_year)s ಮೊಝಿಲ್ಲಾ ವ್ಯಕ್ತಿಗತ ಕೊಡುಗೆದಾರರಿಗೆ ಸೇರಿವೆ. ವಸ್ತುವಿಷಯವು <a href="%(url)s">ಕ್ರಿಯೇಟಿವ್ ಕಾಮನ್ಸ್ ಪರವಾನಿಗೆ</a> ಯ ಅಡಿಯಲ್ಲಿ ಲಭ್ಯವಿದೆ.
 

--- a/kn/main.lang
+++ b/kn/main.lang
@@ -301,7 +301,7 @@ MPEG-4 ವಿನ್ಯಾಸ
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-ಈ ವಸ್ತುವಿಷಯದ ಭಾಗಗಳು ©1998–%(current_year)s ಮೊಝಿಲ್ಲಾ ವ್ಯಕ್ತಿಗತ ಕೊಡುಗೆದಾರರಿಗೆ ಸೇರಿವೆ. ವಸ್ತುವಿಷಯವು <a href="%(url)s">ಕ್ರಿಯೇಟಿವ್ ಕಾಮನ್ಸ್ ಪರವಾನಿಗೆ</a> ಯ ಅಡಿಯಲ್ಲಿ ಲಭ್ಯವಿದೆ.
+ಈ ವಸ್ತುವಿಷಯದ ಭಾಗಗಳು ©1998–%(current_year)s ಮೊಝಿಲ್ಲಾ ವ್ಯಕ್ತಿಗತ ಕೊಡುಗೆದಾರರಿಗೆ ಸೇರಿವೆ. ವಸ್ತುವಿಷಯವು <a rel="license" href="%(url)s">ಕ್ರಿಯೇಟಿವ್ ಕಾಮನ್ಸ್ ಪರವಾನಿಗೆ</a> ಯ ಅಡಿಯಲ್ಲಿ ಲಭ್ಯವಿದೆ.
 
 
 # Previous footer string

--- a/ko/main.lang
+++ b/ko/main.lang
@@ -114,6 +114,11 @@ Careers (영문)
 연락처
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 언어별:
 
@@ -294,7 +299,12 @@ Firefox 모바일
 개인 정보 정책
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 ©1998–%(current_year)s. 콘텐츠의 일부는 개별 mozilla.org 공헌자에게 저작권이 있습니다. 콘텐츠는 <a href="%(url)s">Creative Commons license</a>에 의해 사용할 수 있습니다.
 

--- a/ko/main.lang
+++ b/ko/main.lang
@@ -301,7 +301,7 @@ Firefox 모바일
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+©1998–%(current_year)s. 콘텐츠의 일부는 개별 mozilla.org 공헌자에게 저작권이 있습니다. 콘텐츠는 <a href="%(url)s">Creative Commons license</a>에 의해 사용할 수 있습니다.
 
 
 # Previous footer string

--- a/ko/main.lang
+++ b/ko/main.lang
@@ -301,7 +301,7 @@ Firefox 모바일
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-©1998–%(current_year)s. 콘텐츠의 일부는 개별 mozilla.org 공헌자에게 저작권이 있습니다. 콘텐츠는 <a href="%(url)s">Creative Commons license</a>에 의해 사용할 수 있습니다.
+©1998–%(current_year)s. 콘텐츠의 일부는 개별 mozilla.org 공헌자에게 저작권이 있습니다. 콘텐츠는 <a rel="license" href="%(url)s">Creative Commons license</a>에 의해 사용할 수 있습니다.
 
 
 # Previous footer string

--- a/lij/main.lang
+++ b/lij/main.lang
@@ -301,7 +301,7 @@ Privacy {ok}
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Parte de sti contegnui son fæti de personn-e che colaboran co-o mozilla.org inti anni ©1998–%(current_year)s. I contegnui son a dispoxiçion sotta 'na <a href="%(url)s">licensa Creative Commons</a>.
+Parte de sti contegnui son fæti de personn-e che colaboran co-o mozilla.org inti anni ©1998–%(current_year)s. I contegnui son a dispoxiçion sotta 'na <a rel="license" href="%(url)s">licensa Creative Commons</a>.
 
 
 # Previous footer string

--- a/lij/main.lang
+++ b/lij/main.lang
@@ -301,7 +301,7 @@ Privacy {ok}
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Parte de sti contegnui son fæti de personn-e che colaboran co-o mozilla.org inti anni ©1998–%(current_year)s. I contegnui son a dispoxiçion sotta 'na <a href="%(url)s">licensa Creative Commons</a>.
 
 
 # Previous footer string

--- a/lij/main.lang
+++ b/lij/main.lang
@@ -114,6 +114,11 @@ Centro stanpa
 Contatine
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Atre lengoe:
 
@@ -294,7 +299,12 @@ Agiorna oua
 Privacy {ok}
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Parte de sti contegnui son fæti de personn-e che colaboran co-o mozilla.org inti anni ©1998–%(current_year)s. I contegnui son a dispoxiçion sotta 'na <a href="%(url)s">licensa Creative Commons</a>.
 

--- a/lo/main.lang
+++ b/lo/main.lang
@@ -114,6 +114,11 @@ Add-ons {ok}
 ຕິດຕໍ່ພວກເຮົາ
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 ພາສາອື່ນໆ:
 
@@ -294,7 +299,12 @@ Firefox ສຳລັບໂທລະສັບ
 ຄວາມເປັນສ່ວນໂຕ
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 

--- a/lo/main.lang
+++ b/lo/main.lang
@@ -301,7 +301,7 @@ Firefox ສຳລັບໂທລະສັບ
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/lo/main.lang
+++ b/lo/main.lang
@@ -301,7 +301,7 @@ Firefox ສຳລັບໂທລະສັບ
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/lt/main.lang
+++ b/lt/main.lang
@@ -301,7 +301,7 @@ Privatumas
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+©1998–%(current_year)s. Kai kurių šio turinio dalių autoriai yra atskiri mozilla.org bendradarbiai. Turinys pateikiamas <a href="%(url)s">„Creative Commons“ licencijos</a> sąlygomis.
 
 
 # Previous footer string

--- a/lt/main.lang
+++ b/lt/main.lang
@@ -301,7 +301,7 @@ Privatumas
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-©1998–%(current_year)s. Kai kurių šio turinio dalių autoriai yra atskiri mozilla.org bendradarbiai. Turinys pateikiamas <a href="%(url)s">„Creative Commons“ licencijos</a> sąlygomis.
+©1998–%(current_year)s. Kai kurių šio turinio dalių autoriai yra atskiri mozilla.org bendradarbiai. Turinys pateikiamas <a rel="license" href="%(url)s">„Creative Commons“ licencijos</a> sąlygomis.
 
 
 # Previous footer string

--- a/lt/main.lang
+++ b/lt/main.lang
@@ -114,6 +114,11 @@ Spaudos centras
 Susisiekite su mumis
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Kitos kalbos:
 
@@ -294,7 +299,12 @@ Atnaujinti dabar
 Privatumas
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 ©1998–%(current_year)s. Kai kurių šio turinio dalių autoriai yra atskiri mozilla.org bendradarbiai. Turinys pateikiamas <a href="%(url)s">„Creative Commons“ licencijos</a> sąlygomis.
 

--- a/ltg/main.lang
+++ b/ltg/main.lang
@@ -301,7 +301,7 @@ Privātums
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Satura daļas ©1998–%(current_year)s godūs ir davīnōjuši dažaidi mozilla.org pazīdōtōji. Saturs ir pīejams saskaņā ar <a href="%(url)s">Creative Commons licenci</a>.
+Satura daļas ©1998–%(current_year)s godūs ir davīnōjuši dažaidi mozilla.org pazīdōtōji. Saturs ir pīejams saskaņā ar <a rel="license" href="%(url)s">Creative Commons licenci</a>.
 
 
 # Previous footer string

--- a/ltg/main.lang
+++ b/ltg/main.lang
@@ -114,6 +114,11 @@ Preses centrs
 Sazazynōt
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Cytas volūdas:
 
@@ -294,7 +299,12 @@ E-posts
 Privātums
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Satura daļas ©1998–%(current_year)s godūs ir davīnōjuši dažaidi mozilla.org pazīdōtōji. Saturs ir pīejams saskaņā ar <a href="%(url)s">Creative Commons licenci</a>.
 

--- a/ltg/main.lang
+++ b/ltg/main.lang
@@ -301,7 +301,7 @@ Privātums
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Satura daļas ©1998–%(current_year)s godūs ir davīnōjuši dažaidi mozilla.org pazīdōtōji. Saturs ir pīejams saskaņā ar <a href="%(url)s">Creative Commons licenci</a>.
 
 
 # Previous footer string

--- a/lv/main.lang
+++ b/lv/main.lang
@@ -301,7 +301,7 @@ Privātums
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Daļai no šī satura ©1998–%(current_year)s pieder individuāliem mozilla.org biedriem. Saturs pieejams ar <a href="%(url)s">Creative Commons licenci</a>.
 
 
 # Previous footer string

--- a/lv/main.lang
+++ b/lv/main.lang
@@ -114,6 +114,11 @@ Preses centrs
 Kontakti
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Citas valodas:
 
@@ -294,7 +299,12 @@ Atjaunināt tagad
 Privātums
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Daļai no šī satura ©1998–%(current_year)s pieder individuāliem mozilla.org biedriem. Saturs pieejams ar <a href="%(url)s">Creative Commons licenci</a>.
 

--- a/lv/main.lang
+++ b/lv/main.lang
@@ -301,7 +301,7 @@ Privātums
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Daļai no šī satura ©1998–%(current_year)s pieder individuāliem mozilla.org biedriem. Saturs pieejams ar <a href="%(url)s">Creative Commons licenci</a>.
+Daļai no šī satura ©1998–%(current_year)s pieder individuāliem mozilla.org biedriem. Saturs pieejams ar <a rel="license" href="%(url)s">Creative Commons licenci</a>.
 
 
 # Previous footer string

--- a/mai/main.lang
+++ b/mai/main.lang
@@ -114,6 +114,11 @@ Firefox is non-profit, non-corporate, non-compromised. Choosing Firefox isn’t 
 संपर्क करू
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 आन भाषासभ:
 
@@ -294,7 +299,12 @@ Ogg थियोरा प्रारूप
 गोपनीयता
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 

--- a/mai/main.lang
+++ b/mai/main.lang
@@ -301,7 +301,7 @@ Ogg थियोरा प्रारूप
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/mai/main.lang
+++ b/mai/main.lang
@@ -301,7 +301,7 @@ Ogg थियोरा प्रारूप
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/mk/main.lang
+++ b/mk/main.lang
@@ -301,7 +301,7 @@ Firefox за мобилни
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Делови од оваа содржина се ©1998–%(current_year)s на поединци кои придонеле на mozilla.org. Содржината е достапна под <a href="%(url)s">лиценца на Криејтив комонс</a>.
+Делови од оваа содржина се ©1998–%(current_year)s на поединци кои придонеле на mozilla.org. Содржината е достапна под <a rel="license" href="%(url)s">лиценца на Криејтив комонс</a>.
 
 
 # Previous footer string

--- a/mk/main.lang
+++ b/mk/main.lang
@@ -301,7 +301,7 @@ Firefox за мобилни
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Делови од оваа содржина се ©1998–%(current_year)s на поединци кои придонеле на mozilla.org. Содржината е достапна под <a href="%(url)s">лиценца на Криејтив комонс</a>.
 
 
 # Previous footer string

--- a/mk/main.lang
+++ b/mk/main.lang
@@ -114,6 +114,11 @@ Firefox is non-profit, non-corporate, non-compromised. Choosing Firefox isn’t 
 Контактирајте нѐ
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Други јазици:
 
@@ -294,7 +299,12 @@ Firefox за мобилни
 Приватност
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Делови од оваа содржина се ©1998–%(current_year)s на поединци кои придонеле на mozilla.org. Содржината е достапна под <a href="%(url)s">лиценца на Криејтив комонс</a>.
 

--- a/ml/main.lang
+++ b/ml/main.lang
@@ -301,7 +301,7 @@ MPEG-4 ഫോര്‍മാറ്റ്
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+വിവരങ്ങളുടം ഈ ഭാഗങ്ങള്‍  ഓരോ mozilla.org സംഭാവനക്കാരുടെ ©1998–%(current_year)s പകര്‍പ്പവകാശത്തിലാകുന്നു. <a href="%(url)s">ക്രിയേറ്റീവ് കോമണ്‍സ് ലൈസന്‍സില്‍</a> വിവരങ്ങള്‍ ലഭ്യം.
 
 
 # Previous footer string

--- a/ml/main.lang
+++ b/ml/main.lang
@@ -301,7 +301,7 @@ MPEG-4 ഫോര്‍മാറ്റ്
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-വിവരങ്ങളുടം ഈ ഭാഗങ്ങള്‍  ഓരോ mozilla.org സംഭാവനക്കാരുടെ ©1998–%(current_year)s പകര്‍പ്പവകാശത്തിലാകുന്നു. <a href="%(url)s">ക്രിയേറ്റീവ് കോമണ്‍സ് ലൈസന്‍സില്‍</a> വിവരങ്ങള്‍ ലഭ്യം.
+വിവരങ്ങളുടം ഈ ഭാഗങ്ങള്‍  ഓരോ mozilla.org സംഭാവനക്കാരുടെ ©1998–%(current_year)s പകര്‍പ്പവകാശത്തിലാകുന്നു. <a rel="license" href="%(url)s">ക്രിയേറ്റീവ് കോമണ്‍സ് ലൈസന്‍സില്‍</a> വിവരങ്ങള്‍ ലഭ്യം.
 
 
 # Previous footer string

--- a/ml/main.lang
+++ b/ml/main.lang
@@ -114,6 +114,11 @@ Firefox is non-profit, non-corporate, non-compromised. Choosing Firefox isn’t 
 ഞങ്ങളെ ബന്ധപ്പെടുക
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 മറ്റ് ഭാഷകള്‍:
 
@@ -294,7 +299,12 @@ MPEG-4 ഫോര്‍മാറ്റ്
 സ്വകാര്യത
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 വിവരങ്ങളുടം ഈ ഭാഗങ്ങള്‍  ഓരോ mozilla.org സംഭാവനക്കാരുടെ ©1998–%(current_year)s പകര്‍പ്പവകാശത്തിലാകുന്നു. <a href="%(url)s">ക്രിയേറ്റീവ് കോമണ്‍സ് ലൈസന്‍സില്‍</a> വിവരങ്ങള്‍ ലഭ്യം.
 

--- a/mr/main.lang
+++ b/mr/main.lang
@@ -114,6 +114,11 @@ Mozilla विषयी
 आमच्याशी संपर्क करा
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 इतर भाषा:
 
@@ -294,7 +299,12 @@ MPEG-4 रुपण
 गुप्तता
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 ह्या अंतर्भुत माहितीमधील काही भाग ©1998–%(current_year)s परस्पर mozilla.org सहकार्यांच्या मालकीचे आहे. <a href="%(url)s">Creative Commons license</a> अंतर्गत उपलब्ध अंतर्भुत माहिती.
 

--- a/mr/main.lang
+++ b/mr/main.lang
@@ -301,7 +301,7 @@ MPEG-4 रुपण
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+ह्या अंतर्भुत माहितीमधील काही भाग ©1998–%(current_year)s परस्पर mozilla.org सहकार्यांच्या मालकीचे आहे. <a href="%(url)s">Creative Commons license</a> अंतर्गत उपलब्ध अंतर्भुत माहिती.
 
 
 # Previous footer string

--- a/mr/main.lang
+++ b/mr/main.lang
@@ -301,7 +301,7 @@ MPEG-4 रुपण
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-ह्या अंतर्भुत माहितीमधील काही भाग ©1998–%(current_year)s परस्पर mozilla.org सहकार्यांच्या मालकीचे आहे. <a href="%(url)s">Creative Commons license</a> अंतर्गत उपलब्ध अंतर्भुत माहिती.
+ह्या अंतर्भुत माहितीमधील काही भाग ©1998–%(current_year)s परस्पर mozilla.org सहकार्यांच्या मालकीचे आहे. <a rel="license" href="%(url)s">Creative Commons license</a> अंतर्गत उपलब्ध अंतर्भुत माहिती.
 
 
 # Previous footer string

--- a/ms/main.lang
+++ b/ms/main.lang
@@ -301,7 +301,7 @@ Privasi
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Sebahagian kandungan ini ©1998–%(current_year)s dihasilkan oleh individu penyumbang mozilla.org. Kandungan tersedia di bawah <a href="%(url)s">Lesen Creative Commons</a>.
+Sebahagian kandungan ini ©1998–%(current_year)s dihasilkan oleh individu penyumbang mozilla.org. Kandungan tersedia di bawah <a rel="license" href="%(url)s">Lesen Creative Commons</a>.
 
 
 # Previous footer string

--- a/ms/main.lang
+++ b/ms/main.lang
@@ -114,6 +114,11 @@ Pusat Media
 Hubungi Kami
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Bahasa lain:
 
@@ -294,7 +299,12 @@ Kemaskini sekarang
 Privasi
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Sebahagian kandungan ini ©1998–%(current_year)s dihasilkan oleh individu penyumbang mozilla.org. Kandungan tersedia di bawah <a href="%(url)s">Lesen Creative Commons</a>.
 

--- a/ms/main.lang
+++ b/ms/main.lang
@@ -301,7 +301,7 @@ Privasi
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Sebahagian kandungan ini ©1998–%(current_year)s dihasilkan oleh individu penyumbang mozilla.org. Kandungan tersedia di bawah <a href="%(url)s">Lesen Creative Commons</a>.
 
 
 # Previous footer string

--- a/my/main.lang
+++ b/my/main.lang
@@ -114,6 +114,11 @@ Developer သုံးဗားရှင်း
 ဆက်သွယ်ပါ
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 အခြား ဘာသာများ
 
@@ -294,7 +299,12 @@ Desktop {ok}
 Privacy {ok}
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>. {ok}
 

--- a/my/main.lang
+++ b/my/main.lang
@@ -301,7 +301,7 @@ Privacy {ok}
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>. {ok}
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>. {ok}
 
 
 # Previous footer string

--- a/my/main.lang
+++ b/my/main.lang
@@ -301,7 +301,7 @@ Privacy {ok}
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>. {ok}
 
 
 # Previous footer string

--- a/nb-NO/main.lang
+++ b/nb-NO/main.lang
@@ -301,7 +301,7 @@ Personvern
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Deler av dette innholdet er ©1998–%(current_year)s individuelle mozilla.org-bidragsytere. Innholdet er tilgjengelig under en <a href="%(url)s">Creative Commons-lisens</a>.
+Deler av dette innholdet er ©1998–%(current_year)s individuelle mozilla.org-bidragsytere. Innholdet er tilgjengelig under en <a rel="license" href="%(url)s">Creative Commons-lisens</a>.
 
 
 # Previous footer string

--- a/nb-NO/main.lang
+++ b/nb-NO/main.lang
@@ -114,6 +114,11 @@ Pressesenter
 Kontakt oss
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Andre språk:
 
@@ -294,7 +299,12 @@ Oppdater nå
 Personvern
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Deler av dette innholdet er ©1998–%(current_year)s individuelle mozilla.org-bidragsytere. Innholdet er tilgjengelig under en <a href="%(url)s">Creative Commons-lisens</a>.
 

--- a/nb-NO/main.lang
+++ b/nb-NO/main.lang
@@ -301,7 +301,7 @@ Personvern
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Deler av dette innholdet er ©1998–%(current_year)s individuelle mozilla.org-bidragsytere. Innholdet er tilgjengelig under en <a href="%(url)s">Creative Commons-lisens</a>.
 
 
 # Previous footer string

--- a/ncj/main.lang
+++ b/ncj/main.lang
@@ -301,7 +301,7 @@ Keniuj tiyekpiaj tein tikseliaj
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Sekin taman tein nikan moajsij teaxkauan uan kimatampauiaj tein ika kiiliaj derechos de autor ©1998–%(current_year)s uan ininaxkauan sekin tokniuan akin kipaleuiaj itech mozilla.org. Oksekin taman tein nikan moajsij se uelis kikuis ika se licencia <a href="%(url)s">Creative Commons</a>.
+Sekin taman tein nikan moajsij teaxkauan uan kimatampauiaj tein ika kiiliaj derechos de autor ©1998–%(current_year)s uan ininaxkauan sekin tokniuan akin kipaleuiaj itech mozilla.org. Oksekin taman tein nikan moajsij se uelis kikuis ika se licencia <a rel="license" href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/ncj/main.lang
+++ b/ncj/main.lang
@@ -301,7 +301,7 @@ Keniuj tiyekpiaj tein tikseliaj
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Sekin taman tein nikan moajsij teaxkauan uan kimatampauiaj tein ika kiiliaj derechos de autor ©1998–%(current_year)s uan ininaxkauan sekin tokniuan akin kipaleuiaj itech mozilla.org. Oksekin taman tein nikan moajsij se uelis kikuis ika se licencia <a href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/ncj/main.lang
+++ b/ncj/main.lang
@@ -114,6 +114,11 @@ Amatanauatilmej
 Kampa se uelis techijkuilouilis
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Oksekin tajtolismej:
 
@@ -294,7 +299,12 @@ Maj axkan moyankuili
 Keniuj tiyekpiaj tein tikseliaj
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Sekin taman tein nikan moajsij teaxkauan uan kimatampauiaj tein ika kiiliaj derechos de autor ©1998–%(current_year)s uan ininaxkauan sekin tokniuan akin kipaleuiaj itech mozilla.org. Oksekin taman tein nikan moajsij se uelis kikuis ika se licencia <a href="%(url)s">Creative Commons</a>.
 

--- a/ne-NP/main.lang
+++ b/ne-NP/main.lang
@@ -114,6 +114,11 @@ Mozilla को बारेमा
 सम्पर्क गर्नुहोस्
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 अरु भाषाहरू:
 
@@ -294,7 +299,12 @@ MPEG-4 format {ok}
 गोपनीयता
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 mozilla.org का व्यक्तिगत योगदानकर्ताहरु द्वारा यो सामग्री का अंशहरू ©1998–%(current_year)s अनुसार सुरक्षित छन्। सामग्री<a href="%(url)s">Creative Commons license</a> अन्तर्गत उपलब्ध छ।
 

--- a/ne-NP/main.lang
+++ b/ne-NP/main.lang
@@ -301,7 +301,7 @@ MPEG-4 format {ok}
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+mozilla.org का व्यक्तिगत योगदानकर्ताहरु द्वारा यो सामग्री का अंशहरू ©1998–%(current_year)s अनुसार सुरक्षित छन्। सामग्री<a href="%(url)s">Creative Commons license</a> अन्तर्गत उपलब्ध छ।
 
 
 # Previous footer string

--- a/ne-NP/main.lang
+++ b/ne-NP/main.lang
@@ -301,7 +301,7 @@ MPEG-4 format {ok}
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-mozilla.org का व्यक्तिगत योगदानकर्ताहरु द्वारा यो सामग्री का अंशहरू ©1998–%(current_year)s अनुसार सुरक्षित छन्। सामग्री<a href="%(url)s">Creative Commons license</a> अन्तर्गत उपलब्ध छ।
+mozilla.org का व्यक्तिगत योगदानकर्ताहरु द्वारा यो सामग्री का अंशहरू ©1998–%(current_year)s अनुसार सुरक्षित छन्। सामग्री<a rel="license" href="%(url)s">Creative Commons license</a> अन्तर्गत उपलब्ध छ।
 
 
 # Previous footer string

--- a/nl/main.lang
+++ b/nl/main.lang
@@ -114,6 +114,11 @@ Perscentrum
 Contact
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Andere talen:
 
@@ -294,7 +299,12 @@ Update nu
 Privacy {ok}
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Delen van deze inhoud zijn ©1998–%(current_year)s door individuele mozilla.org-medewerkers. Inhoud is beschikbaar onder een <a href="%(url)s">Creative Commons-licentie</a>.
 

--- a/nl/main.lang
+++ b/nl/main.lang
@@ -301,7 +301,7 @@ Privacy {ok}
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Delen van deze inhoud zijn ©1998–%(current_year)s door individuele mozilla.org-medewerkers. Inhoud is beschikbaar onder een <a href="%(url)s">Creative Commons-licentie</a>.
 
 
 # Previous footer string

--- a/nl/main.lang
+++ b/nl/main.lang
@@ -301,7 +301,7 @@ Privacy {ok}
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Delen van deze inhoud zijn ©1998–%(current_year)s door individuele mozilla.org-medewerkers. Inhoud is beschikbaar onder een <a href="%(url)s">Creative Commons-licentie</a>.
+Delen van deze inhoud zijn ©1998–%(current_year)s door individuele mozilla.org-medewerkers. Inhoud is beschikbaar onder een <a rel="license" href="%(url)s">Creative Commons-licentie</a>.
 
 
 # Previous footer string

--- a/nn-NO/main.lang
+++ b/nn-NO/main.lang
@@ -114,6 +114,11 @@ Pressesenter
 Kontakt oss
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Andre språk:
 
@@ -294,7 +299,12 @@ Oppdater no
 Personvern
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Opphavsretten for delar av dette innhaldet høyrer til einskilde medarbeidarar ved mozilla.org – ©1998–%(current_year)s. Innehaldet er tillgjengeleg under ein <a href="%(url)s">Creative Commons-lisens</a>.
 

--- a/nn-NO/main.lang
+++ b/nn-NO/main.lang
@@ -301,7 +301,7 @@ Personvern
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Opphavsretten for delar av dette innhaldet høyrer til einskilde medarbeidarar ved mozilla.org – ©1998–%(current_year)s. Innehaldet er tillgjengeleg under ein <a href="%(url)s">Creative Commons-lisens</a>.
+Opphavsretten for delar av dette innhaldet høyrer til einskilde medarbeidarar ved mozilla.org – ©1998–%(current_year)s. Innehaldet er tillgjengeleg under ein <a rel="license" href="%(url)s">Creative Commons-lisens</a>.
 
 
 # Previous footer string

--- a/nn-NO/main.lang
+++ b/nn-NO/main.lang
@@ -301,7 +301,7 @@ Personvern
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Opphavsretten for delar av dette innhaldet høyrer til einskilde medarbeidarar ved mozilla.org – ©1998–%(current_year)s. Innehaldet er tillgjengeleg under ein <a href="%(url)s">Creative Commons-lisens</a>.
 
 
 # Previous footer string

--- a/nv/main.lang
+++ b/nv/main.lang
@@ -114,6 +114,11 @@ Press Center
 Contact Us
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Other languages:
 
@@ -294,7 +299,12 @@ Update now
 Dįnę́ bits’ą́ą Nanil’in
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 

--- a/nv/main.lang
+++ b/nv/main.lang
@@ -301,7 +301,7 @@ Dįnę́ bits’ą́ą Nanil’in
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/nv/main.lang
+++ b/nv/main.lang
@@ -301,7 +301,7 @@ Dįnę́ bits’ą́ą Nanil’in
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/oc/main.lang
+++ b/oc/main.lang
@@ -114,6 +114,11 @@ Centre de premsa
 Contactatz-nos
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Autras lengas&nbsp;:
 
@@ -294,7 +299,12 @@ Metètz-vos a jorn ara
 Voda privada
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 D'unas partidas d'aqueste contengut son ©1998–%(current_year)s pels contributors. Lo contengut es disponible jos <a href="%(url)s">licence Creative Commons</a>.
 

--- a/oc/main.lang
+++ b/oc/main.lang
@@ -301,7 +301,7 @@ Voda privada
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-D'unas partidas d'aqueste contengut son ©1998–%(current_year)s pels contributors. Lo contengut es disponible jos <a href="%(url)s">licence Creative Commons</a>.
+D'unas partidas d'aqueste contengut son ©1998–%(current_year)s pels contributors. Lo contengut es disponible jos <a rel="license" href="%(url)s">licence Creative Commons</a>.
 
 
 # Previous footer string

--- a/oc/main.lang
+++ b/oc/main.lang
@@ -301,7 +301,7 @@ Voda privada
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+D'unas partidas d'aqueste contengut son ©1998–%(current_year)s pels contributors. Lo contengut es disponible jos <a href="%(url)s">licence Creative Commons</a>.
 
 
 # Previous footer string

--- a/or/main.lang
+++ b/or/main.lang
@@ -114,6 +114,11 @@ Mozilla ବିଷୟରେ
 ଆମ ସହିତ ଯୋଗାଯୋଗ କରନ୍ତୁ
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 ଅନ୍ୟାନ୍ୟ ଭାଷାଗୁଡ଼ିକ:
 
@@ -294,7 +299,12 @@ MPEG-4 ଶୈଳୀ
 ଗୋପନୀୟତା
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 

--- a/or/main.lang
+++ b/or/main.lang
@@ -301,7 +301,7 @@ MPEG-4 ଶୈଳୀ
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/or/main.lang
+++ b/or/main.lang
@@ -301,7 +301,7 @@ MPEG-4 ଶୈଳୀ
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/pa-IN/main.lang
+++ b/pa-IN/main.lang
@@ -114,6 +114,11 @@
 ਸਾਡੇ ਨਾਲ ਸੰਪਰਕ ਕਰੋ
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 ਹੋਰ ਭਾਸ਼ਾਵਾਂ:
 
@@ -294,7 +299,12 @@ MPEG-4 ਫਾਰਮੈਟ
 ਪਰਦੇਦਾਰੀ
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 ਇਹ ਸਮੱਗਰੀ ਦੇ ਹਿੱਸੇ ©1998–%(current_year)s ਵੱਖ-ਵੱਖ mozilla.org ਦਾ ਯੋਗਦਾਨ ਹਨ। ਸਮੱਗਰੀ <a href="%(url)s">ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਲਸੰਸ</a> ਅਧੀਨ ਹੈ।
 

--- a/pa-IN/main.lang
+++ b/pa-IN/main.lang
@@ -301,7 +301,7 @@ MPEG-4 ਫਾਰਮੈਟ
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+ਇਹ ਸਮੱਗਰੀ ਦੇ ਹਿੱਸੇ ©1998–%(current_year)s ਵੱਖ-ਵੱਖ mozilla.org ਦਾ ਯੋਗਦਾਨ ਹਨ। ਸਮੱਗਰੀ <a href="%(url)s">ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਲਸੰਸ</a> ਅਧੀਨ ਹੈ।
 
 
 # Previous footer string

--- a/pa-IN/main.lang
+++ b/pa-IN/main.lang
@@ -301,7 +301,7 @@ MPEG-4 ਫਾਰਮੈਟ
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-ਇਹ ਸਮੱਗਰੀ ਦੇ ਹਿੱਸੇ ©1998–%(current_year)s ਵੱਖ-ਵੱਖ mozilla.org ਦਾ ਯੋਗਦਾਨ ਹਨ। ਸਮੱਗਰੀ <a href="%(url)s">ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਲਸੰਸ</a> ਅਧੀਨ ਹੈ।
+ਇਹ ਸਮੱਗਰੀ ਦੇ ਹਿੱਸੇ ©1998–%(current_year)s ਵੱਖ-ਵੱਖ mozilla.org ਦਾ ਯੋਗਦਾਨ ਹਨ। ਸਮੱਗਰੀ <a rel="license" href="%(url)s">ਕਰੀਏਟਿਵ ਕਾਮਨਜ਼ ਲਸੰਸ</a> ਅਧੀਨ ਹੈ।
 
 
 # Previous footer string

--- a/pai/main.lang
+++ b/pai/main.lang
@@ -114,6 +114,11 @@ Press Center
 Contact Us
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Other languages:
 
@@ -294,7 +299,12 @@ Update now
 Privacy
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 

--- a/pai/main.lang
+++ b/pai/main.lang
@@ -301,7 +301,7 @@ Privacy
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/pai/main.lang
+++ b/pai/main.lang
@@ -301,7 +301,7 @@ Privacy
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/pbb/main.lang
+++ b/pbb/main.lang
@@ -114,6 +114,11 @@ Press Center
 Contact Us
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Other languages:
 
@@ -294,7 +299,12 @@ Update now
 Privacy
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 

--- a/pbb/main.lang
+++ b/pbb/main.lang
@@ -301,7 +301,7 @@ Privacy
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/pbb/main.lang
+++ b/pbb/main.lang
@@ -301,7 +301,7 @@ Privacy
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/pl/main.lang
+++ b/pl/main.lang
@@ -301,7 +301,7 @@ Prywatność
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Fragmenty treści tej witryny: ©1998–%(current_year)s. Prawa autorskie należą do poszczególnych współtwórców witryny mozilla.org. Treść strony dostępna na licencji <a href="%(url)s">Creative Commons</a>.
+Fragmenty treści tej witryny: ©1998–%(current_year)s. Prawa autorskie należą do poszczególnych współtwórców witryny mozilla.org. Treść strony dostępna na licencji <a rel="license" href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/pl/main.lang
+++ b/pl/main.lang
@@ -114,6 +114,11 @@ Centrum prasowe
 Kontakt z nami
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Inne języki:
 
@@ -294,7 +299,12 @@ Uaktualnij teraz
 Prywatność
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Fragmenty treści tej witryny: ©1998–%(current_year)s. Prawa autorskie należą do poszczególnych współtwórców witryny mozilla.org. Treść strony dostępna na licencji <a href="%(url)s">Creative Commons</a>.
 

--- a/pl/main.lang
+++ b/pl/main.lang
@@ -301,7 +301,7 @@ Prywatność
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Fragmenty treści tej witryny: ©1998–%(current_year)s. Prawa autorskie należą do poszczególnych współtwórców witryny mozilla.org. Treść strony dostępna na licencji <a href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/pt-BR/main.lang
+++ b/pt-BR/main.lang
@@ -301,7 +301,7 @@ Privacidade
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Trechos deste conteúdo possuem direitos reservados (©1998–%(current_year)s) por colaboradores da mozilla.org. Conteúdo disponível sob a licença <a href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/pt-BR/main.lang
+++ b/pt-BR/main.lang
@@ -301,7 +301,7 @@ Privacidade
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Trechos deste conteúdo possuem direitos reservados (©1998–%(current_year)s) por colaboradores da mozilla.org. Conteúdo disponível sob a licença <a href="%(url)s">Creative Commons</a>.
+Trechos deste conteúdo possuem direitos reservados (©1998–%(current_year)s) por colaboradores da mozilla.org. Conteúdo disponível sob a licença <a rel="license" href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/pt-BR/main.lang
+++ b/pt-BR/main.lang
@@ -114,6 +114,11 @@ Carreiras
 Entre em contato
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Outros idiomas:
 
@@ -294,7 +299,12 @@ Atualizar agora
 Privacidade
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Trechos deste conteúdo possuem direitos reservados (©1998–%(current_year)s) por colaboradores da mozilla.org. Conteúdo disponível sob a licença <a href="%(url)s">Creative Commons</a>.
 

--- a/pt-PT/main.lang
+++ b/pt-PT/main.lang
@@ -301,7 +301,7 @@ Privacidade
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Porções deste conteúdo são ©1998–%(current_year)s por contribuidores individuais da mozilla.org. Conteúdo disponível sob uma <a href="%(url)s">licença Creative Commons</a>.
 
 
 # Previous footer string

--- a/pt-PT/main.lang
+++ b/pt-PT/main.lang
@@ -114,6 +114,11 @@ Centro de imprensa
 Contacte-nos
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Outros idiomas:
 
@@ -294,7 +299,12 @@ Atualizar agora
 Privacidade
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Porções deste conteúdo são ©1998–%(current_year)s por contribuidores individuais da mozilla.org. Conteúdo disponível sob uma <a href="%(url)s">licença Creative Commons</a>.
 

--- a/pt-PT/main.lang
+++ b/pt-PT/main.lang
@@ -301,7 +301,7 @@ Privacidade
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Porções deste conteúdo são ©1998–%(current_year)s por contribuidores individuais da mozilla.org. Conteúdo disponível sob uma <a href="%(url)s">licença Creative Commons</a>.
+Porções deste conteúdo são ©1998–%(current_year)s por contribuidores individuais da mozilla.org. Conteúdo disponível sob uma <a rel="license" href="%(url)s">licença Creative Commons</a>.
 
 
 # Previous footer string

--- a/qvi/main.lang
+++ b/qvi/main.lang
@@ -114,6 +114,11 @@ Press Center
 Contact Us
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Other languages:
 
@@ -294,7 +299,12 @@ Update now
 Privacy
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 

--- a/qvi/main.lang
+++ b/qvi/main.lang
@@ -301,7 +301,7 @@ Privacy
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/qvi/main.lang
+++ b/qvi/main.lang
@@ -301,7 +301,7 @@ Privacy
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/rm/main.lang
+++ b/rm/main.lang
@@ -301,7 +301,7 @@ Sfera privata
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Parts dal cuntegn èn ©1998–%(current_year)s da divers contribuents a mozilla.org. Il cuntegn stat a disposiziun tenor la <a href="%(url)s">licenza da Creative Commons</a>.
 
 
 # Previous footer string

--- a/rm/main.lang
+++ b/rm/main.lang
@@ -114,6 +114,11 @@ Center da pressa
 Ans contactescha
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Autras linguas:
 
@@ -294,7 +299,12 @@ Actualisar ussa
 Sfera privata
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Parts dal cuntegn èn ©1998–%(current_year)s da divers contribuents a mozilla.org. Il cuntegn stat a disposiziun tenor la <a href="%(url)s">licenza da Creative Commons</a>.
 

--- a/rm/main.lang
+++ b/rm/main.lang
@@ -301,7 +301,7 @@ Sfera privata
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Parts dal cuntegn èn ©1998–%(current_year)s da divers contribuents a mozilla.org. Il cuntegn stat a disposiziun tenor la <a href="%(url)s">licenza da Creative Commons</a>.
+Parts dal cuntegn èn ©1998–%(current_year)s da divers contribuents a mozilla.org. Il cuntegn stat a disposiziun tenor la <a rel="license" href="%(url)s">licenza da Creative Commons</a>.
 
 
 # Previous footer string

--- a/ro/main.lang
+++ b/ro/main.lang
@@ -114,6 +114,11 @@ Centru de presă
 Contactează-ne
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Alte limbi:
 
@@ -294,7 +299,12 @@ Actualizează acum
 Confidențialitate
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Porțiuni din acest conținut sunt scrise între ©1998–%(current_year)s de contribuitori individuali mozilla.org. Conținut disponibil sub <a href="%(url)s">licența Creative Commons</a>.
 

--- a/ro/main.lang
+++ b/ro/main.lang
@@ -301,7 +301,7 @@ Confidențialitate
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Porțiuni din acest conținut sunt scrise între ©1998–%(current_year)s de contribuitori individuali mozilla.org. Conținut disponibil sub <a href="%(url)s">licența Creative Commons</a>.
 
 
 # Previous footer string

--- a/ro/main.lang
+++ b/ro/main.lang
@@ -301,7 +301,7 @@ Confidențialitate
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Porțiuni din acest conținut sunt scrise între ©1998–%(current_year)s de contribuitori individuali mozilla.org. Conținut disponibil sub <a href="%(url)s">licența Creative Commons</a>.
+Porțiuni din acest conținut sunt scrise între ©1998–%(current_year)s de contribuitori individuali mozilla.org. Conținut disponibil sub <a rel="license" href="%(url)s">licența Creative Commons</a>.
 
 
 # Previous footer string

--- a/ru/main.lang
+++ b/ru/main.lang
@@ -114,6 +114,11 @@ Firefox — некоммерческий, некорпоративный и не
 Обратная связь
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Другие языки:
 
@@ -294,7 +299,12 @@ Firefox — некоммерческий, некорпоративный и не
 Приватность
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Части этого содержимого созданы участниками проекта mozilla.org ©1998–%(current_year)s. Содержимое доступно на условиях <a href="%(url)s">лицензии Creative Commons</a>.
 

--- a/ru/main.lang
+++ b/ru/main.lang
@@ -301,7 +301,7 @@ Language
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Части этого содержимого созданы участниками проекта mozilla.org ©1998–%(current_year)s. Содержимое доступно на условиях <a href="%(url)s">лицензии Creative Commons</a>.
+Части этого содержимого созданы участниками проекта mozilla.org ©1998–%(current_year)s. Содержимое доступно на условиях <a rel="license" href="%(url)s">лицензии Creative Commons</a>.
 
 
 # Previous footer string

--- a/ru/main.lang
+++ b/ru/main.lang
@@ -301,7 +301,7 @@ Language
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Части этого содержимого созданы участниками проекта mozilla.org ©1998–%(current_year)s. Содержимое доступно на условиях <a href="%(url)s">лицензии Creative Commons</a>.
 
 
 # Previous footer string

--- a/si/main.lang
+++ b/si/main.lang
@@ -114,6 +114,11 @@ Mozilla පිළිබඳ
 අපව අමතන්න
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 වෙනත් භාෂා:
 
@@ -294,7 +299,12 @@ MPEG-4 හැඩතලය
 පුද්ගලිකත්වය
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 

--- a/si/main.lang
+++ b/si/main.lang
@@ -301,7 +301,7 @@ MPEG-4 හැඩතලය
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/si/main.lang
+++ b/si/main.lang
@@ -301,7 +301,7 @@ MPEG-4 හැඩතලය
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/sk/main.lang
+++ b/sk/main.lang
@@ -301,7 +301,7 @@ Súkromie
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Časť tohto obsahu bola v rokoch ©1998–%(current_year)s vytvorená individuálnymi prispievateľmi mozilla.org. Obsah je dostupný pod licenciou <a href="%(url)s">Creative Commons</a>.
+Časť tohto obsahu bola v rokoch ©1998–%(current_year)s vytvorená individuálnymi prispievateľmi mozilla.org. Obsah je dostupný pod licenciou <a rel="license" href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/sk/main.lang
+++ b/sk/main.lang
@@ -301,7 +301,7 @@ Súkromie
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Časť tohto obsahu bola v rokoch ©1998–%(current_year)s vytvorená individuálnymi prispievateľmi mozilla.org. Obsah je dostupný pod licenciou <a href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/sk/main.lang
+++ b/sk/main.lang
@@ -114,6 +114,11 @@ Tlačové centrum
 Kontaktujte nás
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Iné jazyky:
 
@@ -294,7 +299,12 @@ Aktualizujte teraz
 Súkromie
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Časť tohto obsahu bola v rokoch ©1998–%(current_year)s vytvorená individuálnymi prispievateľmi mozilla.org. Obsah je dostupný pod licenciou <a href="%(url)s">Creative Commons</a>.
 

--- a/sl/main.lang
+++ b/sl/main.lang
@@ -301,7 +301,7 @@ Zasebnost
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Deli vsebine so avtorsko zaščiteni ©1998–%(current_year)s s strani sodelavcev mozilla.org. Vsebina je na voljo pod pogoji <a href="%(url)s">Creative Commons</a>.
+Deli vsebine so avtorsko zaščiteni ©1998–%(current_year)s s strani sodelavcev mozilla.org. Vsebina je na voljo pod pogoji <a rel="license" href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/sl/main.lang
+++ b/sl/main.lang
@@ -114,6 +114,11 @@ Novinarsko središče
 Pišite nam
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Drugi jeziki:
 
@@ -294,7 +299,12 @@ Posodobi zdaj
 Zasebnost
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Deli vsebine so avtorsko zaščiteni ©1998–%(current_year)s s strani sodelavcev mozilla.org. Vsebina je na voljo pod pogoji <a href="%(url)s">Creative Commons</a>.
 

--- a/sl/main.lang
+++ b/sl/main.lang
@@ -301,7 +301,7 @@ Zasebnost
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Deli vsebine so avtorsko zaščiteni ©1998–%(current_year)s s strani sodelavcev mozilla.org. Vsebina je na voljo pod pogoji <a href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/son/main.lang
+++ b/son/main.lang
@@ -301,7 +301,7 @@ Sutura
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Gundekunaa woo jereyaŋ ti ©1998–%(current_year)s mozilla.org kanbuzaakey sabbu ra. Gundekuna ga bara <a href="%(url)s">Creative Commons duɲe kaddasu</a> ra.
 
 
 # Previous footer string

--- a/son/main.lang
+++ b/son/main.lang
@@ -301,7 +301,7 @@ Sutura
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Gundekunaa woo jereyaŋ ti ©1998–%(current_year)s mozilla.org kanbuzaakey sabbu ra. Gundekuna ga bara <a href="%(url)s">Creative Commons duɲe kaddasu</a> ra.
+Gundekunaa woo jereyaŋ ti ©1998–%(current_year)s mozilla.org kanbuzaakey sabbu ra. Gundekuna ga bara <a rel="license" href="%(url)s">Creative Commons duɲe kaddasu</a> ra.
 
 
 # Previous footer string

--- a/son/main.lang
+++ b/son/main.lang
@@ -114,6 +114,11 @@ Alhabarkoyni gam
 Hantum ir se
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Šenni waaney:
 
@@ -294,7 +299,12 @@ Sohõ taagandiri
 Sutura
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Gundekunaa woo jereyaŋ ti ©1998–%(current_year)s mozilla.org kanbuzaakey sabbu ra. Gundekuna ga bara <a href="%(url)s">Creative Commons duɲe kaddasu</a> ra.
 

--- a/sq/main.lang
+++ b/sq/main.lang
@@ -301,7 +301,7 @@ Privatësi
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Pjesë të kësaj lënde janë nën të drejta kopjimi ©1998–%(current_year)s nga kontribues individualë te mozilla.org. Lëndë e passhme sipas një <a href="%(url)s">licence Creative Commons</a>.
+Pjesë të kësaj lënde janë nën të drejta kopjimi ©1998–%(current_year)s nga kontribues individualë te mozilla.org. Lëndë e passhme sipas një <a rel="license" href="%(url)s">licence Creative Commons</a>.
 
 
 # Previous footer string

--- a/sq/main.lang
+++ b/sq/main.lang
@@ -114,6 +114,11 @@ Qendër Shtypi
 Lidhuni Me Ne
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Gjuhë të tjera:
 
@@ -294,7 +299,12 @@ Përditësojeni tani
 Privatësi
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Pjesë të kësaj lënde janë nën të drejta kopjimi ©1998–%(current_year)s nga kontribues individualë te mozilla.org. Lëndë e passhme sipas një <a href="%(url)s">licence Creative Commons</a>.
 

--- a/sq/main.lang
+++ b/sq/main.lang
@@ -301,7 +301,7 @@ Privatësi
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Pjesë të kësaj lënde janë nën të drejta kopjimi ©1998–%(current_year)s nga kontribues individualë te mozilla.org. Lëndë e passhme sipas një <a href="%(url)s">licence Creative Commons</a>.
 
 
 # Previous footer string

--- a/sr/main.lang
+++ b/sr/main.lang
@@ -114,6 +114,11 @@ Firefox је непрофитан, не-корпоративан, не-комп�
 Контактирајте нас
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Други језици:
 
@@ -294,7 +299,12 @@ Aжурирај сада
 Приватност
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Права над деловима овог садржаја ©1998–%(current_year)s задржали су индивидуални доприноситељи mozilla.org пројекта. Садржај је доступан под <a href="%(url)s">Creative Commons лиценцом</a>.
 

--- a/sr/main.lang
+++ b/sr/main.lang
@@ -301,7 +301,7 @@ Aжурирај сада
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Права над деловима овог садржаја ©1998–%(current_year)s задржали су индивидуални доприноситељи mozilla.org пројекта. Садржај је доступан под <a href="%(url)s">Creative Commons лиценцом</a>.
+Права над деловима овог садржаја ©1998–%(current_year)s задржали су индивидуални доприноситељи mozilla.org пројекта. Садржај је доступан под <a rel="license" href="%(url)s">Creative Commons лиценцом</a>.
 
 
 # Previous footer string

--- a/sr/main.lang
+++ b/sr/main.lang
@@ -301,7 +301,7 @@ Aжурирај сада
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Права над деловима овог садржаја ©1998–%(current_year)s задржали су индивидуални доприноситељи mozilla.org пројекта. Садржај је доступан под <a href="%(url)s">Creative Commons лиценцом</a>.
 
 
 # Previous footer string

--- a/sv-SE/main.lang
+++ b/sv-SE/main.lang
@@ -301,7 +301,7 @@ Sekretess
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Upphovsrätten för delar av detta innehåll tillhör enskilda medarbetare vid mozilla.org – ©1998–%(current_year)s. Innehållet är tillgängligt under en <a href="%(url)s">Creative Commons-licens</a>.
+Upphovsrätten för delar av detta innehåll tillhör enskilda medarbetare vid mozilla.org – ©1998–%(current_year)s. Innehållet är tillgängligt under en <a rel="license" href="%(url)s">Creative Commons-licens</a>.
 
 
 # Previous footer string

--- a/sv-SE/main.lang
+++ b/sv-SE/main.lang
@@ -301,7 +301,7 @@ Sekretess
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Upphovsrätten för delar av detta innehåll tillhör enskilda medarbetare vid mozilla.org – ©1998–%(current_year)s. Innehållet är tillgängligt under en <a href="%(url)s">Creative Commons-licens</a>.
 
 
 # Previous footer string

--- a/sv-SE/main.lang
+++ b/sv-SE/main.lang
@@ -114,6 +114,11 @@ Presscenter
 Kontakta oss
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Andra språk:
 
@@ -294,7 +299,12 @@ Uppdatera nu
 Sekretess
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Upphovsrätten för delar av detta innehåll tillhör enskilda medarbetare vid mozilla.org – ©1998–%(current_year)s. Innehållet är tillgängligt under en <a href="%(url)s">Creative Commons-licens</a>.
 

--- a/sw/main.lang
+++ b/sw/main.lang
@@ -301,7 +301,7 @@ Faragha
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Sehemu ya yaliyomo ni ©1998%(current_year)s na wachangiaji binafsi wa mozilla.org. Yaliyomo yako katika <a href="%(url)s">Leseni ya Creative Commons</a>
 
 
 # Previous footer string

--- a/sw/main.lang
+++ b/sw/main.lang
@@ -301,7 +301,7 @@ Faragha
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Sehemu ya yaliyomo ni ©1998%(current_year)s na wachangiaji binafsi wa mozilla.org. Yaliyomo yako katika <a href="%(url)s">Leseni ya Creative Commons</a>
+Sehemu ya yaliyomo ni ©1998%(current_year)s na wachangiaji binafsi wa mozilla.org. Yaliyomo yako katika <a rel="license" href="%(url)s">Leseni ya Creative Commons</a>
 
 
 # Previous footer string

--- a/sw/main.lang
+++ b/sw/main.lang
@@ -114,6 +114,11 @@ Kituo cha Wanahabari
 Wasiliana Nasi
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Lugha Zingine:
 
@@ -294,7 +299,12 @@ Sasisha sasa
 Faragha
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Sehemu ya yaliyomo ni ©1998%(current_year)s na wachangiaji binafsi wa mozilla.org. Yaliyomo yako katika <a href="%(url)s">Leseni ya Creative Commons</a>
 

--- a/ta/main.lang
+++ b/ta/main.lang
@@ -301,7 +301,7 @@ MPEG-4 வடிவம்
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+mozilla.org இல் உள்ள சில உள்ளடக்கங்கள் தனித்தனி பங்களிப்பாளர்களால் வழங்கப்பட்டது ©1998–%(current_year)s. உள்ளடக்கங்கள் <a href="%(url)s"> கிரியேடிவ் காமன்ஸ் உரிமத்தின் கீழ் உள்ளடக்கங்கள் கிடைக்கும்</a>.
 
 
 # Previous footer string

--- a/ta/main.lang
+++ b/ta/main.lang
@@ -114,6 +114,11 @@ Mozilla பற்றி
 எங்களை தொடர்பு கொள்ள
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 வேறு மொழிகள்:
 
@@ -294,7 +299,12 @@ MPEG-4 வடிவம்
 தனியுரிமை
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 mozilla.org இல் உள்ள சில உள்ளடக்கங்கள் தனித்தனி பங்களிப்பாளர்களால் வழங்கப்பட்டது ©1998–%(current_year)s. உள்ளடக்கங்கள் <a href="%(url)s"> கிரியேடிவ் காமன்ஸ் உரிமத்தின் கீழ் உள்ளடக்கங்கள் கிடைக்கும்</a>.
 

--- a/ta/main.lang
+++ b/ta/main.lang
@@ -301,7 +301,7 @@ MPEG-4 வடிவம்
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-mozilla.org இல் உள்ள சில உள்ளடக்கங்கள் தனித்தனி பங்களிப்பாளர்களால் வழங்கப்பட்டது ©1998–%(current_year)s. உள்ளடக்கங்கள் <a href="%(url)s"> கிரியேடிவ் காமன்ஸ் உரிமத்தின் கீழ் உள்ளடக்கங்கள் கிடைக்கும்</a>.
+mozilla.org இல் உள்ள சில உள்ளடக்கங்கள் தனித்தனி பங்களிப்பாளர்களால் வழங்கப்பட்டது ©1998–%(current_year)s. உள்ளடக்கங்கள் <a rel="license" href="%(url)s"> கிரியேடிவ் காமன்ஸ் உரிமத்தின் கீழ் உள்ளடக்கங்கள் கிடைக்கும்</a>.
 
 
 # Previous footer string

--- a/te/main.lang
+++ b/te/main.lang
@@ -114,6 +114,11 @@ Mozilla గురించి
 మమ్ముల్ని సంప్రదించండి
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 ఇతర భాషలు:
 
@@ -294,7 +299,12 @@ MPEG-4 ఫార్మాటు
 గోప్యత
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 ఈ సమాచారంలో కొన్ని భాగాల కాపీహక్కులు ©1998–%(current_year)s వ్యక్తిగత mozilla.org తోడ్పాటుదార్లవి. ఈ సమాచారం <a href="%(url)s">క్రియేటివ్ కామన్స్ లైసెన్సు</a> క్రింద లభ్యం.
 

--- a/te/main.lang
+++ b/te/main.lang
@@ -301,7 +301,7 @@ MPEG-4 ఫార్మాటు
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-ఈ సమాచారంలో కొన్ని భాగాల కాపీహక్కులు ©1998–%(current_year)s వ్యక్తిగత mozilla.org తోడ్పాటుదార్లవి. ఈ సమాచారం <a href="%(url)s">క్రియేటివ్ కామన్స్ లైసెన్సు</a> క్రింద లభ్యం.
+ఈ సమాచారంలో కొన్ని భాగాల కాపీహక్కులు ©1998–%(current_year)s వ్యక్తిగత mozilla.org తోడ్పాటుదార్లవి. ఈ సమాచారం <a rel="license" href="%(url)s">క్రియేటివ్ కామన్స్ లైసెన్సు</a> క్రింద లభ్యం.
 
 
 # Previous footer string

--- a/te/main.lang
+++ b/te/main.lang
@@ -301,7 +301,7 @@ MPEG-4 ఫార్మాటు
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+ఈ సమాచారంలో కొన్ని భాగాల కాపీహక్కులు ©1998–%(current_year)s వ్యక్తిగత mozilla.org తోడ్పాటుదార్లవి. ఈ సమాచారం <a href="%(url)s">క్రియేటివ్ కామన్స్ లైసెన్సు</a> క్రింద లభ్యం.
 
 
 # Previous footer string

--- a/th/main.lang
+++ b/th/main.lang
@@ -301,7 +301,7 @@ Firefox สำหรับอุปกรณ์เคลื่อนที่
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+บางส่วนของเนื้อหานี้สงวนลิขสิทธิ์ ©1998–%(current_year)s โดยผู้มีส่วนร่วมของ mozilla.org แต่ละคน เนื้อหาใช้งานได้ภายใต้ <a href="%(url)s">สัญญาอนุญาต Creative Commons</a>
 
 
 # Previous footer string

--- a/th/main.lang
+++ b/th/main.lang
@@ -301,7 +301,7 @@ Firefox สำหรับอุปกรณ์เคลื่อนที่
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-บางส่วนของเนื้อหานี้สงวนลิขสิทธิ์ ©1998–%(current_year)s โดยผู้มีส่วนร่วมของ mozilla.org แต่ละคน เนื้อหาใช้งานได้ภายใต้ <a href="%(url)s">สัญญาอนุญาต Creative Commons</a>
+บางส่วนของเนื้อหานี้สงวนลิขสิทธิ์ ©1998–%(current_year)s โดยผู้มีส่วนร่วมของ mozilla.org แต่ละคน เนื้อหาใช้งานได้ภายใต้ <a rel="license" href="%(url)s">สัญญาอนุญาต Creative Commons</a>
 
 
 # Previous footer string

--- a/th/main.lang
+++ b/th/main.lang
@@ -114,6 +114,11 @@ Firefox ไม่แสวงหากำไร ไม่ใช่ธุรก�
 ติดต่อเรา
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 ภาษาอื่น ๆ:
 
@@ -294,7 +299,12 @@ Firefox สำหรับอุปกรณ์เคลื่อนที่
 ความเป็นส่วนตัว
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 บางส่วนของเนื้อหานี้สงวนลิขสิทธิ์ ©1998–%(current_year)s โดยผู้มีส่วนร่วมของ mozilla.org แต่ละคน เนื้อหาใช้งานได้ภายใต้ <a href="%(url)s">สัญญาอนุญาต Creative Commons</a>
 

--- a/tl/main.lang
+++ b/tl/main.lang
@@ -114,6 +114,11 @@ Press Center {ok}
 Makipag-ugnayan sa amin
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Mga ibang wika:
 
@@ -294,7 +299,12 @@ Update now
 Privacy {ok}
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 

--- a/tl/main.lang
+++ b/tl/main.lang
@@ -301,7 +301,7 @@ Privacy {ok}
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/tl/main.lang
+++ b/tl/main.lang
@@ -301,7 +301,7 @@ Privacy {ok}
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/tr/main.lang
+++ b/tr/main.lang
@@ -114,6 +114,11 @@ Basın Merkezi
 Bize ulaşın
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Diğer diller:
 
@@ -294,7 +299,12 @@ E-posta
 Gizlilik
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Bu içeriğin bazı kısımları ©1998–%(current_year)s bireysel mozilla.org yazarları. İçerik, <a href="%(url)s">Creative Commons lisansı</a> ile sunulmaktadır.
 

--- a/tr/main.lang
+++ b/tr/main.lang
@@ -301,7 +301,7 @@ Gizlilik
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Bu içeriğin bazı kısımları ©1998–%(current_year)s bireysel mozilla.org yazarları. İçerik, <a href="%(url)s">Creative Commons lisansı</a> ile sunulmaktadır.
 
 
 # Previous footer string

--- a/tr/main.lang
+++ b/tr/main.lang
@@ -301,7 +301,7 @@ Gizlilik
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Bu içeriğin bazı kısımları ©1998–%(current_year)s bireysel mozilla.org yazarları. İçerik, <a href="%(url)s">Creative Commons lisansı</a> ile sunulmaktadır.
+Bu içeriğin bazı kısımları ©1998–%(current_year)s bireysel mozilla.org yazarları. İçerik, <a rel="license" href="%(url)s">Creative Commons lisansı</a> ile sunulmaktadır.
 
 
 # Previous footer string

--- a/trs/main.lang
+++ b/trs/main.lang
@@ -301,7 +301,7 @@ Sa hùii
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Da'aj sa nu riña man huin ©1998–%(current_year)s sa 'iaj sun nej dugui' nikaj ñu'unj mozilla.org. da'uit gachinj ni'iat riña <a href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/trs/main.lang
+++ b/trs/main.lang
@@ -114,6 +114,11 @@ Rayi'i prensan
 Contacto
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 A'ngo nanj a'mi'
 
@@ -294,7 +299,12 @@ Nagi'ia nako' ma
 Sa hùii
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Da'aj sa nu riña man huin ©1998–%(current_year)s sa 'iaj sun nej dugui' nikaj ñu'unj mozilla.org. da'uit gachinj ni'iat riña <a href="%(url)s">Creative Commons</a>.
 

--- a/trs/main.lang
+++ b/trs/main.lang
@@ -301,7 +301,7 @@ Sa hùii
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Da'aj sa nu riña man huin ©1998–%(current_year)s sa 'iaj sun nej dugui' nikaj ñu'unj mozilla.org. da'uit gachinj ni'iat riña <a href="%(url)s">Creative Commons</a>.
+Da'aj sa nu riña man huin ©1998–%(current_year)s sa 'iaj sun nej dugui' nikaj ñu'unj mozilla.org. da'uit gachinj ni'iat riña <a rel="license" href="%(url)s">Creative Commons</a>.
 
 
 # Previous footer string

--- a/uk/main.lang
+++ b/uk/main.lang
@@ -301,7 +301,7 @@ Firefox для мобільних пристроїв
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Частини цього вмісту створені учасниками проекту mozilla.org ©1998–%(current_year)s. Вміст доступний на умовах <a href="%(url)s">ліцензії Creative Commons</a>.
 
 
 # Previous footer string

--- a/uk/main.lang
+++ b/uk/main.lang
@@ -114,6 +114,11 @@ Firefox є неприбутковим, некорпоративним, безк�
 Зв’язок з нами
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Інші мови:
 
@@ -294,7 +299,12 @@ Firefox для мобільних пристроїв
 Приватність
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Частини цього вмісту створені учасниками проекту mozilla.org ©1998–%(current_year)s. Вміст доступний на умовах <a href="%(url)s">ліцензії Creative Commons</a>.
 

--- a/uk/main.lang
+++ b/uk/main.lang
@@ -301,7 +301,7 @@ Firefox для мобільних пристроїв
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Частини цього вмісту створені учасниками проекту mozilla.org ©1998–%(current_year)s. Вміст доступний на умовах <a href="%(url)s">ліцензії Creative Commons</a>.
+Частини цього вмісту створені учасниками проекту mozilla.org ©1998–%(current_year)s. Вміст доступний на умовах <a rel="license" href="%(url)s">ліцензії Creative Commons</a>.
 
 
 # Previous footer string

--- a/ur/main.lang
+++ b/ur/main.lang
@@ -114,6 +114,11 @@
 ہم سے رابطہ کریں
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 دیگر زبانیں
 
@@ -294,7 +299,12 @@ MPEG-4 فارمیٹ
 نجی نوعیت
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 اس مواد کے کچھ حصےذاتی mozilla.org معاونین کے جانب سے © 1998 تا %(current_year)s ہیں۔ مواد <a href="%(url)s">Creative Commons لائسنس</a> کے تحت دستیاب ہے۔
 

--- a/ur/main.lang
+++ b/ur/main.lang
@@ -301,7 +301,7 @@ MPEG-4 فارمیٹ
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-اس مواد کے کچھ حصےذاتی mozilla.org معاونین کے جانب سے © 1998 تا %(current_year)s ہیں۔ مواد <a href="%(url)s">Creative Commons لائسنس</a> کے تحت دستیاب ہے۔
+اس مواد کے کچھ حصےذاتی mozilla.org معاونین کے جانب سے © 1998 تا %(current_year)s ہیں۔ مواد <a rel="license" href="%(url)s">Creative Commons لائسنس</a> کے تحت دستیاب ہے۔
 
 
 # Previous footer string

--- a/ur/main.lang
+++ b/ur/main.lang
@@ -301,7 +301,7 @@ MPEG-4 فارمیٹ
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+اس مواد کے کچھ حصےذاتی mozilla.org معاونین کے جانب سے © 1998 تا %(current_year)s ہیں۔ مواد <a href="%(url)s">Creative Commons لائسنس</a> کے تحت دستیاب ہے۔
 
 
 # Previous footer string

--- a/uz/main.lang
+++ b/uz/main.lang
@@ -301,7 +301,7 @@ Maxfiylik
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Ushbu tarkib qismlari mozilla.org ishtirokchilari tomonidan ©1998–%(current_year)sda tuzilgan. Tarkib <a href="%(url)s">Creative Commons</a> litsenziyasi shartlari asosida mavjud.
+Ushbu tarkib qismlari mozilla.org ishtirokchilari tomonidan ©1998–%(current_year)sda tuzilgan. Tarkib <a rel="license" href="%(url)s">Creative Commons</a> litsenziyasi shartlari asosida mavjud.
 
 
 # Previous footer string

--- a/uz/main.lang
+++ b/uz/main.lang
@@ -301,7 +301,7 @@ Maxfiylik
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Ushbu tarkib qismlari mozilla.org ishtirokchilari tomonidan ©1998–%(current_year)sda tuzilgan. Tarkib <a href="%(url)s">Creative Commons</a> litsenziyasi shartlari asosida mavjud.
 
 
 # Previous footer string

--- a/uz/main.lang
+++ b/uz/main.lang
@@ -114,6 +114,11 @@ Matbuot markazi
 Biz bilan bog‘lanish
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Boshqa tillar:
 
@@ -294,7 +299,12 @@ Hoziroq yangilang
 Maxfiylik
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Ushbu tarkib qismlari mozilla.org ishtirokchilari tomonidan ©1998–%(current_year)sda tuzilgan. Tarkib <a href="%(url)s">Creative Commons</a> litsenziyasi shartlari asosida mavjud.
 

--- a/vi/main.lang
+++ b/vi/main.lang
@@ -301,7 +301,7 @@ Riêng tư
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Một phần nội dung này được giữ bản quyền ©1998–%(current_year)s bởi từng cộng tác viên của mozilla.org độc lập. Nội dung được phát hành với <a href="%(url)s">giấy phép Creative Commons</a>.
 
 
 # Previous footer string

--- a/vi/main.lang
+++ b/vi/main.lang
@@ -114,6 +114,11 @@ Dành cho báo giới
 Liên hệ
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Ngôn ngữ khác:
 
@@ -294,7 +299,12 @@ Cập nhật ngay
 Riêng tư
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Một phần nội dung này được giữ bản quyền ©1998–%(current_year)s bởi từng cộng tác viên của mozilla.org độc lập. Nội dung được phát hành với <a href="%(url)s">giấy phép Creative Commons</a>.
 

--- a/vi/main.lang
+++ b/vi/main.lang
@@ -301,7 +301,7 @@ Riêng tư
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Một phần nội dung này được giữ bản quyền ©1998–%(current_year)s bởi từng cộng tác viên của mozilla.org độc lập. Nội dung được phát hành với <a href="%(url)s">giấy phép Creative Commons</a>.
+Một phần nội dung này được giữ bản quyền ©1998–%(current_year)s bởi từng cộng tác viên của mozilla.org độc lập. Nội dung được phát hành với <a rel="license" href="%(url)s">giấy phép Creative Commons</a>.
 
 
 # Previous footer string

--- a/wo/main.lang
+++ b/wo/main.lang
@@ -301,7 +301,7 @@ Dundu biir
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Yenn wàll ci ëmbiit yi, ay dollikati ©1998–%(current_year)s yu mozilla.org lañu. Ëmbiit bi jàppandi na <a href="%(url)s">Sañ-sañu Bokk Defar</a>.
+Yenn wàll ci ëmbiit yi, ay dollikati ©1998–%(current_year)s yu mozilla.org lañu. Ëmbiit bi jàppandi na <a rel="license" href="%(url)s">Sañ-sañu Bokk Defar</a>.
 
 
 # Previous footer string

--- a/wo/main.lang
+++ b/wo/main.lang
@@ -114,6 +114,11 @@ Barabu Peres
 Jokkoo ak Nun
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Yeneen làkk:
 
@@ -294,7 +299,12 @@ Yeesal leegi
 Dundu biir
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Yenn wàll ci ëmbiit yi, ay dollikati ©1998–%(current_year)s yu mozilla.org lañu. Ëmbiit bi jàppandi na <a href="%(url)s">Sañ-sañu Bokk Defar</a>.
 

--- a/wo/main.lang
+++ b/wo/main.lang
@@ -301,7 +301,7 @@ Dundu biir
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Yenn wàll ci ëmbiit yi, ay dollikati ©1998–%(current_year)s yu mozilla.org lañu. Ëmbiit bi jàppandi na <a href="%(url)s">Sañ-sañu Bokk Defar</a>.
 
 
 # Previous footer string

--- a/xh/main.lang
+++ b/xh/main.lang
@@ -301,7 +301,7 @@ Okwabucala
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Iinxalenye zesi siqulatho zi- ©1998–%(current_year)s ziyilwe ngabanikeli be-mozilla.org. Umba ofumanekayo phantsi <a href="%(url)s">kwelayisenisi ye-Creative Commons</a>.
+Iinxalenye zesi siqulatho zi- ©1998–%(current_year)s ziyilwe ngabanikeli be-mozilla.org. Umba ofumanekayo phantsi <a rel="license" href="%(url)s">kwelayisenisi ye-Creative Commons</a>.
 
 
 # Previous footer string

--- a/xh/main.lang
+++ b/xh/main.lang
@@ -301,7 +301,7 @@ Okwabucala
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Iinxalenye zesi siqulatho zi- ©1998–%(current_year)s ziyilwe ngabanikeli be-mozilla.org. Umba ofumanekayo phantsi <a href="%(url)s">kwelayisenisi ye-Creative Commons</a>.
 
 
 # Previous footer string

--- a/xh/main.lang
+++ b/xh/main.lang
@@ -114,6 +114,11 @@ Iziko leendaba
 Qhagamshelana nathi
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Ezinye iilwimi:
 
@@ -294,7 +299,12 @@ Hlaziya ngoku
 Okwabucala
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Iinxalenye zesi siqulatho zi- ©1998–%(current_year)s ziyilwe ngabanikeli be-mozilla.org. Umba ofumanekayo phantsi <a href="%(url)s">kwelayisenisi ye-Creative Commons</a>.
 

--- a/zam/main.lang
+++ b/zam/main.lang
@@ -114,6 +114,11 @@ Press Center
 Contact Us
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Mtá thíb diiste:
 
@@ -294,7 +299,12 @@ Líy kúb nal
 Lut ta güiy
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 

--- a/zam/main.lang
+++ b/zam/main.lang
@@ -301,7 +301,7 @@ Lut ta güiy
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/zam/main.lang
+++ b/zam/main.lang
@@ -301,7 +301,7 @@ Lut ta güiy
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/zh-CN/main.lang
+++ b/zh-CN/main.lang
@@ -301,7 +301,7 @@ Firefox 移动版
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+这些内容的部分内容系 mozilla.org 志愿者个人版权所有（©1998–%(current_year)s）。内容可按<a href="%(url)s">知识共享许可协议</a>使用。
 
 
 # Previous footer string

--- a/zh-CN/main.lang
+++ b/zh-CN/main.lang
@@ -114,6 +114,11 @@ Firefox 是非营利、无企业背景、无妥协的。选择 Firefox 不仅是
 联系我们
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 其他语言
 
@@ -294,7 +299,12 @@ Firefox 移动版
 隐私
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 这些内容的部分内容系 mozilla.org 志愿者个人版权所有（©1998–%(current_year)s）。内容可按<a href="%(url)s">知识共享许可协议</a>使用。
 

--- a/zh-CN/main.lang
+++ b/zh-CN/main.lang
@@ -301,7 +301,7 @@ Firefox 移动版
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-这些内容的部分内容系 mozilla.org 志愿者个人版权所有（©1998–%(current_year)s）。内容可按<a href="%(url)s">知识共享许可协议</a>使用。
+这些内容的部分内容系 mozilla.org 志愿者个人版权所有（©1998–%(current_year)s）。内容可按<a rel="license" href="%(url)s">知识共享许可协议</a>使用。
 
 
 # Previous footer string

--- a/zh-TW/main.lang
+++ b/zh-TW/main.lang
@@ -114,6 +114,11 @@ Firefox 非營利、非商業、永不妥協。選擇 Firefox 不只是選擇一
 聯絡我們
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 其他語言：
 
@@ -294,7 +299,12 @@ Firefox 行動版
 隱私權
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 本頁的部分內容著作權為 ©1998–%(current_year)s 由個別 mozilla.org 貢獻者所有，使用 <a href="%(url)s">創用 CC 授權條款</a> 進行授權。
 

--- a/zh-TW/main.lang
+++ b/zh-TW/main.lang
@@ -301,7 +301,7 @@ Firefox 行動版
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+本頁的部分內容著作權為 ©1998–%(current_year)s 由個別 mozilla.org 貢獻者所有，使用 <a href="%(url)s">創用 CC 授權條款</a> 進行授權。
 
 
 # Previous footer string

--- a/zh-TW/main.lang
+++ b/zh-TW/main.lang
@@ -301,7 +301,7 @@ Firefox 行動版
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-本頁的部分內容著作權為 ©1998–%(current_year)s 由個別 mozilla.org 貢獻者所有，使用 <a href="%(url)s">創用 CC 授權條款</a> 進行授權。
+本頁的部分內容著作權為 ©1998–%(current_year)s 由個別 mozilla.org 貢獻者所有，使用 <a rel="license" href="%(url)s">創用 CC 授權條款</a> 進行授權。
 
 
 # Previous footer string

--- a/zu/main.lang
+++ b/zu/main.lang
@@ -301,7 +301,7 @@ Ukugcinwa kuyimfihlo
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Izingxenye zalokhu okuqukethwe ©1998–%(current_year)s kwenziwe ngabe-mozilla.org. Okuqukethwe kuyatholakala ngaphansi kwe<a href="%(url)s">Creative Commons license</a>.
+Izingxenye zalokhu okuqukethwe ©1998–%(current_year)s kwenziwe ngabe-mozilla.org. Okuqukethwe kuyatholakala ngaphansi kwe<a rel="license" href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string

--- a/zu/main.lang
+++ b/zu/main.lang
@@ -114,6 +114,11 @@ Isizinda Sabezindaba
 Xhumana nathi
 
 
+# Used in new footer to switch the language of the page
+;Language
+Language
+
+
 ;Other languages:
 Ezinye izilimi:
 
@@ -294,7 +299,12 @@ Vuselela manje
 Ukugcinwa kuyimfihlo
 
 
-# Footer string
+# New footer string
+;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+
+
+# Previous footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a href="%(url)s">Creative Commons license</a>.
 Izingxenye zalokhu okuqukethwe ©1998–%(current_year)s kwenziwe ngabe-mozilla.org. Okuqukethwe kuyatholakala ngaphansi kwe<a href="%(url)s">Creative Commons license</a>.
 

--- a/zu/main.lang
+++ b/zu/main.lang
@@ -301,7 +301,7 @@ Ukugcinwa kuyimfihlo
 
 # New footer string
 ;Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
-Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel="license" href="%(url)s">Creative Commons license</a>.
+Izingxenye zalokhu okuqukethwe ©1998–%(current_year)s kwenziwe ngabe-mozilla.org. Okuqukethwe kuyatholakala ngaphansi kwe<a href="%(url)s">Creative Commons license</a>.
 
 
 # Previous footer string


### PR DESCRIPTION
Added "Language" and the license notice: the text is identical to the previous translation, only a `rel="license"` added to the HTML.