### PR TITLE
Patch untranslated "Restart Tour" button

### DIFF
--- a/ach/firefox/tracking-protection-tour.lang
+++ b/ach/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Restart tour
 
 
 ;Restart Tour
-Restart Tour
+Restart tour
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/ach/firefox/tracking-protection-tour.lang
+++ b/ach/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 Restart tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/af/firefox/tracking-protection-tour.lang
+++ b/af/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Herbegin toer
 
 
 ;Restart Tour
-Restart Tour
+Herbegin toer
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/af/firefox/tracking-protection-tour.lang
+++ b/af/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 Herbegin toer
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/am/firefox/tracking-protection-tour.lang
+++ b/am/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Restart tour
 
 
 ;Restart Tour
-Restart Tour
+Restart tour
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/am/firefox/tracking-protection-tour.lang
+++ b/am/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 Restart tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/an/firefox/tracking-protection-tour.lang
+++ b/an/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Tornar a empecipiar a gambadeta
 
 
 ;Restart Tour
-Restart Tour
+Tornar a empecipiar a gambadeta
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/an/firefox/tracking-protection-tour.lang
+++ b/an/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 Tornar a empecipiar a gambadeta
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/ar/firefox/tracking-protection-tour.lang
+++ b/ar/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+أعد الجولة مرة أخرى
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/ar/firefox/tracking-protection-tour.lang
+++ b/ar/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 أعد الجولة مرة أخرى
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/as/firefox/tracking-protection-tour.lang
+++ b/as/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Restart tour
 
 
 ;Restart Tour
-Restart Tour
+Restart tour
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/as/firefox/tracking-protection-tour.lang
+++ b/as/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 Restart tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/ast/firefox/tracking-protection-tour.lang
+++ b/ast/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Reaniciar percorríu
 
 
 ;Restart Tour
-Restart Tour
+Reaniciar percorríu
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/ast/firefox/tracking-protection-tour.lang
+++ b/ast/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 Reaniciar percorríu
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/az/firefox/tracking-protection-tour.lang
+++ b/az/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Məzmun Əngəlləmə haqqında oxuduğunuz üçün təşəkkürlər.
 Turu təkrar başlat
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 İzlənmə Qorumasının üstünlükləri artıq məzmun əngəlləmənin içindədir. Qalxanı gördüyünüzdə məzmun əngəlləmə aktiv olur.
 

--- a/az/firefox/tracking-protection-tour.lang
+++ b/az/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Turu təkrar başlat
 
 
 ;Restart Tour
-Restart Tour
+Turu təkrar başlat
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/azz/firefox/tracking-protection-tour.lang
+++ b/azz/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 Oksepa maj peua paxalolis
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/azz/firefox/tracking-protection-tour.lang
+++ b/azz/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Oksepa maj peua paxalolis
 
 
 ;Restart Tour
-Restart Tour
+Oksepa maj peua paxalolis
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/be/firefox/tracking-protection-tour.lang
+++ b/be/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@
 
 
 ;Restart Tour
-Restart Tour
+Пачаць тур ізноў
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/be/firefox/tracking-protection-tour.lang
+++ b/be/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@
 Пачаць тур ізноў
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Паляпшэнне прыватнасці пры ахове ад сачэння цяпер ёсць часткаю функцыі блакавання змесціва. Калі вы бачыце гэты шчыт, задзейнічана блакаванне змесціва.
 

--- a/bg/firefox/tracking-protection-tour.lang
+++ b/bg/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+Започване отново
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/bg/firefox/tracking-protection-tour.lang
+++ b/bg/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Thanks for learning about Content Blocking.
 Започване отново
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/bn-BD/firefox/tracking-protection-tour.lang
+++ b/bn-BD/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 সফর পুনরারম্ভ করুন
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/bn-BD/firefox/tracking-protection-tour.lang
+++ b/bn-BD/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+সফর পুনরারম্ভ করুন
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/bn-IN/firefox/tracking-protection-tour.lang
+++ b/bn-IN/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+অবিলম্বে পুনরারম্ভ করুন
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/bn-IN/firefox/tracking-protection-tour.lang
+++ b/bn-IN/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 অবিলম্বে পুনরারম্ভ করুন
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/br/firefox/tracking-protection-tour.lang
+++ b/br/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 Adstagañ gant an droiad
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/br/firefox/tracking-protection-tour.lang
+++ b/br/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Adstagañ gant an droiad
 
 
 ;Restart Tour
-Restart Tour
+Adstagañ gant an droiad
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/bs/firefox/tracking-protection-tour.lang
+++ b/bs/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 Započnite obilazak ponovo
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/bs/firefox/tracking-protection-tour.lang
+++ b/bs/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Započnite obilazak ponovo
 
 
 ;Restart Tour
-Restart Tour
+Započnite obilazak ponovo
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/ca/firefox/tracking-protection-tour.lang
+++ b/ca/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Thanks for learning about Content Blocking.
 Torna a començar
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/ca/firefox/tracking-protection-tour.lang
+++ b/ca/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Torna a començar
 
 
 ;Restart Tour
-Restart Tour
+Torna a començar
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/cak/firefox/tracking-protection-tour.lang
+++ b/cak/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Titikirisäx chik b'eyajnem
 
 
 ;Restart Tour
-Restart Tour
+Titikirisäx chik b'eyajnem
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/cak/firefox/tracking-protection-tour.lang
+++ b/cak/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Matyox ruma nawajo' nawetamaj pa ruwi' ri Ruq'atoj Rupam.
 Titikirisäx chik b'eyajnem
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Ri ichinanem taq rutzil ri Chajinïk chuwäch Ojqanem xa e jun peraj richin yeq'at rupam. Toq xtatz'et ri pokob', tzijïl ri ruq'atik rupam.
 

--- a/crh/firefox/tracking-protection-tour.lang
+++ b/crh/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Restart tour
 
 
 ;Restart Tour
-Restart Tour
+Restart tour
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/crh/firefox/tracking-protection-tour.lang
+++ b/crh/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 Restart tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/cs/firefox/tracking-protection-tour.lang
+++ b/cs/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Děkujeme za váš zájem o funkci blokování obsahu.
 Znovu spustit průvodce
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Nová funkce blokování obsahu přejímá výhody i z dřívější ochrany proti sledování. Pokud vidíte ikonu štítu v adresním řádku, blokování obsahu s ochranou proti sledování je zapnuté.
 

--- a/cs/firefox/tracking-protection-tour.lang
+++ b/cs/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Znovu spustit průvodce
 
 
 ;Restart Tour
-Restart Tour
+Znovu spustit průvodce
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/cy/firefox/tracking-protection-tour.lang
+++ b/cy/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Ailgychwyn y cyflwyniad
 
 
 ;Restart Tour
-Restart Tour
+Ailgychwyn y cyflwyniad
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/cy/firefox/tracking-protection-tour.lang
+++ b/cy/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Diolch am ddysgu am Rwystro Cynnwys.
 Ailgychwyn y cyflwyniad
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Mae manteisio preifatrwydd Diogelu rhag Tracio yn ddim ond un elfen o rwystro cynnwys. Pan fyddwch yn gweld y darian, mae rhwystro cynnwys ymlaen.
 

--- a/da/firefox/tracking-protection-tour.lang
+++ b/da/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Tak for din interesse for blokering af indhold.
 Genstart rundvisningen
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Beskyttelse mod sporing er nu en del af blokering af indhold. Blokering af indhold er slået til, når skjoldet er synligt.
 

--- a/da/firefox/tracking-protection-tour.lang
+++ b/da/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Genstart rundvisningen
 
 
 ;Restart Tour
-Restart Tour
+Genstart rundvisningen
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/de/firefox/tracking-protection-tour.lang
+++ b/de/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Rundgang erneut starten
 
 
 ;Restart Tour
-Restart Tour
+Rundgang erneut starten
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/de/firefox/tracking-protection-tour.lang
+++ b/de/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Danke, dass Du Dich für Inhaltsblockierung interessierst.
 Rundgang erneut starten
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Die Vorteile des Schutzes vor Aktivitätenverfolgung sind jetzt nur ein Teil der Inhaltsblockierung. Wenn Du den Schild siehst, ist die Inhaltsblockierung aktiviert.
 

--- a/dsb/firefox/tracking-protection-tour.lang
+++ b/dsb/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Turu znowego startowaś
 
 
 ;Restart Tour
-Restart Tour
+Turu znowego startowaś
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/dsb/firefox/tracking-protection-tour.lang
+++ b/dsb/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Wjeliki źěk, až se za blokěrowanje wopśimjeśa zajmujośo.
 Turu znowego startowaś
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Lěpšyny priwatnosći slědujucego šćita su něnto jano jaden źěl blokěrowanja wopśimjeśa. Gaž šćit wiźiśo, jo blokěrowanje wopśimjeśa zmóžnjone.
 

--- a/el/firefox/tracking-protection-tour.lang
+++ b/el/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+Επανεκκίνηση οδηγού
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/el/firefox/tracking-protection-tour.lang
+++ b/el/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Thanks for learning about Content Blocking.
 Επανεκκίνηση οδηγού
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/en-CA/firefox/tracking-protection-tour.lang
+++ b/en-CA/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Restart tour {ok}
 
 
 ;Restart Tour
-Restart Tour
+Restart tour {ok}
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/en-CA/firefox/tracking-protection-tour.lang
+++ b/en-CA/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Thanks for learning about Content Blocking. {ok}
 Restart tour {ok}
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on. {ok}
 

--- a/en-GB/firefox/tracking-protection-tour.lang
+++ b/en-GB/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Restart tour {ok}
 
 
 ;Restart Tour
-Restart Tour
+Restart tour {ok}
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/en-GB/firefox/tracking-protection-tour.lang
+++ b/en-GB/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 Restart tour {ok}
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/en-US/firefox/tracking-protection-tour.lang
+++ b/en-US/firefox/tracking-protection-tour.lang
@@ -170,6 +170,10 @@ Thanks for learning about Content Blocking.
 Restart tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/en-ZA/firefox/tracking-protection-tour.lang
+++ b/en-ZA/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Restart tour
 
 
 ;Restart Tour
-Restart Tour
+Restart tour
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/en-ZA/firefox/tracking-protection-tour.lang
+++ b/en-ZA/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 Restart tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/eo/firefox/tracking-protection-tour.lang
+++ b/eo/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Rekomenci prezenton
 
 
 ;Restart Tour
-Restart Tour
+Rekomenci prezenton
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/eo/firefox/tracking-protection-tour.lang
+++ b/eo/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 Rekomenci prezenton
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/es-AR/firefox/tracking-protection-tour.lang
+++ b/es-AR/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Reiniciar el tour
 
 
 ;Restart Tour
-Restart Tour
+Reiniciar el tour
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/es-AR/firefox/tracking-protection-tour.lang
+++ b/es-AR/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Gracias por aprender acerca del Bloqueo de contenido.
 Reiniciar el tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Los beneficios de la privacidad de la Protección de rastreo son ahora solo una parte del Bloqueo de contenido. Cuando veas el escudo, el bloqueo de contenido está activo.
 

--- a/es-CL/firefox/tracking-protection-tour.lang
+++ b/es-CL/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Gracias por aprender acerca del bloqueo de contenido.
 Reiniciar tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/es-CL/firefox/tracking-protection-tour.lang
+++ b/es-CL/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Reiniciar tour
 
 
 ;Restart Tour
-Restart Tour
+Reiniciar tour
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/es-ES/firefox/tracking-protection-tour.lang
+++ b/es-ES/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Reiniciar visita
 
 
 ;Restart Tour
-Restart Tour
+Reiniciar visita
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/es-ES/firefox/tracking-protection-tour.lang
+++ b/es-ES/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Gracias por interesarte sobre el bloqueo de contenido.
 Reiniciar visita
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Los beneficios para la privacidad de la protección contra el rastreo son solo una parte de los que ofrece el bloqueo de contenido. Cuando ves el escudo, el bloqueo de contenido está activado.
 

--- a/es-MX/firefox/tracking-protection-tour.lang
+++ b/es-MX/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Gracias por querer aprender más sobre el bloqueo de contenido.
 Reiniciar recorrido
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/es-MX/firefox/tracking-protection-tour.lang
+++ b/es-MX/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Reiniciar recorrido
 
 
 ;Restart Tour
-Restart Tour
+Reiniciar recorrido
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/et/firefox/tracking-protection-tour.lang
+++ b/et/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Täname, et tundsid huvi sisu blokkimise vastu.
 Taaskäivita tuur
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Jälitamisvastase kaitse privaatsushüved on nüüd vaid osa sisu blokkimisest. Kui näed kilpi, siis on sisu blokkimine lubatud.
 

--- a/et/firefox/tracking-protection-tour.lang
+++ b/et/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Taaskäivita tuur
 
 
 ;Restart Tour
-Restart Tour
+Taaskäivita tuur
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/eu/firefox/tracking-protection-tour.lang
+++ b/eu/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 Berrabiarazi itzulia
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/eu/firefox/tracking-protection-tour.lang
+++ b/eu/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Berrabiarazi itzulia
 
 
 ;Restart Tour
-Restart Tour
+Berrabiarazi itzulia
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/fa/firefox/tracking-protection-tour.lang
+++ b/fa/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+شروع مجدد سیاحت
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/fa/firefox/tracking-protection-tour.lang
+++ b/fa/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 شروع مجدد سیاحت
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/ff/firefox/tracking-protection-tour.lang
+++ b/ff/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Hurmitin njillu
 
 
 ;Restart Tour
-Restart Tour
+Hurmitin njillu
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/ff/firefox/tracking-protection-tour.lang
+++ b/ff/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 Hurmitin njillu
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/fi/firefox/tracking-protection-tour.lang
+++ b/fi/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Esittelyn alkuun
 
 
 ;Restart Tour
-Restart Tour
+Esittelyn alkuun
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/fi/firefox/tracking-protection-tour.lang
+++ b/fi/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Kiitos, että luit sisällön estämisestä.
 Esittelyn alkuun
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Seurannan suojauksen tuomat hyödyt yksityisyydylle ovat nyt vain yksi osa sisällön estosta. Kun näet kilven, sisällön estäminen on käytössä.
 

--- a/fr/firefox/tracking-protection-tour.lang
+++ b/fr/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Merci d’avoir pris le temps d’en apprendre davantage sur le blocage de conte
 Recommencer la visite guidée
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 La protection contre le pistage n’est qu’un des avantages du blocage de contenu pour protéger votre vie privée. Lorsque le bouclier est visible, le blocage de contenu est activé.
 

--- a/fr/firefox/tracking-protection-tour.lang
+++ b/fr/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Recommencer la visite guidée
 
 
 ;Restart Tour
-Restart Tour
+Recommencer la visite guidée
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/fy-NL/firefox/tracking-protection-tour.lang
+++ b/fy-NL/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Rûnlieding opnij starte
 
 
 ;Restart Tour
-Restart Tour
+Rûnlieding opnij starte
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/fy-NL/firefox/tracking-protection-tour.lang
+++ b/fy-NL/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Tank foar it lêzen fan de ynfo oer Ynhâldsblokkearring.
 Rûnlieding opnij starte
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 De privacyfoardielen fan Beskerming tsjin folgjen binne no mar ien ûnderdiel fan ynhâldsblokkearring. As jo it skyldsje sjogge, is ynhâldsblokkearring ynskeakele.
 

--- a/ga-IE/firefox/tracking-protection-tour.lang
+++ b/ga-IE/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 Tosaigh an turas arís
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/ga-IE/firefox/tracking-protection-tour.lang
+++ b/ga-IE/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Tosaigh an turas arís
 
 
 ;Restart Tour
-Restart Tour
+Tosaigh an turas arís
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/gd/firefox/tracking-protection-tour.lang
+++ b/gd/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 Tòisich an turas as ùr
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/gd/firefox/tracking-protection-tour.lang
+++ b/gd/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Tòisich an turas as ùr
 
 
 ;Restart Tour
-Restart Tour
+Tòisich an turas as ùr
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/gl/firefox/tracking-protection-tour.lang
+++ b/gl/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Reiniciar visita guiada
 
 
 ;Restart Tour
-Restart Tour
+Reiniciar visita guiada
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/gl/firefox/tracking-protection-tour.lang
+++ b/gl/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Grazas por informarse sobre o bloqueo de contido.
 Reiniciar visita guiada
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 A protección contra o seguimento é só un dos beneficios do bloqueo de contido para protexer a súa privacidade. Cando vexa o escudo, o bloqueo de contido está activado.
 

--- a/gn/firefox/tracking-protection-tour.lang
+++ b/gn/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Aguyje eikuaa haguére tetepy jejoko rehegua.
 Eho ñepyrũjeýpe
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Ñemigua Tapykueho mo’ãha mba’eporã ko’ág̃ rupi ha’e tetepy jejoko vore. Ehechávo ta’anga’i, pe tetepy jejoko hendýma.
 

--- a/gn/firefox/tracking-protection-tour.lang
+++ b/gn/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Eho ñepyrũjeýpe
 
 
 ;Restart Tour
-Restart Tour
+Eho ñepyrũjeýpe
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/gu-IN/firefox/tracking-protection-tour.lang
+++ b/gu-IN/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Content blocking can keep parts of pages or entire pages from loading.
 પુનઃપ્રારંભ કરો પ્રવાસ
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 ટ્રેકિંગ સુરક્ષાના ગોપનીયતા લાભો હવે સામગ્રી અવરોધિત કરવાનું માત્ર એક ભાગ છે. જ્યારે તમે કવચ જુઓ છો, ત્યારે સામગ્રી અવરોધિત થાય છે.
 

--- a/gu-IN/firefox/tracking-protection-tour.lang
+++ b/gu-IN/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Content blocking can keep parts of pages or entire pages from loading.
 
 
 ;Restart Tour
-Restart Tour
+પુનઃપ્રારંભ કરો પ્રવાસ
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/he/firefox/tracking-protection-tour.lang
+++ b/he/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 התחלת הסיור מחדש
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/he/firefox/tracking-protection-tour.lang
+++ b/he/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+התחלת הסיור מחדש
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/hi-IN/firefox/tracking-protection-tour.lang
+++ b/hi-IN/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Firefox में नया: सामग्री ब्लॉकिंग
 
 
 ;Restart Tour
-Restart Tour
+टूर फिर से प्रारंभ करें
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/hi-IN/firefox/tracking-protection-tour.lang
+++ b/hi-IN/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Firefox में नया: सामग्री ब्लॉकिंग
 टूर फिर से प्रारंभ करें
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 ट्रैकिंग सुरक्षा के गोपनीयता से जुड़े फ़ायदे अब सामग्री ब्लॉकिंग का केवल एक हिस्सा है। जब आप शील्ड देखते हैं, जब आप शील्ड देखते हैं, तब सामग्री ब्लॉकिंग चालू रहता है।
 

--- a/hr/firefox/tracking-protection-tour.lang
+++ b/hr/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Restart tour
 
 
 ;Restart Tour
-Restart Tour
+Restart tour
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/hr/firefox/tracking-protection-tour.lang
+++ b/hr/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 Restart tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/hsb/firefox/tracking-protection-tour.lang
+++ b/hsb/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Turu znowa startować
 
 
 ;Restart Tour
-Restart Tour
+Turu znowa startować
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/hsb/firefox/tracking-protection-tour.lang
+++ b/hsb/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Wulki dźak, zo so za blokowanje wobsaha zajimujeće.
 Turu znowa startować
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Lěpšiny priwatnosće slědowanskeho škita su nětko jenož jedyn dźěl blokowanja wobsaha. Hdyž tarč widźiće, je blokowanje wobsaha zmóžnjene.
 

--- a/hu/firefox/tracking-protection-tour.lang
+++ b/hu/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Bemutató újrakezdése
 
 
 ;Restart Tour
-Restart Tour
+Bemutató újrakezdése
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/hu/firefox/tracking-protection-tour.lang
+++ b/hu/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Köszönjük, hogy többet megtudott a tartalomblokkolásról.
 Bemutató újrakezdése
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 A követésvédelem adatvédelmi előnyei csak egy része a tartalomblokkolásnak. Ha a pajzsot látja, akkor működik a tartalomblokkolás.
 

--- a/hy-AM/firefox/tracking-protection-tour.lang
+++ b/hy-AM/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 Վերսկսել շրջայցը
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/hy-AM/firefox/tracking-protection-tour.lang
+++ b/hy-AM/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+Վերսկսել շրջայցը
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/ia/firefox/tracking-protection-tour.lang
+++ b/ia/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Reinitia le tour
 
 
 ;Restart Tour
-Restart Tour
+Reinitia le tour
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/ia/firefox/tracking-protection-tour.lang
+++ b/ia/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Gratias pro apprender circa Bloco de contentos.
 Reinitia le tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Le beneficios del confidentialitate del Protection del traciamento es ora parte integrante del bloco de contentos. Quando tu vide le escudo, le bloco del contentos es active.
 

--- a/id/firefox/tracking-protection-tour.lang
+++ b/id/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Terima kasih telah mempelajari Pemblokiran Konten.
 Ulangi tur
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/id/firefox/tracking-protection-tour.lang
+++ b/id/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Ulangi tur
 
 
 ;Restart Tour
-Restart Tour
+Ulangi tur
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/is/firefox/tracking-protection-tour.lang
+++ b/is/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 Byrja aftur á skoðunarferð
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/is/firefox/tracking-protection-tour.lang
+++ b/is/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Byrja aftur á skoðunarferð
 
 
 ;Restart Tour
-Restart Tour
+Byrja aftur á skoðunarferð
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/it/firefox/tracking-protection-tour.lang
+++ b/it/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Ripeti la panoramica dall’inizio
 
 
 ;Restart Tour
-Restart Tour
+Ripeti la panoramica dall’inizio
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/it/firefox/tracking-protection-tour.lang
+++ b/it/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Grazie per aver seguito la panoramica sul blocco contenuti.
 Ripeti la panoramica dall’inizio
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Tutti i vantaggi per la privacy offerti dalla protezione antitracciamento sono ora parte integrante del blocco contenuti. Quando viene visualizzato lo scudo, il blocco contenuti è attivo.
 

--- a/ja/firefox/tracking-protection-tour.lang
+++ b/ja/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Thanks for learning about Content Blocking.
 ツアーをもう一度見る
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/ja/firefox/tracking-protection-tour.lang
+++ b/ja/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+ツアーをもう一度見る
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/ka/firefox/tracking-protection-tour.lang
+++ b/ka/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Firefox-ის შიგთავსის შეზღუდვა
 
 
 ;Restart Tour
-Restart Tour
+გზამკვლევის გამეორება
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/ka/firefox/tracking-protection-tour.lang
+++ b/ka/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Firefox-ის შიგთავსის შეზღუდვა
 გზამკვლევის გამეორება
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 თვალთვალისგან დაცვით უზრუნველყოფილი პირადი მონაცემების უსაფრთხოება, ახლა უკვე მხოლოდ ცალკეულ ნაწილს წარმოადგენს შიგთავსის შეზღუდვის. როდესაც დაინახავთ ფარს ეს ნიშნავს, რომ შიგთავსის შეზღუდვა ამოქმედებულია.
 

--- a/kab/firefox/tracking-protection-tour.lang
+++ b/kab/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Senker tikelt nniḍen tirza
 
 
 ;Restart Tour
-Restart Tour
+Senker tikelt nniḍen tirza
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/kab/firefox/tracking-protection-tour.lang
+++ b/kab/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Tanemmirt ɣef tmsuni n usewḥel n ugbur.
 Senker tikelt nniḍen tirza
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Ammesten n usfuɣel itteka tura deg usewḥel n ugbur. Mi ara twaliḍ urti, asewḥel n ugbur irmed.
 

--- a/kk/firefox/tracking-protection-tour.lang
+++ b/kk/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 Турды қайта іске қосу
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/kk/firefox/tracking-protection-tour.lang
+++ b/kk/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+Турды қайта іске қосу
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/km/firefox/tracking-protection-tour.lang
+++ b/km/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Restart tour
 
 
 ;Restart Tour
-Restart Tour
+Restart tour
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/km/firefox/tracking-protection-tour.lang
+++ b/km/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 Restart tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/kn/firefox/tracking-protection-tour.lang
+++ b/kn/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+ಪ್ರವಾಸವನ್ನು ಮತ್ತೆ ಆರಂಭಿಸು
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/kn/firefox/tracking-protection-tour.lang
+++ b/kn/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 ಪ್ರವಾಸವನ್ನು ಮತ್ತೆ ಆರಂಭಿಸು
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/ko/firefox/tracking-protection-tour.lang
+++ b/ko/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 다시 하기
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/ko/firefox/tracking-protection-tour.lang
+++ b/ko/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+다시 하기
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/lij/firefox/tracking-protection-tour.lang
+++ b/lij/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 Amia torna
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/lij/firefox/tracking-protection-tour.lang
+++ b/lij/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Amia torna
 
 
 ;Restart Tour
-Restart Tour
+Amia torna
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/lo/firefox/tracking-protection-tour.lang
+++ b/lo/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 ເລີ່ມການທ່ອງທ່ຽວໃຫມ່
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/lo/firefox/tracking-protection-tour.lang
+++ b/lo/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+ເລີ່ມການທ່ອງທ່ຽວໃຫມ່
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/lt/firefox/tracking-protection-tour.lang
+++ b/lt/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Kartoti pristatymą
 
 
 ;Restart Tour
-Restart Tour
+Kartoti pristatymą
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/lt/firefox/tracking-protection-tour.lang
+++ b/lt/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Dėkojame, kad susipažinote su turinio blokavimu.
 Kartoti pristatymą
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Apsauga nuo sekimo ir jos suteikiamas papildomas privatumas – tai tik dalis turinio blokavimo. Kai matote šį skydą, jis reiškia, jog dalis turinio yra blokuojama.
 

--- a/ltg/firefox/tracking-protection-tour.lang
+++ b/ltg/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 Sōkt par jaunu
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/ltg/firefox/tracking-protection-tour.lang
+++ b/ltg/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Sōkt par jaunu
 
 
 ;Restart Tour
-Restart Tour
+Sōkt par jaunu
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/lv/firefox/tracking-protection-tour.lang
+++ b/lv/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Atsākt tūri
 
 
 ;Restart Tour
-Restart Tour
+Atsākt tūri
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/lv/firefox/tracking-protection-tour.lang
+++ b/lv/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 Atsākt tūri
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/mai/firefox/tracking-protection-tour.lang
+++ b/mai/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Restart tour
 
 
 ;Restart Tour
-Restart Tour
+Restart tour
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/mai/firefox/tracking-protection-tour.lang
+++ b/mai/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 Restart tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/mk/firefox/tracking-protection-tour.lang
+++ b/mk/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Restart tour
 
 
 ;Restart Tour
-Restart Tour
+Restart tour
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/mk/firefox/tracking-protection-tour.lang
+++ b/mk/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 Restart tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/ml/firefox/tracking-protection-tour.lang
+++ b/ml/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+വീണ്ടും നോക്കു
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/ml/firefox/tracking-protection-tour.lang
+++ b/ml/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 വീണ്ടും നോക്കു
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/mr/firefox/tracking-protection-tour.lang
+++ b/mr/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Thanks for learning about Content Blocking.
 दौरा पुन्हा सुरु करा
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/mr/firefox/tracking-protection-tour.lang
+++ b/mr/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+दौरा पुन्हा सुरु करा
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/ms/firefox/tracking-protection-tour.lang
+++ b/ms/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Terima kasih kerana belajar perihal Sekatan Kandungan.
 Mula semula panduan ringkas
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Manfaat privasi daripada Perlindungan Penjejakan kini hanya sebahagian sekatan kandungan. Apabila anda melihat perisai, sekatan kandungan sedang aktif.
 

--- a/ms/firefox/tracking-protection-tour.lang
+++ b/ms/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Mula semula panduan ringkas
 
 
 ;Restart Tour
-Restart Tour
+Mula semula panduan ringkas
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/my/firefox/tracking-protection-tour.lang
+++ b/my/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 လှည့်လည်ခြင်းအားပြန်စပါ
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/my/firefox/tracking-protection-tour.lang
+++ b/my/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+လှည့်လည်ခြင်းအားပြန်စပါ
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/nb-NO/firefox/tracking-protection-tour.lang
+++ b/nb-NO/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Thanks for learning about Content Blocking.
 Kjør presentasjonen en gang til
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/nb-NO/firefox/tracking-protection-tour.lang
+++ b/nb-NO/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Kjør presentasjonen en gang til
 
 
 ;Restart Tour
-Restart Tour
+Kjør presentasjonen en gang til
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/ne-NP/firefox/tracking-protection-tour.lang
+++ b/ne-NP/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 भ्रमण पुनः सुरु गर्नुहोस्
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/ne-NP/firefox/tracking-protection-tour.lang
+++ b/ne-NP/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+भ्रमण पुनः सुरु गर्नुहोस्
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/nl/firefox/tracking-protection-tour.lang
+++ b/nl/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Rondleiding opnieuw starten
 
 
 ;Restart Tour
-Restart Tour
+Rondleiding opnieuw starten
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/nl/firefox/tracking-protection-tour.lang
+++ b/nl/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Bedankt voor het lezen van de info over Inhoudsblokkering.
 Rondleiding opnieuw starten
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 De privacyvoordelen van Bescherming tegen volgen zijn nu maar één onderdeel van inhoudsblokkering. Als u het schildje ziet, is inhoudsblokkering ingeschakeld.
 

--- a/nn-NO/firefox/tracking-protection-tour.lang
+++ b/nn-NO/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Køyr presentasjonen ein gong til
 
 
 ;Restart Tour
-Restart Tour
+Køyr presentasjonen ein gong til
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/nn-NO/firefox/tracking-protection-tour.lang
+++ b/nn-NO/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 Køyr presentasjonen ein gong til
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/nv/firefox/tracking-protection-tour.lang
+++ b/nv/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Restart tour
 
 
 ;Restart Tour
-Restart Tour
+Restart tour
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/nv/firefox/tracking-protection-tour.lang
+++ b/nv/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 Restart tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/oc/firefox/tracking-protection-tour.lang
+++ b/oc/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Tornar començar la visita
 
 
 ;Restart Tour
-Restart Tour
+Tornar començar la visita
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/oc/firefox/tracking-protection-tour.lang
+++ b/oc/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 Tornar començar la visita
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/or/firefox/tracking-protection-tour.lang
+++ b/or/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Restart tour
 
 
 ;Restart Tour
-Restart Tour
+Restart tour
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/or/firefox/tracking-protection-tour.lang
+++ b/or/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 Restart tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/pa-IN/firefox/tracking-protection-tour.lang
+++ b/pa-IN/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Content blocking can keep parts of pages or entire pages from loading.
 
 
 ;Restart Tour
-Restart Tour
+ਦੌਰਾ ਮੁੜ-ਚਾਲੂ ਕਰੋ
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/pa-IN/firefox/tracking-protection-tour.lang
+++ b/pa-IN/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Content blocking can keep parts of pages or entire pages from loading.
 ਦੌਰਾ ਮੁੜ-ਚਾਲੂ ਕਰੋ
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 ਟ੍ਰੈਕਿੰਗ ਸੁਰੱਖਿਆ ਦੇ ਗੋਪਨੀਯ ਲਾਭ ਹੁਣ ਸਮਗਰੀ ਬਲੌਕਿੰਗ ਦਾ ਸਿਰਫ਼ ਇਕ ਹਿੱਸਾ ਹਨ। ਜਦੋਂ ਤੁਸੀਂ ਢਾਲ ਦੇਖਦੇ ਹੋ, ਸਮੱਗਰੀ ਨੂੰ ਬਲੌਕ ਕਰਨਾ ਚਾਲੂ ਹੁੰਦਾ ਹੈ।
 

--- a/pai/firefox/tracking-protection-tour.lang
+++ b/pai/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Restart tour
 
 
 ;Restart Tour
-Restart Tour
+Restart tour
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/pai/firefox/tracking-protection-tour.lang
+++ b/pai/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 Restart tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/pl/firefox/tracking-protection-tour.lang
+++ b/pl/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Rozpocznij od nowa
 
 
 ;Restart Tour
-Restart Tour
+Rozpocznij od nowa
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/pl/firefox/tracking-protection-tour.lang
+++ b/pl/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Dziękujemy za poświęcenie chwili na poznanie funkcji blokowania treści.
 Rozpocznij od nowa
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Zwiększona prywatność ochrony przed śledzeniem to teraz tylko jedna część funkcji blokowania treści. Kiedy widoczna jest ikona tarczy, blokowanie treści jest włączone.
 

--- a/pt-BR/firefox/tracking-protection-tour.lang
+++ b/pt-BR/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Reiniciar o tour
 
 
 ;Restart Tour
-Restart Tour
+Reiniciar o tour
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/pt-BR/firefox/tracking-protection-tour.lang
+++ b/pt-BR/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Obrigado por aprender sobre bloqueio de conteúdo.
 Reiniciar o tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Os benefícios de privacidade da proteção contra rastreamento são agora apenas uma parte do bloqueio de conteúdo. Quando você ver o escudo, o bloqueio de conteúdo estará ativado.
 

--- a/pt-PT/firefox/tracking-protection-tour.lang
+++ b/pt-PT/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Obrigado por aprender acerca do Bloqueio de conteúdo.
 Recomeçar a visita
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Os benefícios da Proteção contra monitorização são apenas uma parte do bloqueio de conteúdo. Quando estiver a ver o escudo, o bloqueio de conteúdo está ligado.
 

--- a/pt-PT/firefox/tracking-protection-tour.lang
+++ b/pt-PT/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Recomeçar a visita
 
 
 ;Restart Tour
-Restart Tour
+Recomeçar a visita
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/rm/firefox/tracking-protection-tour.lang
+++ b/rm/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Grazia per l'interess per la bloccada da cuntegn.
 Repeter la tura
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Tut ils avantatgs per la sfera privata che la protecziun cunter il fastizar porscha èn ussa mo ina part da la bloccada da cuntegn. Cura che ti vesas il scut è la bloccada da cuntegn activada.
 

--- a/rm/firefox/tracking-protection-tour.lang
+++ b/rm/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Repeter la tura
 
 
 ;Restart Tour
-Restart Tour
+Repeter la tura
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/ro/firefox/tracking-protection-tour.lang
+++ b/ro/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Blocarea de conținut poate ajuta la încărcarea mai rapidă a paginilor, dar p
 Repornește turul
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Beneficiile pentru confidențialitatea datelor oferite de protecția împotriva urmăririi reprezintă acum doar o parte din blocarea de conținut. Când vezi scutul, blocarea de conținut este activă.
 

--- a/ro/firefox/tracking-protection-tour.lang
+++ b/ro/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Repornește turul
 
 
 ;Restart Tour
-Restart Tour
+Repornește turul
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/ru/firefox/tracking-protection-tour.lang
+++ b/ru/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@
 Повторить тур
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Повышение уровня приватности при Защите от отслеживания является лишь частью работы блокировки содержимого. Когда вы видите значок щита, блокировка содержимого включена.
 

--- a/ru/firefox/tracking-protection-tour.lang
+++ b/ru/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@
 
 
 ;Restart Tour
-Restart Tour
+Повторить тур
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/si/firefox/tracking-protection-tour.lang
+++ b/si/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+සවාරිය නැවත අරඹන්න
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/si/firefox/tracking-protection-tour.lang
+++ b/si/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 සවාරිය නැවත අරඹන්න
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/sk/firefox/tracking-protection-tour.lang
+++ b/sk/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Znova spustiť sprievodcu
 
 
 ;Restart Tour
-Restart Tour
+Znova spustiť sprievodcu
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/sk/firefox/tracking-protection-tour.lang
+++ b/sk/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Blokovanie obsah môže zrýchliť načítavanie stránok ale taktiež zabráni�
 Znova spustiť sprievodcu
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Nová funkcia blokovania obsahu obsahuje výhody jej predchodcu - ochrany pred sledovaním. Ak vidíte ikonu štítu, blokovanie obsahu je zapnuté.
 

--- a/sl/firefox/tracking-protection-tour.lang
+++ b/sl/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Ponovno zaženi ogled
 
 
 ;Restart Tour
-Restart Tour
+Ponovno zaženi ogled
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/sl/firefox/tracking-protection-tour.lang
+++ b/sl/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Hvala za zanimanje za zavračanje vsebine,
 Ponovno zaženi ogled
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Izboljšana zasebnost z zaščito pred sledenjem je sedaj le ena od prednosti zavračanja vsebine. Kadar vidite ščit, je zavračanje vsebine vključeno.
 

--- a/son/firefox/tracking-protection-tour.lang
+++ b/son/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Restart tour
 
 
 ;Restart Tour
-Restart Tour
+Restart tour
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/son/firefox/tracking-protection-tour.lang
+++ b/son/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 Restart tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/sq/firefox/tracking-protection-tour.lang
+++ b/sq/firefox/tracking-protection-tour.lang
@@ -164,7 +164,7 @@ Riniseni turin
 
 
 ;Restart Tour
-Restart Tour
+Riniseni turin
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/sq/firefox/tracking-protection-tour.lang
+++ b/sq/firefox/tracking-protection-tour.lang
@@ -163,6 +163,10 @@ Faleminderit që mësoni rreth Bllokimit të Lëndës.
 Riniseni turin
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Tanimë, përfitimet në privatësi të Mbrojtjes Nga Gjurmimet janë vetëm një nga aspektet e bllokimit të lëndës. Kur mburoja është e dukshme, bllokimi i lëndës është aktiv.
 

--- a/sr/firefox/tracking-protection-tour.lang
+++ b/sr/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+Поново покрени обилазак
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/sr/firefox/tracking-protection-tour.lang
+++ b/sr/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 Поново покрени обилазак
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/sv-SE/firefox/tracking-protection-tour.lang
+++ b/sv-SE/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Tack för ditt intresse om innehållsblockering.
 Starta om guide
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Sekretessfördelarna med spårningsskydd är nu endast en del av innehållsblockering. När du ser skölden är innehållsblockering på.
 

--- a/sv-SE/firefox/tracking-protection-tour.lang
+++ b/sv-SE/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Starta om guide
 
 
 ;Restart Tour
-Restart Tour
+Starta om guide
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/sw/firefox/tracking-protection-tour.lang
+++ b/sw/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Restart tour
 
 
 ;Restart Tour
-Restart Tour
+Restart tour
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/sw/firefox/tracking-protection-tour.lang
+++ b/sw/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 Restart tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/ta/firefox/tracking-protection-tour.lang
+++ b/ta/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+சுற்றுலாவை மீட்தொடங்கு
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/ta/firefox/tracking-protection-tour.lang
+++ b/ta/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 சுற்றுலாவை மீட்தொடங்கு
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/te/firefox/tracking-protection-tour.lang
+++ b/te/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+పర్యటన పునఃప్రారంభించు
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/te/firefox/tracking-protection-tour.lang
+++ b/te/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 పర్యటన పునఃప్రారంభించు
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/th/firefox/tracking-protection-tour.lang
+++ b/th/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 เริ่มการทัศนาจรใหม่
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/th/firefox/tracking-protection-tour.lang
+++ b/th/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+เริ่มการทัศนาจรใหม่
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/tl/firefox/tracking-protection-tour.lang
+++ b/tl/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Muling simulan ang tour
 
 
 ;Restart Tour
-Restart Tour
+Muling simulan ang tour
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/tl/firefox/tracking-protection-tour.lang
+++ b/tl/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 Muling simulan ang tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/tr/firefox/tracking-protection-tour.lang
+++ b/tr/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Turu baştan başlat
 
 
 ;Restart Tour
-Restart Tour
+Turu baştan başlat
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/tr/firefox/tracking-protection-tour.lang
+++ b/tr/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Bir sitede içerik engellemeyi yeniden açmak isterseniz denetim merkezinden “
 Turu baştan başlat
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 İzlenme Koruması’nın avantajları artık içerik engellemenin içinde. Kalkanı gördüğünüzde içerik engelleme açık demektir.
 

--- a/uk/firefox/tracking-protection-tour.lang
+++ b/uk/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@
 Повторити знайомство
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 Захист приватності за допомогою блокування вмісту є лише однією з переваг захисту від стеження. Коли ви бачите зображення у вигляді щита - це означає, що блокування вмісту активне.
 

--- a/uk/firefox/tracking-protection-tour.lang
+++ b/uk/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@
 
 
 ;Restart Tour
-Restart Tour
+Повторити знайомство
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/ur/firefox/tracking-protection-tour.lang
+++ b/ur/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 دورہ دوباره شروع کریں
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/ur/firefox/tracking-protection-tour.lang
+++ b/ur/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Thanks for learning about Content Blocking.
 
 
 ;Restart Tour
-Restart Tour
+دورہ دوباره شروع کریں
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/uz/firefox/tracking-protection-tour.lang
+++ b/uz/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Restart tour
 
 
 ;Restart Tour
-Restart Tour
+Restart tour
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/uz/firefox/tracking-protection-tour.lang
+++ b/uz/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 Restart tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/vi/firefox/tracking-protection-tour.lang
+++ b/vi/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Xem lại hướng dẫn
 
 
 ;Restart Tour
-Restart Tour
+Xem lại hướng dẫn
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/vi/firefox/tracking-protection-tour.lang
+++ b/vi/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 Xem lại hướng dẫn
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/xh/firefox/tracking-protection-tour.lang
+++ b/xh/firefox/tracking-protection-tour.lang
@@ -162,6 +162,10 @@ Thanks for learning about Content Blocking.
 Phinda uqale ukhenketho
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/xh/firefox/tracking-protection-tour.lang
+++ b/xh/firefox/tracking-protection-tour.lang
@@ -163,7 +163,7 @@ Phinda uqale ukhenketho
 
 
 ;Restart Tour
-Restart Tour
+Phinda uqale ukhenketho
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/zam/firefox/tracking-protection-tour.lang
+++ b/zam/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Bí~rè là kíy kùe
 
 
 ;Restart Tour
-Restart Tour
+Bí~rè là kíy kùe
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/zam/firefox/tracking-protection-tour.lang
+++ b/zam/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 Bí~rè là kíy kùe
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 

--- a/zh-CN/firefox/tracking-protection-tour.lang
+++ b/zh-CN/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Firefox 新功能：内容拦截
 
 
 ;Restart Tour
-Restart Tour
+重新开始导览
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/zh-CN/firefox/tracking-protection-tour.lang
+++ b/zh-CN/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Firefox 新功能：内容拦截
 重新开始导览
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 跟踪保护的隐私保障现已融入内容拦截功能。在您看到盾牌时，内容拦截功能为开启状态。
 

--- a/zh-TW/firefox/tracking-protection-tour.lang
+++ b/zh-TW/firefox/tracking-protection-tour.lang
@@ -164,6 +164,10 @@ Firefox 全新功能: 內容封鎖
 重新進行導覽
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 追蹤保護功能的隱私保護部分已整合進內容封鎖功能。當您看到盾牌時，內容封鎖功能就開啟了。
 

--- a/zh-TW/firefox/tracking-protection-tour.lang
+++ b/zh-TW/firefox/tracking-protection-tour.lang
@@ -165,7 +165,7 @@ Firefox 全新功能: 內容封鎖
 
 
 ;Restart Tour
-Restart Tour
+重新進行導覽
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/zu/firefox/tracking-protection-tour.lang
+++ b/zu/firefox/tracking-protection-tour.lang
@@ -160,7 +160,7 @@ Restart tour
 
 
 ;Restart Tour
-Restart Tour
+Restart tour
 
 
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.

--- a/zu/firefox/tracking-protection-tour.lang
+++ b/zu/firefox/tracking-protection-tour.lang
@@ -159,6 +159,10 @@ Thanks for learning about Content Blocking.
 Restart tour
 
 
+;Restart Tour
+Restart Tour
+
+
 ;The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.
 


### PR DESCRIPTION
"Restart Tour" in tracking protection tour is currently untranslated, because the string is missing.

Adding the string and using the translation for "Restart tour" as a temporary fix.

See also https://github.com/mozilla/bedrock/pull/6169