### PR TITLE
Deactivate sendto.lang for tl

### DIFF
--- a/tl/firefox/sendto.lang
+++ b/tl/firefox/sendto.lang
@@ -1,4 +1,3 @@
-## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/styleguide/docs/send-to-device/
 ## NOTE: Add ?geo=us to the URL (https://www-dev.allizom.org/styleguide/docs/send-to-device/) to display the SMS strings.
 


### PR DESCRIPTION
We are about to enable "tl" on www.m.o and this active langfile causes some untranslated pages to be available.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1482045