### PR TITLE
Remove unneeded strings from firefox/campaign.lang

### DIFF
--- a/ach/firefox/campaign.lang
+++ b/ach/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Pwoc! Itye ka tic ki kit Firefox manyen loyo.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Ket ngec manyen</a> i Firefox mamegi pi ma nyen loyo i dwiro ki mung.
-
-
-;You’re using a pre-release version of Firefox.
-Itye ka tic ki kit Firefox mapud pe kikelo woko.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Dwir matwal.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Rwate ki Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nyen. Dwir. Pi matwal.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Gam kombedi
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Nwo cako Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Tim ber i lub <a href="%(url)s">yoo magi</a> me keto Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Bed kacel ki <br> jami weng ma Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Gam Firefox <span>pi Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Gam Firefox <span>pi macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Gam Firefox <span>pi Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Gam i leb mapat
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Gam mamegi myero ocake pire kene. Ka pe, <a id="%(id)s" href="%(fallback_url)s">dii kany</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Ket kanonge me email mamegi
-
-
-;How will Mozilla use my email?
-Mozilla bitic ki email na nining?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-Ngo ma wamito ingee:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Pe mite ni myero imii ki wan email mamegi me gamo ki tic ki Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-Pe wabi nywako, cato onyo tiyo ki email mamegi pi gin mo mukene.
-
-
-;Let’s do this!
-Watim!
-
-
-;Sync up with Firefox on mobile:
-Rib ki Firefox ma tye i cing:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Layeny Kakube me nono
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Gam Mozilla Firefox, layeny Kakube me nono. Firefox layubo ne aye dul me wilobo ma pe me nongo magoba ma odyere me keto dano i loc iwiyamo. Nong Firefox pi Windows, macOS, Linux, Android ki iOS tin!
-
-
-;Download the fastest Firefox ever
-Gam Firefox ma pud dong dwir loyo
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Wajoli i Firefox
-
-
-;Take Firefox with You
-Wot ki Firefox
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Nong alamabuk mamegi, gin mukato, mung me donyo ki ter mukene i nyonyo ni weng.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Dong itye ka tic ki Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Dony iyie account mamegi ci wa biribo alamabuk, mung me donyo ki jami mogo mabeco ma igowko i Firefox ma i nyonyo ni mukene.
-
-
-;Learn more about Firefox Accounts
-Nong ngec mapol ikom Akaunt me Firefox
-
-
-;Skip this step
-Kal citep man
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/af/firefox/campaign.lang
+++ b/af/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Geluk! U gebruik die jongste weergawe van Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Gradeer Firefox op</a> vir die jongste spoed en privaatheid.
-
-
-;You’re using a pre-release version of Firefox.
-U gebruik tans 'n Firefox-weergawe voor vrystelling.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Verfris Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Volg gerus <a href="%(url)s">dié instruksies</a> om Firefox te installeer.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Bly op datum met<br>alles oor Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Laai Firefox <span>vir Windows</span> af
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Laai Firefox <span>vir macOS</span> af
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Laai Firefox <span>vir Linux</span> af
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Gratis webblaaier
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Laai Mozilla Firefox af, ’n gratis webblaaier. Firefox word gebou deur 'n wêreldwye organisasie sonder winsbejag om mense beheer te gee oor hul lewens aanlyn. Kry Firefox vir Windows, macOS, Linux, Android en iOS vandag!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welkom by Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/am/firefox/campaign.lang
+++ b/am/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Congrats! You’re using the latest version of Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refresh Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Free Web Browser
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/an/firefox/campaign.lang
+++ b/an/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/an/firefox/campaign.lang
+++ b/an/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Parabiens! Yes fendo servir la zaguera versión de Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Esviella</a> lo tuyo Firefox pa amillorar la tuya velocidat y privacidat.
-
-
-;You’re using a pre-release version of Firefox.
-Yes fendo servir una versión preliminar de Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Yes fendo servir un sistema operativo inseguro y obsoleto <a href="%(url)s">que ya no ye soportau per Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Lo nuevo <strong>Firefox</strong>
 
 ;Fast for good.
 Rapido pa fer bien.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Descubre Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nuevo. Rapido. Pa fer bien.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Descarga-lo agora
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Repara lo Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Per favor, sigue <a href="%(url)s">estas instruccions</a> pa instalar Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Opcions abanzadas d'instalación y atras plataformas
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Opcions abanzadas d'instalación y atras plataformas
-
-
-;Keep up with<br> all things Firefox.
-Mantiene-te informau <br> de tot lo de Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Descarga-te lo Firefox <span>pa Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Descarga-te lo Firefox <span>pa macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Descarga-te lo Firefox <span>pa Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Descarga-lo pa atras plataformas y luengas
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Descarga-lo en atro idioma
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-La tuya descargar empecipiará automaticament. No ha funcionau? <a id="%(id)s" href="%(fallback_url)s">Preba tornarndo-lo a descargar.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-La tuya descarga habría d'empecipiar automaticament. Si no lo fa, <a id="%(id)s" href="%(fallback_url)s">fe clic aquí</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Aprende a fer lo Firefox mas listo, rapido y seguro.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Obtiene directament en o tuyo buzón de correu información de trucos y anuncios de productos.
-
-
-;Enter your email address
-Escribe la tuya adreza de correu
-
-
-;How will Mozilla use my email?
-Cómo usará Mozilla lo mío correu?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla no nomás valora la privacidat y seguranza d'o tuyo correu – ye parte d'o nuestro <a href="%(manifesto)s">Manifiesto</a>: “La seguranza y la privacidat d'os individuos en internet ye fundamental, y no s'ha de considerar como opcional."  <a href="%(principles)s">Aquí puetz saber mas sobre los nuestros principios de confidencialidat de datos</a>.
-
-
-;What we want you to know:
-Lo que queremos que sepas:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Yo cal que nos des lo tuyo correu pa descargar-te y emplegar Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Te demandamos lo tuyo correu perque la nuestra investigación amuestra que las personas que reciben una experiencia de presentación rinden mas y millor con Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Puetz recibir correus disenyaus pa aduyar-te a optimizar Firefox pa que treballe millor con tu, pa aprender mas sobre privacidat y seguranza y pa trobar cómo aproveitar tot lo que se pueda lo tiempo pasau en a web.
-
-
-;You can unsubscribe anytime, for any reason.
-Te puedtz desuscribir en qualsequier momento, per qualsequier razón.
-
-
-;We will not share, sell or use your email for any other purposes.
-No compartiremos, venderemos ni faremos servir lo tuyo correu electronico pa garra atra cosa.
-
-
-;Let’s do this!
-Fagamos-lo!
-
-
-;Sync up with Firefox on mobile:
-Sincronizar con lo Fierfox en o mobil:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Navegador web gratuito
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Descarga lo Mozilla Firefox, un navegador web gratuito. Firefox ye estau creau per una comunidat global sin animo de lucro dedicada a dar a los individuos lo control en linia. Descarga hue lo Firefox pa Windows, macOS, Linux, Android u iOS!
-
-
-;Download the fastest Firefox ever
-Descarga lo Firefox mas rapido
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Carga de pachinas mas rapida, menor uso de memoria y pleno de funcionalidatz, lo nuevo Firefox ye aquí.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Poderosament privau
 
 ;Truly Private Browsing with Tracking Protection
 Verdadera navegación privada con protección contra seguimiento
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Bienveniu ta Firefox
-
-
-;Take Firefox with You
-Leva-te con tu lo Firefox
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Obtiene los tuyos marcapachinas, historials, claus y atros achustes en totz los tuyos dispositivos.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Ya fas servir Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Dentre en o tuyo conto y sincronizaremos los marcapachinas, claus y atras cosas grans que has alzau en o Firefox d'atros dispositivos.
-
-
-;Learn more about Firefox Accounts
-Aprende mas sobre los contos de Firefox
-
-
-;Skip this step
-Blinca-te este paso
-
-
-# Old firstrun page
-;Chart your own course
-Sigue lo tuyo propio camín
 
 

--- a/ar/firefox/campaign.lang
+++ b/ar/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-تهانينا. أنت تستعمل أحدث إصدار من فَيَرفُكس.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">حدّث</a> فَيَرفُكس لتحصل على أداء أفضل من حيث السُّرعة والخصوصية
-
-
-;You’re using a pre-release version of Firefox.
-أنت تستخدم إصدارًا قبليًا من فَيَرفُكس.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-أنت تستخدم نظام تشغيل غير آمن وقديم <a href="%(url)s">لم يعد فَيَرفُكس يدعمه</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@
 
 ;Fast for good.
 سريع بأتم معنى الكلمة.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-رحّب بفَيَرفُكس كوانتُم
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-جديد وسريع بكل ما تحمله الكلمة من معنى.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-نزِّله الآن
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-أنعش فيَرفُكس
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-رجاءً اتّبع  <a href="%(url)s">هذه التّعليمات</a> لتنصيب فَيَرفُكس.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-خيارات التنصيب المتقدمة و منصات أخرى
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-خيارات التنصيب المتقدمة و منصات أخرى
-
-
-;Keep up with<br> all things Firefox.
-ابق على اطّلاع<br> على جديد فَيَرفُكس.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-حمّل فَيَرفُكس <span>على ويندوز</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-حمّل فَيَرفُكس <span>على ماك أو إس</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-حمّل فَيَرفُكس <span>على لينكس</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-حمّل على مُختلف المنصّات وبمُختلف اللغات
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-نزِّله بلغة أخرى
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-سيبدأ التنزيل تلقائيًا خلال ثوان من الآن. إن لم يحدث ذلك، <a id="%(id)s" href="%(fallback_url)s">جرّب معاودة التنزيل من هنا</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-سيبدأ التنزيل تلقائيًا خلال ثوان من الآن. إن لم يحدث ذلك، <a id="%(id)s" href="%(fallback_url)s">انقر هنا</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-اطّلع على طريقة جعل فَيَرفُكس أكثر ذكاء وسرعة وأمنًا مما هو عليه أساسًا.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-استلم نصائح وخدع مفيدة و إعلانات المنتجات بصندوق بريدك.
-
-
-;Enter your email address
-أدخِل عنوان بريدك الإلكتروني
-
-
-;How will Mozilla use my email?
-كيف ستستخدم موزيلا بريدي الإلكتروني؟
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-إنّ موزيلا لا تقدّر أهمية خصوصية بريدك وأمانه فحسب، بل ووضعته ضمن <a href="%(manifesto)s">البيان</a>: ”إنّ ضمان أمن الأفراد وخصوصيتهم على شبكة الإنترنت لهو أمر أساسي ويجب ألا يُعتبر ثانويا أبدا.“ <a href="%(principles)s">يمكنك الاطلاع على مبادئ خصوصية البيانات من هنا</a>.
-
-
-;What we want you to know:
-هذا ما نريد منك معرفته:
-
-
-;You don’t need to give us your email to download and use Firefox.
-ليس عليك تقديم بريدك الإلكتروني إلينا لتنزّل فَيَرفُكس وتستخدمه.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-طلبنا بريدك الإلكتروني لأن أبحاثنا تقول بأن أولئك الذين يتلقّون تجربة تمهيدية يمكنهم الاستفادة من فَيَرفُكس أكثر وأكثر.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-ستستلم رسائل الإلكترونية مصممة لمساعدتك علي تحسن أداء فَيَرفُكس والمزيد حول الخصوصية والأمان وكيفية تحقيق أقصى استفادة من وقتك على الويب.
-
-
-;You can unsubscribe anytime, for any reason.
-يمكنك إلغاء الاشتراك متى ما أردت، ولأيّ سبب كان.
-
-
-;We will not share, sell or use your email for any other purposes.
-لن نشارك أو نبيع أو حتى نستخدم بريدك الإلكتروني لأية أغراض أخرى.
-
-
-;Let’s do this!
-لننطلق
-
-
-;Sync up with Firefox on mobile:
-زامِن مع فَيَرفُكس للمحمول:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 حمّل موزيلا فَيَرفُكس، المتصفّح الحر والمجاني. قام ببناء فَيَرفُكس شركة غير ربحية تهدف إلى إعطاء الأفراد الحرّية التّامة على الإنترنت. احصل على فَيَرفُكس على ويندوز، ماك أو إس، لينكس، أندرويد، وآي أو إس الآن.
-
-
-;Download the fastest Firefox ever
-نزِّل أسرع فَيَرفُكس على الإطلاق
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-تحميل الصفحات بات أسرع، واستخدام الذاكرة قل، هذا عدا المزايا المضمنة. لقد وصل فَيَرفُكس الجديد.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@
 
 ;Truly Private Browsing with Tracking Protection
 التصفح الخاص الحق مع الحماية من التعقب
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-أهلا بك على فَيَرفُكس
-
-
-;Take Firefox with You
-خذ معك فَيَرفُكس أينما ذهبت
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-تشارك العلامات، تاريخ التّصفّح، كلمات السّر وباقي الإعدادات على جميع أجهزتك.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-هل تستخدم فَيَرفُكس؟
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-سجّل دخولك إلى حسابك وسنقوم بمُزامنة علاماتك وكلمات السّر المحفوظة وأمور أخرى عديدة سبق لك حفظها على فَيَرفُكس على أجهزة أخرى.
-
-
-;Learn more about Firefox Accounts
-اعرف المزيد حول حسابات فَيَرفُكس
-
-
-;Skip this step
-تجاوز هذه الخُطوة
-
-
-# Old firstrun page
-;Chart your own course
-اسلك الطّريق الذي ترسمه لنفسك
 
 

--- a/ar/firefox/campaign.lang
+++ b/ar/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/as/firefox/campaign.lang
+++ b/as/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-অভিনন্দন! আপুনি Firefox ৰ শেহতীয়া সংস্কৰণ ব্যৱহাৰ কৰি আছে।
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refresh Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Download Firefox
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/ast/firefox/campaign.lang
+++ b/ast/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/ast/firefox/campaign.lang
+++ b/ast/firefox/campaign.lang
@@ -1,24 +1,4 @@
-## active ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-¡Norabona! Tas usando la versión cabera de Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Anueva</a> Firefox pa lo cabero en velocidá y privacidá.
-
-
-;You’re using a pre-release version of Firefox.
-Tas usando una versión de pre-llanzamientu de Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -27,133 +7,6 @@ El <strong>Firefox</strong> nuevu
 
 ;Fast for good.
 Rápidu pa bien.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Conoz Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nuevu. Rápidu. Pa bien.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Baxar agora
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Reafitar Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Sigui <a href="%(url)s">estes instrucciones</a> pa instalar Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Opciones avanzaes d'instalación y otres plataformes
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Opciones avanzaes d'instalación y otres plataformes
-
-
-;Keep up with<br> all things Firefox.
-Sigui toles coses<br> de Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Baxa Firefox <span>pa Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Baxa Firefox <span>pa macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Baxa Firefox <span>pa Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Baxar pa otres plataformes y llingües
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Baxar n'otra llingua
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-La descarga debería entamar automáticamente. ¿Nun lo fizo? <a id="%(id)s" href="%(fallback_url)s">Volvi tentalo</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-La to descarga debería entamar automáticamente. Si non, <a id="%(id)s" href="%(fallback_url)s">primi equí</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-¡Vamos facelo!
-
-
-;Sync up with Firefox on mobile:
-<em>Sync</em>oniza Firefox nel móvil:
 
 
 # HTML page title prefix
@@ -169,14 +22,6 @@ Restolador web de baldre
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Baxa Mozilla Firefox, un restolador web de baldre. Firefox ta creáu por una asociación global ensin ánimu de llucru dedicada a facer que particulares tengan el control en llinia. ¡Consigui güei Firefox pa Linux, Windows, macOS, Android ya iOS!
-
-
-;Download the fastest Firefox ever
-Baxa'l Firefox más rápidu del momentu
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Carga de páxines más rápida, usu menor de memoria y enllenu de carauterístiques. El Firefox nuevu ta equí.
 
 
 ;2x Faster
@@ -201,41 +46,5 @@ Poderosamente priváu
 
 ;Truly Private Browsing with Tracking Protection
 Un restolar que ye privao daveres con proteición y rastrexu
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Afáyate en Firefox
-
-
-;Take Firefox with You
-Lleva Firefox contigo
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-¿Yá uses Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Anicia sesión na to cuenta y sincronizarémoste los marcadores, contraseñes y otres coses xeniales que guardares nel Firefox d'otros preseos.
-
-
-;Learn more about Firefox Accounts
-Deprendi más tocante a Cuentes de Firefox
-
-
-;Skip this step
-Saltar esti pasu
-
-
-# Old firstrun page
-;Chart your own course
-Traza'l to propiu camín
 
 

--- a/az/firefox/campaign.lang
+++ b/az/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Təbriklər! Siz ən yeni Firefox versiyasını işlədirsiniz.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-Sürət və məxfilikdə yeniliklər üçün Firefox səyyahınızı <a href="%(url)s">Yeniləyin</a>.
-
-
-;You’re using a pre-release version of Firefox.
-Firefox-un buraxılış öncəsi versiyasını işlədirsiniz.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-İşlətdiyiniz əməliyyat sisteminin vaxtı çıxıb və <a href="%(url)s">artıq Firefox tərəfindən dəstəklənmir</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Yeni <strong>Firefox</strong>
 
 ;Fast for good.
 Yaxşı insanların səyyahı.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Firefox Quantum ilə tanış olun
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Yeni. Sürətli. Yaxşı insanlar üçün.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-İndi Endir
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox Səyyahını Yenilə
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Lütfən Firefox qurmaq üçün <a href="%(url)s">bu qaydaları</a> izləyin.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Təkmilləşmiş Quraşdırma Seçimləri və Digər Platformalar
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Təkmilləşmiş quraşdırma seçimləri və digər platformalar
-
-
-;Keep up with<br> all things Firefox.
-Firefox-un hər yeniliklərindən<br> xəbərdar olun.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-<span>Windows üçün</span> Firefox Endir
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-<span>macOS üçün</span> Firefox Endir
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-<span>Linux üçün</span> Firefox Endir
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Digər platforma və dillər üçün endir
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Başqa dildə endir
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Endirməniz avtomatik olaraq başlamalıdır. Başlamadısa <a id="%(id)s" href="%(fallback_url)s">endirməyi təzədən yoxlayın</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Endirməniz avtomatik olaraq başlamalıdır. Başlamadısa <a id="%(id)s" href="%(fallback_url)s">buraya klikləyin</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Firefoxu necə daha ağıllı, sürətli və təhlükəsiz edə biləcəyinizi öyrənin.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Məlumatlandırıcı məsləhətləri, təcrübələri və məhsul elanlarını birbaşa gələn qutunuzda əldə edin.
-
-
-;Enter your email address
-E-poçt ünvanınızı daxil edin
-
-
-;How will Mozilla use my email?
-Mozilla mənim e-poçt ünvanımı necə işlədəcək?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla nəinki sizin e-poçt məxfiliyinizi və təhlükəsizliyinizi fikirləşir – bu həmçinin bizim <a href="%(manifesto)s">Manifesto</a>nun bir hissəsidir: “fərdlərin internetdəki təhlükəsizliyi və məxfiliyi bünövrədir və seçim olaraq qəbul edilə bilməz.” <a href="%(principles)s">Məlumat Məxfiliyi Prinsiplərimiz haqqında ətraflı burada öyrənə bilərsiz</a>.
-
-
-;What we want you to know:
-Bunları bilməyinizi istəyirik:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Firefox səyyahını endirmək və işlətmək üçün bizə e-poçt ünvanınızı vermək məcburiyyətində deyilsiniz.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Tədqiqatlarımız göstərir ki, məlumatlandırıcı yazılarımızı alan istifadəçilər Firefox səyyahını daha səmərəli işlədirlər, bu səbəbdən e-poçt ünvanınızı soruşduq.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Firefox səyyahını özünüz üçün daha yaxşı hala gətirmək, məxfilik və təhlükəsizlik haqqında daha ətraflı öyrənmək və internetdə vaxtınızı daha səmərəli sərf eləməyi öyrənmək üçün hazırlanmış e-poçtları göndərəcik.
-
-
-;You can unsubscribe anytime, for any reason.
-İstənilən vaxt, istənilən səbəblə abunəliyinizi ləğv edə bilərsiz.
-
-
-;We will not share, sell or use your email for any other purposes.
-E-poçt ünvanınızı hər nə səbəblə olsun, paylaşmayacağıq, satmayacağıq və başqa heç bir məqsədlər üçün işlətməyəcəyik.
-
-
-;Let’s do this!
-Bunu edək!
-
-
-;Sync up with Firefox on mobile:
-Firefox ilə mobildə sinxronlaşın:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Pulsuz Web Səyyah
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Mozilla Firefox, pulsuz Web Səyyahı Endirin. Firefox qlobal qeyri-kommersial təşkilat tərəfindən yaradılmışdır. Windows, macOS, Linux, Android və iOS üçün Firefoxu bu gün əldə edin!
-
-
-;Download the fastest Firefox ever
-İndiyə qədər olan ən sürətli Firefox-u endir
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Daha sürətli səhifə yüklənməsi, daha az yaddaş istifadəsi və daha çox özəlliklər, yeni Firefox buradadır.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Gücləndirilmiş Məxfilik
 
 ;Truly Private Browsing with Tracking Protection
 İzlənmə Qoruması ilə əsl Məxfi Səyahət
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Firefox-a Xoş Gəldiniz
-
-
-;Take Firefox with You
-Firefox-u özünüzlə gəzdirin
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Əlfəcin, tarixçə, parol və digər tənzimləmələrinizi bütün cihazlarınızda əldə edin.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Artıq Firefox işlədirsiniz?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Hesabınıza daxil olun və digər cihazlarınızdakı Firefox-da saxladığınız əlfəcin, parol və digər şeylər sinxronlaşsın.
-
-
-;Learn more about Firefox Accounts
-Firefox Hesabları haqqında ətraflı öyrənin
-
-
-;Skip this step
-Bu addımı keç
-
-
-# Old firstrun page
-;Chart your own course
-Öz yolunuzu seçin
 
 

--- a/az/firefox/campaign.lang
+++ b/az/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/azz/firefox/campaign.lang
+++ b/azz/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-¡Xionyolpaki! Tikontatekiujtijtok okachi yankuik versión Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Xikonyankuili</a> moFirefox uan ijkon okachi kualiok kiyekpias tein kiselis uan okachi isiujkaok tekitis.
-
-
-;You’re using a pre-release version of Firefox.
-Tikontatekiujtijtok se versión Firefox tein achto release.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Xikonyankuili Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Xikonchiua <a href="%(url)s">nejin tanauatilmej</a> uan ijkon tikontalilis Fiefox motepos.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Xikonsentoka ika<br> nochi taman tein kipia Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Xikontemoui Firefox <span>tein kualtia Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Xikontemoui Firefox <span>tein kualtia macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Xikontemoui Firefox <span>tein kualtia Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Navegador tein amo se moneki kiixtauas
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Xikontemoui Mozilla Firefox, se navegador web tein amo se moneki kiixtauas. Firefox kichijchiujkej se nechikol semanauak taltikpak tein amo kitemouaj motomintiskej ta kinpaleuiskej taltikpakneminij maj kiixyekantinemij keniuj kitatekiujtiaj Internet. ¡Xikonpia axkan Firerfox tein tionuelis tikonkuis ika Windows, macOS, Linux, Android uan iOS!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Kuali ke tikontapoj Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-¿Tikontatekiujtijtokya Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Xionkalakteua itech mocuenta uan tikchiuaskej maj mosenixpatatiyajkan neskayomej marcadores, ichtaktajkuilolmej uan oksekin taman tein semi kualtsin tein tikoneuani itech oksekin teposmej.
-
-
-;Learn more about Firefox Accounts
-Kampa se okachi uelis momachtis cuentas tein kipia Firefox
-
-
-;Skip this step
-Amo xikonchiua nejin
-
-
-# Old firstrun page
-;Chart your own course
-Xikonixtali moojpan saj
 
 

--- a/be/firefox/campaign.lang
+++ b/be/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/be/firefox/campaign.lang
+++ b/be/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Віншуем! Вы карыстаецеся сучаснай версіяй Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Абнавіце</a> свой Firefox для лепшай прадукцыйнасці і прыватнасці.
-
-
-;You’re using a pre-release version of Firefox.
-Вы карыстаецеся перадрэлізнай версіяй Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Вы выкарыстоўваеце неабароненую, састарэлую аперацыйную сістэму, якая <a href="%(url)s">больш не падтрымліваецца Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@
 
 ;Fast for good.
 Хуткі на добра.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Знаёмцеся з Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Новы. Хуткі. На добра.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Сцягнуць зараз
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Абнавіць Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Калі ласка, прытрымлівайцеся <a href="%(url)s">гэтых інструкцый</a>, каб усталяваць Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Пашыраныя магчымасці ўсталявання і іншыя платформы
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Пашыраныя магчымасці ўсталявання і іншыя платформы
-
-
-;Keep up with<br> all things Firefox.
-Будзьце ў курсе ўсяго,<br> што звязана з Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Сцягнуць Firefox <span>для Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Сцягнуць Firefox <span>для macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Сцягнуць Firefox <span>для Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Сцягванні для іншых платформ і на іншых мовах
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Сцягнуць на іншай мове
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Ваша сцягванне пачнецца аўтаматычна. Не робіць? <a id="%(id)s" href="%(fallback_url)s">Паспрабуйце яшчэ раз</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Ваша сцягванне пачнецца аўтаматычна. Калі яно не пачалося, <a id="%(id)s" href="%(fallback_url)s">клікніце тут</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Даведайцеся, як зрабіць Firefox яшчэ разумнейшым, хутчэйшым і больш бяспечным.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Атрымлівайце змястоўныя парады, звесткі пра асаблівасці і анонсы прадуктаў на сваю скрынку.
-
-
-;Enter your email address
-Увядзіце ваш адрас эл.пошты
-
-
-;How will Mozilla use my email?
-Як Mozilla будзе выкарыстоўваць мой адрас эл.пошты?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla не толькі цэніць прыватнасць і бяспеку вашага адраса эл.пошты – гэта частка нашага <a href="%(manifesto)s">Маніфест</a>: “Бяспека і прыватнасць асобы ў інтэрнэце – рэчы фундаментальныя і не могуць разглядацца як опцыі.” <a href="%(principles)s">Вы можаце даведацца больш аб нашых прынцыпах прыватнасці даных тут</a>.
-
-
-;What we want you to know:
-Мы хочам, каб вы ведалі:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Вам не трэба ўказваць свой адрас эл.пошты, каб сцягнуць і карыстацца Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Мы просім ваш адрас эл.пошты, бо нашы даследаванні паказваюць, што людзі, якія атрымалі ўводны курс у Firefox, робяць з ім больш і лепш.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Вы можаце чакаць лістоў, напісаных з мэтай дапамагчы вам аптымізаваць Firefox пад вашы патрэбы, даведацца больш аб прыватнасці і бяспецы, дарадзіць, як найлепей выкарыстаць ваш час у сеціве.
-
-
-;You can unsubscribe anytime, for any reason.
-Вы можаце адпісацца ў любы час, з любой прычыны.
-
-
-;We will not share, sell or use your email for any other purposes.
-Мы не будзем дзяліцца, прадаваць або выкарыстоўваць ваш адрас эл.пошты ў якіх-небудзь іншых мэтах.
-
-
-;Let’s do this!
-Давайце зробім!
-
-
-;Sync up with Firefox on mobile:
-Сінхранізуйцеся з Firefox на мабільным:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Mozilla не толькі цэніць прыватнасць і бяспеку 
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Сцягніце бясплатны вэб-браўзер Mozilla Firefox. Firefox створаны глабальнай некамерцыйнай арганізацыяй, якая хоча даць людзям магчымасць кантраляваць сваё жыццё ў Інтэрнэце. Загрузіце Firefox для Windows, macOS, Linux, Android і iOS зараз!
-
-
-;Download the fastest Firefox ever
-Сцягніце найхутчэйшы ў гісторыі Firefox
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Хутчэйшая загрузка старонак, меншае спажыванне памяці, і мноства функцый, новы Firefox ужо тут.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Mozilla не толькі цэніць прыватнасць і бяспеку 
 
 ;Truly Private Browsing with Tracking Protection
 Сапраўды прыватнае агляданне з аховай ад сачэння
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Калі ласка да Firefox
-
-
-;Take Firefox with You
-Вазьміце Firefox з сабой
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Атрымайце доступ к вашым закладкам, гісторыі, паролямі і іншым наладам на ўсіх вашых прыладах.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Ужо карыстаецеся Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Увайдзіце ў свой уліковы запіс, і мы сінхранізуем закладкі, паролі і іншыя патрэбныя рэчы, якія вы захавалі ў Firefox на іншых прыладах.
-
-
-;Learn more about Firefox Accounts
-Даведайцеся больш пра ўліковыя запісы Firefox
-
-
-;Skip this step
-Прапусціць гэты крок
-
-
-# Old firstrun page
-;Chart your own course
-Вызначайце ўласны курс
 
 

--- a/bg/firefox/campaign.lang
+++ b/bg/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/bg/firefox/campaign.lang
+++ b/bg/firefox/campaign.lang
@@ -1,25 +1,4 @@
-## active ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Използвате последната версия на Firefox. Благодарим!
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Обновете</a> вашия Firefox, за да е бърз и поверителен.
-
-
-;You’re using a pre-release version of Firefox.
-Използвате предварително издание на Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Използвате незащитена, остаряла операционна система, която <a href="%(url)s">вече не се поддържа от Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -28,133 +7,6 @@
 
 ;Fast for good.
 Бърз завинаги.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Запознайте се с Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Нов. Бърз. Завинаги.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Изтегляне
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Опреснете Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Моля, следвайте <a href="%(url)s">тези инструкции</a>, за да инсталирате Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Допълнителни инсталатори и платформи
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Допълнителни инсталатори и платформи
-
-
-;Keep up with<br> all things Firefox.
-Бъдете в течение с<br>всичко около Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Изтегляне на Firefox <span>за Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Изтегляне на Firefox <span>за macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Изтегляне на Firefox <span>за Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Изтегляне за други платформи и езици
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Изтеглете на друг език
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Изтеглянето трябва да започне автоматично. Не става ли? <a id="%(id)s" href="%(fallback_url)s">Изтеглете отново</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Изтеглянето ви трябва да започне автоматично. Ако ли пък не, <a id="%(id)s" href="%(fallback_url)s">натиснете тук</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Да го направим!
-
-
-;Sync up with Firefox on mobile:
-Синхронизиране с Firefox на мобилнo устройствo:
 
 
 # HTML page title prefix
@@ -170,14 +22,6 @@ We will not share, sell or use your email for any other purposes.
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Изтеглете Mozilla Firefox, един наистина безплатен и свободен мрежов четец. Firefox е създаден от общност с нестопанска цел посветена да даде на потребителя пълен контрол, когато е онлайн. Вземете Firefox за Windows, macOS, Linux, Android и iOS днес!
-
-
-;Download the fastest Firefox ever
-Изтеглете най-бързия Firefox
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-По-бързо зареждане на страници, по-малко използване на паметта и пълен с функции, новият Firefox е тук.
 
 
 ;2x Faster
@@ -202,41 +46,5 @@ We will not share, sell or use your email for any other purposes.
 
 ;Truly Private Browsing with Tracking Protection
 Наистина частно сърфиране със защита за проследяване
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Добре дошли във Firefox
-
-
-;Take Firefox with You
-Вземете Firefox с вас
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Вземете своите отметки, история, пароли и всички други настройки на всички ваши устройства.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Вече използвате Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Влезте във вашата сметка и ние ще синхронизираме отметките, паролите и другите неща, които сте запазили във Firefox от всички ваши устройства.
-
-
-;Learn more about Firefox Accounts
-Научете повече за Firefox Accounts
-
-
-;Skip this step
-Пропускане
-
-
-# Old firstrun page
-;Chart your own course
-Сами определете вашия курс
 
 

--- a/bn-BD/firefox/campaign.lang
+++ b/bn-BD/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-অভিনন্দন! আপনি Firefox এর সর্বশেষ সংস্করণ ব্যবহার করছেন।
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-নতুন গতি এবং গোপনীয়তায় আপনার Firefox <a href="%(url)s">হালনাগাদ</a> করুন।
-
-
-;You’re using a pre-release version of Firefox.
-আপনি Firefox এর প্রি-রিলিজ সংস্করণ ব্যবহার করছেন।
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 নতুন <strong> Firefox </strong>
 
 
 ;Fast for good.
 মঙ্গলের জন্য দ্রুততা।
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-দেখুন Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-নতুন। দ্রুত। চিরতরে।
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-এখন ডাউনলোড করুন
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox রিফ্রেশ করুন
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-অনুগ্রহ করে Firefox ইন্সটল করতে <a href="%(url)s">এই নির্দেশনাগুলো</a> অনুসরণ করুন।
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-উন্নত ইনস্টল অপশন ও অন্যান্য প্ল্যাটফর্ম
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-উন্নত ইনস্টল অপশন ও অন্যান্য প্ল্যাটফর্ম
-
-
-;Keep up with<br> all things Firefox.
-Firefox এর সবকিছুর<br> সাথেই থাকুন।
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-<span>Windows এর জন্য</span> Firefox ডাউনলোড করুন
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-<span>macOS এর জন্য</span> Firefox ডাউনলোড করুন
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-<span>Linux এর জন্য</span> Firefox ডাউনলোড করুন
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-অন্যান্য প্ল্যাটফর্ম ও ভাষার জন্য ডাউনলোড করুন
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-অন্য ভাষাতে ডাউনলোড করুন
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-স্বয়ংক্রিয়ভাবে ডাউনলোড শুরু হওয়া উচিত। কাজ করছে না? <a id="%(id)s" href="%(fallback_url)s">পুনরায় ডাউনলোড করুন</a>।
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-আপনার ডাউনলোড এখনি শুরু হবে। যদি না হয় তবে <a id="%(id)s" href="%(fallback_url)s">এখানে ক্লিক করুন</a>।
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-কীভাবে Firefox কে স্মার্ট, গতিময় এবং আরও বেশি নিরাপদ করা যায় তা জানুন।
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-আপনার ইনবক্সে তথ্যবহুল টিপস, কৌশল এবং পণ্যের ঘোষণা পান।
-
-
-;Enter your email address
-আপনার ইমেইল ঠিকানা দিন
-
-
-;How will Mozilla use my email?
-কিভাবে Mozilla আমার ইমেইল ব্যবহার করবে?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-যা আমরা আপনাকে জানাতে চাই:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Firefox ডাউনলোড এবং ব্যবহার করতে আমাদের ইমেইল করার প্রয়োজন নেই।
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-আপনি যে কোন কারণে, যে কোন সময় আনসাবস্ক্রাইব করতে পারেন।
-
-
-;We will not share, sell or use your email for any other purposes.
-আপনার ইমেইল আমরা শেয়ার, বিক্রি বা অন্য কোন উদ্দেশ্যে ব্যবহার করি না।
-
-
-;Let’s do this!
-চলুন করা যাক!
-
-
-;Sync up with Firefox on mobile:
-মোবাইলে Firefox এর সাথে সিঙ্ক আপ করুন:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Firefox ডাউনলোড করুন
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-দ্রুততম Firefox ডাউনলোড করুন
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-দ্রুততর পাতা লোডিং, কম মেমরির ব্যবহার এবং নতুন নতুন বৈশিষ্ট্যে ভরপুর, নতুন Firefox এখানে।
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Chrome এর চেয়ে 30% কম মেমরি ব্যবহার �
 
 ;Truly Private Browsing with Tracking Protection
 সত্যিই ট্র্যাকিং সুরক্ষার সাথে ব্যক্তিগত ব্রাউজিং
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Firefox এ আপনাকে স্বাগতম
-
-
-;Take Firefox with You
-Firefox আপনার সাথেই রাখুন
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-ইতোমধ্যেই Firefox ব্যবহার করছেন?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-আপনার অ্যাকাউন্টে সাইন ইন করুন এবং আমরা আপনার বুকমার্ক, পাসওয়ার্ড এবং অন্য সব দারুন দারুন জিনিসগুলো Firefox এর অন্য ডিভাইসগুলোতে সংরক্ষণ করেছেন তা সিঙ্ক করব।
-
-
-;Learn more about Firefox Accounts
-Firefox Accounts সম্পর্কে আরও জানুন
-
-
-;Skip this step
-এই ধাপটি বাদ দিন
-
-
-# Old firstrun page
-;Chart your own course
-আপনার নিজের কোর্সটি চার্ট করুন
 
 

--- a/bn-IN/firefox/campaign.lang
+++ b/bn-IN/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-অভিনন্দন! আপনি Firefox এর সর্বশেষ সংস্করণ ব্যবহার করছেন।
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-আপনার Firefox গতি এবং গোপনীয়তাকে সর্বশেষ ভাবে পাওয়ার জন্য <a href="%(url)s">আপডেউ</a> করুন।
-
-
-;You’re using a pre-release version of Firefox.
-আপনি Firefox এর একটি পুরোনো সংস্করণ ব্যবহার করছেন।
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox-কে রিফ্রেশ করুন
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Firefox ইনস্টল করার জন্য <a href="%(url)s">এই নির্দেশাবলী</a> অনুসরণ করুন।
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Download Firefox
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/br/firefox/campaign.lang
+++ b/br/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Gourc'hemennoù&nbsp;! Emaoc'h oc'h arverañ an handelv diwezhañ eus Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 Ar <strong>Firefox</strong> nevez
 
 
 ;Fast for good.
 Buanoc'h-buanañ.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Dizoloit Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nevez. Buan. Da vat.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Pellgargañ diouzhtu
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Azbevaat Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Heulit ar <a href="%(url)s">sturadurioù-mañ</a> evit staliañ Firefox mar plij.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Bezit kelaouet<br> eus kement tra Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Pellgargañ Firefox <span>evit Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Pellgargañ Firefox <span>evit macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Pellgargañ Firefox <span>evit Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Deomp dezhi!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Merdeer web digoust
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Donemat e Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Ober van ouzh ar bazenn-mañ
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/bs/firefox/campaign.lang
+++ b/bs/firefox/campaign.lang
@@ -1,25 +1,4 @@
-## active ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Čestitamo! Koristite najnoviju verziju Firefoxa.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Nadogradite</a> vaš Firefox za najnovije u brzini i privatnosti.
-
-
-;You’re using a pre-release version of Firefox.
-Koristite beta verziju Firefoxa.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -28,133 +7,6 @@ Novi <strong>Firefox</strong>
 
 ;Fast for good.
 Brz zauvijek.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Upoznajte Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nov. Brz. Zauvijek.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Preuzmite sada
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Osvježite Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Molimo pratite <a href="%(url)s">ove instrukcije</a> da instalirate Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Napredne opcije instalacije i druge platforme
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Napredne opcije instalacije i druge platforme
-
-
-;Keep up with<br> all things Firefox.
-Budite u toku<br> sa svim vezanim uz Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Preuzmite Firefox <span>za Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Preuzmite Firefox <span> za macOS </span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Preuzmite Firefox <span>za Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Preuzmite za ostale platforme i jezike
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Preuzmite na drugom jeziku
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Vaše preuzimanje treba započeti automatski. Nije uspjelo? <a id="%(id)s" href="%(fallback_url)s">Pokušajte preuzeti ponovo</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Vaše preuzimanje treba automatski započeti. Ako se to ne desi, <a id="%(id)s" href="%(fallback_url)s">kliknite ovdje</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Idemo to učiniti!
-
-
-;Sync up with Firefox on mobile:
-Sinhronizujte se s Firefoxom na mobilnom:
 
 
 # HTML page title prefix
@@ -170,14 +22,6 @@ Besplatni web pretraživač
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Preuzmite Mozilla Firefox, besplatni web pretraživač. Firefox je kreiran od globalne neprofitne organizacije usmjerene na postavljanje pojedinaca u kontrolu na mreži. Preuzmite Firefox za Windows, macOS, Linux, Android i iOS danas!
-
-
-;Download the fastest Firefox ever
-Preuzmite najbrži Firefox ikad
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Brže učitavanje stranica, manje korištenje memorije i upakovane funkcije - novi Firefox je ovdje.
 
 
 ;2x Faster
@@ -202,41 +46,5 @@ Snažna privatnost
 
 ;Truly Private Browsing with Tracking Protection
 Istinsko privatno pretraživanje sa zaštitom od praćenja
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Dobrodošli u Firefox
-
-
-;Take Firefox with You
-Ponesite Firefox sa sobom
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Imajte zabilješke, historiju, lozinke i druge postavke na svim vašim uređajima.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Već koristite Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Prijavite se na vaš račun i mi ćemo sinhronizovati zabilješke, lozinke i druge stvari, koje ste sačuvali u Firefoxu na drugim uređajima.
-
-
-;Learn more about Firefox Accounts
-Saznajte više o Firefox računima
-
-
-;Skip this step
-Preskočite ovaj korak
-
-
-# Old firstrun page
-;Chart your own course
-Napravite svoj vlastiti kurs
 
 

--- a/bs/firefox/campaign.lang
+++ b/bs/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/ca/firefox/campaign.lang
+++ b/ca/firefox/campaign.lang
@@ -1,25 +1,4 @@
-## active ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Felicitats! Esteu fent servir la darrera versió del Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Actualitzeu</a> el Firefox per millorar la velocitat i privadesa.
-
-
-;You’re using a pre-release version of Firefox.
-Esteu utilitzant una versió preliminar del Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-El sistema operatiu que utilitzeu és insegur, obsolet i <a href="%(url)s">ja no és compatible amb el Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -28,133 +7,6 @@ El nou <strong>Firefox</strong>
 
 ;Fast for good.
 Definitivament veloç.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Conegueu el Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nou. Ràpid. Per sempre.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Baixa'l ara
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Renoveu el Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Seguiu <a href="%(url)s">aquestes instruccions</a> per instal·lar el Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Opcions avançades d'instal·lació i altres plataformes
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Opcions avançades d'instal·lació i altres plataformes
-
-
-;Keep up with<br> all things Firefox.
-Mantingueu-vos al dia<br>del Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Baixeu el Firefox <span>per al Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Baixeu el Firefox <span>per al macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Baixeu el Firefox <span>per al Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Baixeu-lo per a altres plataformes i llengües
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Baixeu-lo en una altra llengua
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-La baixada s'iniciarà automàticament. No funciona? <a id="%(id)s" href="%(fallback_url)s">Proveu de baixar-lo de nou</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-La baixada s'iniciarà automàticament. Si no és així, <a id="%(id)s" href="%(fallback_url)s">feu clic aquí</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Som-hi!
-
-
-;Sync up with Firefox on mobile:
-Sincronitzeu amb el Firefox en el mòbil:
 
 
 # HTML page title prefix
@@ -170,14 +22,6 @@ Navegador web gratuït
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Baixeu el Mozilla Firefox, un navegador web lliure i gratuït. El Firefox està creat per una organització global sense ànim de lucre dedicada a donar el control als usuaris. Instal·leu ara el Firefox per al Windows, macOS, Linux, Android i iOS!
-
-
-;Download the fastest Firefox ever
-Baixeu el Firefox més ràpid que mai
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-El nou Firefox ja és aquí: carrega les pàgines més ràpid, consumeix menys memòria i està farcit de noves funcions.
 
 
 ;2x Faster
@@ -202,41 +46,5 @@ Privadesa absoluta
 
 ;Truly Private Browsing with Tracking Protection
 Navegació realment privada amb protecció contra el seguiment
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Us donem la benvinguda al Firefox
-
-
-;Take Firefox with You
-El vostre Firefox, a tot arreu
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Accediu a les vostres adreces d'interès, historial, contrasenyes i preferències en tots els vostres dispositius.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Ja utilitzeu el Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Inicieu la sessió per sincronitzar les vostres adreces d'interès, contrasenyes i altres dades que hàgiu desat al Firefox en altres dispositius.
-
-
-;Learn more about Firefox Accounts
-Més informació sobre el Compte del Firefox
-
-
-;Skip this step
-Omet aquest pas
-
-
-# Old firstrun page
-;Chart your own course
-Decidiu el vostre propi camí
 
 

--- a/ca/firefox/campaign.lang
+++ b/ca/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/cak/firefox/campaign.lang
+++ b/cak/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-¡Kakikot! Tajin nawokisaj ri ruk'isib'äl ruwäch chi Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Tik'ex ruwäch</a> ri Firefox richin ri ruk'isib'äl pa ruwi' aninem chuqa' ichinanem.
-
-
-;You’re using a pre-release version of Firefox.
-Tajin nawokisaj jun nab'ey ruwäch chi Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Nawokisaj jun ojer chuqa' man ütz ta samajel q'inoj <a href="%(url)s">ri man nuk'ül ta chik ruk'exoj Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Ri k'ak'a' <strong>Firefox</strong>
 
 ;Fast for good.
 Junelïk aninäq.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Titamäx ruwäch Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-K'ak'a'. Aninäq. Junelïk.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Tiqasäx Wakami
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Titzolïx Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Tab'ana' utzil ke'awoqaj <a href="%(url)s">re taq k'utunem</a> richin niyak ri Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Q'axinäq taq Rucha'oj Yakoj chuqa' Ch'aqa' chik taq Nuk'uche'el
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Q'axinäq taq rucha'oj yakoj chuqa' ch'aqa' chik taq nuk'uche'el
-
-
-;Keep up with<br> all things Firefox.
-Tik'oje' rik'in<br> ronojel ri taq rub'anikil Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Tiqasäx Firefox <span>richin Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Tiqasäx Firefox <span>richin macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Tiqasäx Firefox <span>richin Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Tiqasäx kichin ch'aqa' chik taq nuk'uche'el & taq ch'ab'äl
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Tiqasäx pa jun chik ch'ab'äl
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Ruyonil xtutikirisaj ri aqasanik. ¿La man nub'än ta? <a id="%(id)s" href="%(fallback_url)s">Titojtob'ëx niqasäx chik</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Pa ruyonil xutikirisaj ri aqasanik. We man nub'än ta <a id="%(id)s" href="%(fallback_url)s">tipitz' wawe'</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Tawetamaj rub'eyal nab'än na'owinäq, aninäq chuqa' jikïl chi re ri Firefox.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Ke'ak'ulu' taq etamanel pixa', q'oloj chuqa' k'ak'a' taq tikojil pa ataqob'äl.
-
-
-;Enter your email address
-Tatz'ib'aj ri rochochib'al ataqoya'l
-
-
-;How will Mozilla use my email?
-¿Achike rub'eyal nrokisaj nutaqoya'l ri Mozilla?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Pa Mozilla man xa xe ta niya' ruq'ij ri richinanem chuqa' ri rujikomal ataqoya'l – richin ri <a href="%(manifesto)s">Qatzijoxik</a>: “Ri kijikomal chuqa' kichinanem winaqi' pa k'amaya'l yalan kejqalem, ri man ruk'amon ta yetz'et xab'achike.” <a href="%(principles)s">Yatikïr nawetamaj ch'aqa' chik chi rij ri ruk'u'x kichinanem qatzij wawe'</a>.
-
-
-;What we want you to know:
-Niqajo' chi tawetamaj:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Man k'atzinel ta naya' ataqoya'l chi qe richin naqasaj chuqa' nawokisaj Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Niqak'utuj ri ataqoya'l ruma ri qetamab'al nuk'üt chi ri winaqi' nikik'ül nab'ey taq tzij yalan nisamäj chuqa' yalan ütz nisamäj rik'in ri Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Yatikïr ye'ak'ül taq taqoya'l enuk'un richin yatikito' rik'in rutzil Firefox richin ütz tisamäj chawäch, nawetamaj ch'aqa' chik pa ruwi' ichinanem chuqa' jikomal chuqa' nawïl achike rub'eyal nawutzilaj ri aramaj pan ajk'amaya'l.
-
-
-;You can unsubscribe anytime, for any reason.
-Yatikïr nayüj el ab'i' xab'achike ramaj, ruma xab'achike aruma.
-
-
-;We will not share, sell or use your email for any other purposes.
-Majun aruma xtiqakomonij, xtiqak'ayij chuqa' xtiqokisaj ri ataqoya'l.
-
-
-;Let’s do this!
-¡Tiqab'ana'!
-
-
-;Sync up with Firefox on mobile:
-Tixim rik'in ri Firefox pan oyonib'äl:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Sipan chi Ajk'amaya'l Okik'amaya'l
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Taqasaj Mozilla Firefox, jun sipan okik'amaya'l. Firefox nuk'un ruma jun ajronojel moloj ri majun ch'akoj rutzeqelib'en, ri nusamajij rij chi ri winaqi' tik'oje' kiq'ij pa ri k'amab'ey. ¡Wakami tak'ulu' Firefox richin Windows MacOS, Linux, Android chuqa' iOS!
-
-
-;Download the fastest Firefox ever
-Tiqasäx ri Firefox, ri janila chi aninäq majub'ey titz'et
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Ri rusamajib'exik ri aninäq ruxaq, rokisaxik jub'a' tzatzq'ob'äl chuqa' nojinäq chi b'anikil, wawe' k'o wi ri k'ak'a' Firefox.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Nïm ruchuq'a' ichinanem
 
 ;Truly Private Browsing with Tracking Protection
 Qitzij Ichinan Okik'amaya'l rik'in Chajinïk chuwäch Ojqanïk
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Ütz apetik pa Firefox
-
-
-;Take Firefox with You
-Tak'waj ri Firefox Awik'in
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Ke'ak'waj ri taq yaketal, natab'äl, ewan taq tzij chuqa' ch'aqa' chik taq nuk'ulem pa konojel taq awokisaxel.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-¿La tajin chik nawokisaj ri Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Tatikirisaj molojri'ïl pa ri ataqoya'l richin yeqaxïm ri taq yaketal, ewan taq tzij chuqa' ri ch'aqa' chik utziläj taq wachinäq e'ayakon pa ch'aqa' chik taq okisaxel.
-
-
-;Learn more about Firefox Accounts
-Tawetamaj ch'aqa' chik pa ruwi' ri Firefox Taqoya'l
-
-
-;Skip this step
-Choj tik'o re jun ruxak re'
-
-
-# Old firstrun page
-;Chart your own course
-Tajaqa' ri ab'ey
 
 

--- a/cak/firefox/campaign.lang
+++ b/cak/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/crh/firefox/campaign.lang
+++ b/crh/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Congrats! You’re using the latest version of Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refresh Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Free Web Browser
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/cs/firefox/campaign.lang
+++ b/cs/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Gratulujeme! Používáte nejnovější verzi Firefoxu.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Aktualizujte</a> svůj Firefox pro vyšší rychlost a ochranu soukromí.
-
-
-;You’re using a pre-release version of Firefox.
-Používáte nefinální verzi Firefoxu.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Používáte zastaralou verzi operačního systému, <a href="%(url)s">kterou už Firefox nepodporuje</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Nový <strong>Firefox</strong>
 
 ;Fast for good.
 Vždy rychlý.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Poznejte Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nový. Rychlý. Prostě dobrý.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Stáhnout
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Obnovit Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Pro instalaci Firefoxu prosím <a href="%(url)s">postupujte podle těchto pokynů</a>.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Pokročilé možnosti instalace a další platformy
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Pokročilé možnosti instalace a další platformy
-
-
-;Keep up with<br> all things Firefox.
-Zůstaňte ve spojení<br> s Firefoxem.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Stáhnout Firefox <span>pro Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Stáhnout Firefox <span>pro macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Stáhnout Firefox <span>pro Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Stáhnout pro jiné platformy a jazyky
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Stáhnout v jiném jazyce
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Vaše stahování by mělo začít automaticky. Nezačalo? <a id="%(id)s" href="%(fallback_url)s">Zkuste to znova</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Stahování by mělo automaticky začít během několika sekund. Pokud ne, <a id="%(id)s" href="%(fallback_url)s">klepněte zde</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Zjistěte, jak můžete Firefox zrychlit, zabezpečit a dále vylepšit.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Nechte si do své schránky posílat oznámení, tipy a triky.
-
-
-;Enter your email address
-Zadejte svou e-mailovou adresu
-
-
-;How will Mozilla use my email?
-Jak bude Mozilla používat můj e-mail?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla si vašeho soukromí a bezpečnosti nejen váží, ale jsou přímo nedílnou součástí našeho <a href="%(manifesto)s">Manifestu</a>: „Bezpečnost každého na internetu je stěžejní a nemůže být brána na lehkou váhu.“ O našich principech ochrany dat se <a href="%(principles)s">dočtete zde</a>.
-
-
-;What we want you to know:
-Co byste měli vědět:
-
-
-;You don’t need to give us your email to download and use Firefox.
-V žádném případě nám nepotřebujete dávat svou e-mailovou adresu pro stažení ani pro používání Firefoxu.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-O vaši adresu vás žádáme, protože náš průzkum prokázal, že pokud si necháte poslat úvodní informace, budete s Firefoxem spokojenější.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Můžete od nás očekávat zprávy, které vám pomohou nastavit Firefox přímo pro vás a zjistit více o jeho funkcích pro ochranu soukromí a zabezpečení.
-
-
-;You can unsubscribe anytime, for any reason.
-Kdykoliv a z jakéhokoliv důvodu se můžete z odběru e-mailů odhlásit.
-
-
-;We will not share, sell or use your email for any other purposes.
-Vaši e-mailovou adresu nebudeme s nikým sdílet, nikomu ji neprodáme a ani sami ji nepoužijem pro jiné účely.
-
-
-;Let’s do this!
-Pojďme na to!
-
-
-;Sync up with Firefox on mobile:
-Synchronizace s Firefoxem na mobilu:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Webový prohlížeč zdarma
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Stáhněte si Mozillu Firefox, svobodný webový prohlížeč. Firefox je vyvíjen neziskovou organizací s cílem dát kontrolu nad internetem do vašich rukou. Stáhněte si Firefox pro Windows, macOS, Linux, Android nebo iOS!
-
-
-;Download the fastest Firefox ever
-Stáhněte si ten nejrychlejší Firefox
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Rychlejší načítání stránek, menší spotřeba paměti a plno funkcí - je tu nový Firefox.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Zaměřený na soukromí
 
 ;Truly Private Browsing with Tracking Protection
 Skutečně anonymní prohlížení s ochranou proti sledování
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Vítejte ve Firefoxu
-
-
-;Take Firefox with You
-Vezměte si Firefox s sebou
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Mějte své záložky, historii i uložená hesla s sebou na všech svých zařízeních.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Už Firefox používáte?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Přihlaste se do svého účtu a my zařídíme, že se synchronizují záložky, hesla a další skvělé věci, které jste uložili do Firefoxu na jiných zařízeních.
-
-
-;Learn more about Firefox Accounts
-Zjistěte více o účtech Firefoxu
-
-
-;Skip this step
-Přeskočit tento krok
-
-
-# Old firstrun page
-;Chart your own course
-Vyberte si svůj vlastní směr
 
 

--- a/cs/firefox/campaign.lang
+++ b/cs/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/cy/firefox/campaign.lang
+++ b/cy/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/cy/firefox/campaign.lang
+++ b/cy/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Llongyfarchiadau! Rydych yn defnyddio'r fersiwn diweddaraf o Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Diweddarwch</a> eich Firefox am y cyflymder a'r preifatrwydd diweddaraf.
-
-
-;You’re using a pre-release version of Firefox.
-Rydych yn defnyddio fersiwn cyn ei ryddhau o Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Rydych yn defnyddio system weithredu hen ac anniogel <a href="%(url)s">sydd ddim yn cael ei gynnal bellach gan Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Y <strong>Firefox</strong> newydd
 
 ;Fast for good.
 Cyflym am byth.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Dyma Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Newydd. Cyflym. Am byth.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Llwythwch i Lawr Nawr
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Adnewyddu Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Dilynwch <a href="%(url)s">y cyfarwyddiadau hyn</a> er mwyn gosod Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Ddewisiadau Gosod Uwch a Llwyfannau eraill
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Ddewisiadau gosod uwch a llwyfannau eraill
-
-
-;Keep up with<br> all things Firefox.
-Cadw'n gyfredol<br> gyda phopeth Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Llwytho Firefox i lawr <span>ar gyfer Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Llwytho Firefox i lawr <span>ar gyfer macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Llwytho Firefox i lawr <span>ar gyfer Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Llwytho i lawr ar gyfer llwyfannau ac ieithoedd eraill
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Llwytho i lawr mewn iaith arall
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Dylai'r llwytho ddigwydd yn awtomatig. Heb weithio? <a id="%(id)s" href="%(fallback_url)s">Ceisiwch eto</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Dylai eich llwytho i lawr gychwyn yn awtomatig. Os nad yw, <a id="%(id)s" href="%(fallback_url)s">cliciwch yma</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Gweld sut mae gwneud Firefox yn glyfrach, cynt a mwy diogel.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Derbyn awgrymiadau defnyddiol, triciau a chyhoeddiadau am gynnyrch yn syth i'ch blwch derbyn.
-
-
-;Enter your email address
-Rhowch eich cyfeiriad e-bost
-
-
-;How will Mozilla use my email?
-Sut fydd Mozilla'n defnyddio fy e-bost?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mae Mozilla yn rhoi pwys mawr ar breifatrwydd a diogelwch eich e-byst - mae'n rhan o'n <a href="%(manifesto)s">Maniffesto</a>: “Mae diogelwch a phreifatrwydd unigolion ar y rhyngrwyd yn fater sylfaenol ac ni ddylent gael eu trin fel pethau dewisol." <a href="%(principles)s">Mae modd darllen rhagor am ein Hegwyddorion Preifatrwydd Data yma</a>.
-
-
-;What we want you to know:
-Beth rydym am i chi wybod:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Does dim angen i chi roi eich e-bost i ni cyn llwytho i lawr a defnyddio Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Rydym yn gofyn am eich e-bost gan fod ein hymchwil yn dangos fod pobl sydd wedi derbyn cyflwyniad cychwynnol yn gwneud mwy ac yn well gyda Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Gallwch ddisgwyl e-byst wedi eu cynllunio i'ch helpu i wneud Firefox i weithio'n well i chi, dysgu rhagor am breifatrwydd a diogelwch a gweld sut mae gwneud y gorau o'ch amser ar y we.
-
-
-;You can unsubscribe anytime, for any reason.
-Gallwch ddad-danysgrifo ar unrhyw adeg, am unrhyw reswm.
-
-
-;We will not share, sell or use your email for any other purposes.
-Gallwch ddad-danysgrifo ar unrhyw adeg, am unrhyw reswm.
-
-
-;Let’s do this!
-Mae'n amser gweithredu!
-
-
-;Sync up with Firefox on mobile:
-Cydweddwch gyda Firefox symudol:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Porwr Gwe am Ddim
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Llwythwch Mozilla Firefox i lawr, mae'n borwr gwe rhydd a rhad. Mae Firefox wedi ei greu gan gorff byd-eang, dim-er-elw sydd a'i fryd ar roi grym i unigolion ar-lein. Defnyddiwch Firefox ar Windows, macOS, Linux, Android ac iOS heddiw!
-
-
-;Download the fastest Firefox ever
-Llwythwch i lawr y Firefox cyflymaf erioed
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Llwytho tudalennau cynt, llai o ddefnydd o gof, ac yn llawn nodweddion, mae'r Firefox newydd wedi cyrraedd.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Preifatrwydd pwerus
 
 ;Truly Private Browsing with Tracking Protection
 Pori Preifat Go Iawn gyda Diogelu rhag Tracio
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Croeso i Firefox
-
-
-;Take Firefox with You
-Cymrwch Firefox gyda Chi
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Cewch eich nodau tudalen, hanes, cyfrineiriau a gosodiadau eraill ar eich holl ddyfeisiau.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Yn defnyddio Firefox yn barod?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Mewngofnodwch i'ch cyfrif ac mi wnawn ni gydweddu'r nodau tudalen, cyfrineiriau a phethau gwerthfawr eraill rydych wedi eu cadw i Firefox ar ddyfeisiau eraill.
-
-
-;Learn more about Firefox Accounts
-Dysgu rhagor am Gyfrif Firefox
-
-
-;Skip this step
-Hepgor y cam hwn
-
-
-# Old firstrun page
-;Chart your own course
-Crëwch eich ffordd eich hun
 
 

--- a/da/firefox/campaign.lang
+++ b/da/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Tillykke! Du benytter den seneste version af Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Opdatér</a> Firefox og få det nyeste inden for hastighed og privatliv.
-
-
-;You’re using a pre-release version of Firefox.
-Du bruger en tidlig udgivelse af Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Du bruger et usikkert og forældet styresystem, <a href="%(url)s">der ikke længere understøttes af Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Den nye <strong>Firefox</strong>
 
 ;Fast for good.
 Den hurtigste browser.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Mød Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Ny. Hurtig. For altid.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Hent nu
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Nulstil Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Følg <a href="%(url)s">vejledningen</a> for at installere Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Andre installationsmuligheder og platforme
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Andre installationsmuligheder og platforme
-
-
-;Keep up with<br> all things Firefox.
-Få nyheder<br> om Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Hent Firefox <span>til Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Hent Firefox <span>til macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Hent Firefox <span>til Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Firefox til andre platforme og sprog
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Hent på et andet sprog
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Din download skulle gerne begynde automatisk. Virker det ikke? <a id="%(id)s" href="%(fallback_url)s">Prøv at hente igen</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Din download skulle gerne begynde automatisk. Hvis det ikke sker, så <a id="%(id)s" href="%(fallback_url)s">klik her</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Lær at gøre Firefox endnu smartere, hurtigere og sikrere.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Få nyttige tips, tricks og nyheder om vores produkter direkte i din indbakke.
-
-
-;Enter your email address
-Indtast din mailadresse
-
-
-;How will Mozilla use my email?
-Hvordan bruger Mozilla min mailadresse?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Beskyttelse af dit privatliv og sikkerhed omkring din mailadresse er så vigtigt for Mozilla, at det er en del af <a href="%(manifesto)s"> vores manifest</a>: "Individets sikkerhed og ret til privatliv på internettet er grundlæggende og må ikke betragtes som noget, der kan vælges fra." <a href="%(principles)s">Læs mere om vores principper for beskyttelse af private data her</a>.
-
-
-;What we want you to know:
-Hvad du skal vide:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Du er ikke nødt til at give os din mailadresse for at hente og anvende Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Vi spørger efter din mailadresse, fordi vores undersøgelser viser, at folk får mere ud af Firefox, hvis de får en introduktion.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Du kan forvente at modtage mails, der skal gøre dig bedre til at få Firefox til at fungere bedst muligt for dig. Vi lærer dig også at beskytte dit privatliv bedre, om sikkerhed, og hvordan du får den bedste oplevelse på nettet.
-
-
-;You can unsubscribe anytime, for any reason.
-Du kan altid vælge ikke at modtage flere mails.
-
-
-;We will not share, sell or use your email for any other purposes.
-Vi hverken deler, sælger eller anvender din mailadresse til andre formål end dem beskrevet på siden.
-
-
-;Let’s do this!
-Lad os gøre det!
-
-
-;Sync up with Firefox on mobile:
-Synkronisér med Firefox på mobilen:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Gratis browser
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Hent Mozilla Firefox, en gratis browser. Firefox er skabt af en global nonprofit-organisation, der arbejder ihærdigt på at give den enkelte bruger kontrol på nettet. Hent Firefox til Windows, macOS, Linux, Android og iOS i dag!
-
-
-;Download the fastest Firefox ever
-Hent den hurtigste Firefox nogensinde
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Hurtigere indlæsning af sider, mindre brug af hukommelse og proppet med nye funktioner - Den nye Firefox er her.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Bedre beskyttelse af dit privatliv
 
 ;Truly Private Browsing with Tracking Protection
 Ægte beskyttelse af privatlivet med beskyttelse mod sporing
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Velkommen til Firefox
-
-
-;Take Firefox with You
-Tag Firefox med dig
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Få dine bogmærker, historik, adgangskoder og andre indstillinger på alle dine enheder.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Bruger du allerede Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Log ind på din konto, så vil vi synkronisere bogmærkerne, adgangskoderne og andre ting, du har gemt i Firefox på andre enheder.
-
-
-;Learn more about Firefox Accounts
-Læs mere om Firefox-konti
-
-
-;Skip this step
-Spring dette trin over
-
-
-# Old firstrun page
-;Chart your own course
-Læg din egen kurs
 
 

--- a/da/firefox/campaign.lang
+++ b/da/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/de/firefox/campaign.lang
+++ b/de/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/de/firefox/campaign.lang
+++ b/de/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Perfekt! Du hast die neueste Version von Firefox am Start.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Bitte aktualisiere Firefox</a>– für optimale Geschwindigkeit und maximale Privatsphäre.
-
-
-;You’re using a pre-release version of Firefox.
-Du verwendest eine Vorabversion von Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Sie verwenden ein unsicheres, veraltetes Betriebssystem, <a href="%(url)s">das von Firefox nicht mehr unterstützt wird</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Der neue <strong>Firefox</strong>
 
 ;Fast for good.
 Schnell. Und richtig gut.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Firefox Quantum ist da
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Neu. Schnell. Und richtig gut.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Jetzt herunterladen
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox bereinigen
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Bitte folge <a href="%(url)s">dieser Anleitung</a>, um Firefox zu installieren.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Erweiterte Installationsoptionen & andere Plattformen
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Erweiterte Installationsoptionen & andere Plattformen
-
-
-;Keep up with<br> all things Firefox.
-Dranbleiben mit dem Firefox Newsletter.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Jetzt Firefox <span>für Windows</span> herunterladen
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Jetzt Firefox <span>für macOS</span> herunterladen
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Jetzt Firefox <span>für Linux</span> herunterladen
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Firefox für andere Plattformen & Sprachen herunterladen
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-In anderer Sprachversion herunterladen
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Der Download startet automatisch. Klappt nicht? <a id="%(id)s" href="%(fallback_url)s">Starten Sie den Download erneut</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Dein Download startet automatisch. Falls nicht <a id="%(id)s" href="%(fallback_url)s">bitte hier klicken</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Erfahren Sie, wie Sie Firefox noch intelligenter, schneller und sicher machen.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Erhalten Sie informative Tipps, Tricks und Produktankündigungen direkt in Ihren Posteingang.
-
-
-;Enter your email address
-Gib deine E-Mail-Adresse an
-
-
-;How will Mozilla use my email?
-Wie verwendet Mozilla meine E-Mail-Adresse?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla ist der Schutz Ihrer E-Mail-Privatsphäre und -Sicherheit nicht nur wichtig – sie sind Teil unseres <a href="%(manifesto)s">Manifests</a>:„ Individuelle Sicherheit und Datenschutz im Internet sind von grundlegender Bedeutung und dürfen nicht als optional betrachtet werden.“ <a href="%(principles)s">Hier können Sie mehr über unsere Prinzipien zur Datensicherheit erfahren</a>.
-
-
-;What we want you to know:
-Was Sie wissen sollten:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Sie müssen Ihre E-Mail-Adresse nicht angeben, um Firefox herunterzuladen und zu verwenden.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Wir fragen nach Ihrer E-Mail-Adresse, weil unsere Forschung zeigt, dass Menschen, die eine Einführung erhalten, mehr und besser mit Firefox arbeiten.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Sie können E-Mails erwarten, mit deren Hilfe Sie besser mit Firefox arbeiten können, mehr über Datenschutz und Sicherheit erfahren und herausfinden, wie Sie Ihre Zeit im Internet am besten nutzen können.
-
-
-;You can unsubscribe anytime, for any reason.
-Sie können den Newsletter jederzeit aus beliebigen Gründen abbestellen.
-
-
-;We will not share, sell or use your email for any other purposes.
-Wir werden Ihre E-Mail-Adresse nicht weitergeben, verkaufen oder zu anderen Zwecken nutzen.
-
-
-;Let’s do this!
-Los geht’s!
-
-
-;Sync up with Firefox on mobile:
-Synchronisation mit Firefox für Mobilgeräte:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Der kostenlose Webbrowser
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, den kostenlosen Browser für Windows, macOS, Linux, Android oder iOS. Firefox ist Teil von Mozilla – der Non-Profit-Organisation, die sich für Deine Online-Rechte stark macht.
-
-
-;Download the fastest Firefox ever
-Jetzt den schnellsten Firefox aller Zeiten herunterladen
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Der neue Firefox: Schnellere Seitenladezeiten, weniger Speicherverbrauch und vollgepackt mit neuen Funktionen.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Liebt Deine Privatsphäre
 
 ;Truly Private Browsing with Tracking Protection
 Privat Surfen plus Schutz vor Aktivitätenverfolgung
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Willkommen bei Firefox
-
-
-;Take Firefox with You
-Firefox für unterwegs
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Nehmen Sie Ihre Lesezeichen, Chronik, Passwörter und andere Einstellungen auf allen Geräten mit.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Nutzt Du bereits Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Melde Dich bei Deinem Konto an und schon synchronisieren wir Lesezeichen, Passwörter und was Du sonst noch mit Firefox auf anderen Geräten gespeichert hast.
-
-
-;Learn more about Firefox Accounts
-Jetzt mehr über Firefox Konten erfahren
-
-
-;Skip this step
-Diesen Schritt überspringen
-
-
-# Old firstrun page
-;Chart your own course
-Willkommen in der Freiheit
 
 

--- a/dsb/firefox/campaign.lang
+++ b/dsb/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/dsb/firefox/campaign.lang
+++ b/dsb/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Glukužycenje! Wužywaśo nejnowšu wersiju Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Aktualizěrujśo</a> swój Firefox za nejnowše w malsnosći a priwatnosći.
-
-
-;You’re using a pre-release version of Firefox.
-Wužywaśo pśedwersiju Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Wužywaśo njewěsty, zestarjony źěłowy system, kótaryž <a href="%(url)s">se wěcej wót Firefox njedpódpěra</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Nowy <strong>Firefox</strong>
 
 ;Fast for good.
 Malsny a dobry.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Póznajśo Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nowy. Malsny. Za dobre.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Něnto ześěgnuś
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox aktualizěrowaś
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Pšosym slědujśo <a href="%(url)s">toś tym instrukcijam</a> za instalěrowanje Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Rozšyrjone instalěrowańske nastajenja a druge platformy
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Rozšyrjone instalěrowańske nastajenja a druge platformy
-
-
-;Keep up with<br> all things Firefox.
-Wóstańśo ze<br> wšym wó Firefox na běžnem.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Ześěgniśo Firefox <span>za Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Ześěgniśo Firefox <span>za macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Ześěgniśo Firefox <span>za Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Za druge platformy a rěcy ześěgnuś
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-W drugej rěcy ześěgnuś
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Wašo ześěgnjenje dejało se awtomatiski zachopiś. Njefunkcioněrujo? <a id="%(id)s" href="%(fallback_url)s">Ześěgniśo znowego</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Wašo ześěgnjenje dejało se awtomatiski zachopiś. Jolic nic, <a id="%(id)s" href="%(fallback_url)s">klikniśo how</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Zgóńśo, kak móžośo Firefox hyšći wěcej inteligentny, malsnjejšy a wěsćejšy cyniś.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Dostańśo informatiwne pokazki, triki a produktowe pśipowěźenja direktnje we swójom postowem dochaźe.
-
-
-;Enter your email address
-Zapódajśo swóju e-mailowu adresu
-
-
-;How will Mozilla use my email?
-Kak buźo Mozilla móju e-mailowu adresu wužywaś?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla sej nic jenož wašu e-mejlowu priwatnosć a wěstotu waži - je dźěl našeho <a href="%(manifesto)s">manifesta</a>: “Wěstota a priwatnosć jadnych samych w interneśe su fundamentalne a njesměju se za opcionalne měś.” <a href="%(principles)s">How móžośo wěcej wó našych principach datoweje priwatnosći zgóniś</a>.
-
-
-;What we want you to know:
-To wy měł wěźeś:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Njetrjebaśo wašu e-mailowu adresu pódaś, aby Firefox ześěgnuł a wužywał.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Smy se za wašeju e-mailoweju adresu pšašali, dokulaž našo slěźenje pokazujo, až luźe, kótarež zapokazanje dostawaju, wěcej a lěpjej z Firefox źěłaju.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Móžośo mejlki wótcakowaś, kótarež wam maju pomagaś, Firefox optiměrowaś, aby nejlěpje za was funkciobněrował, wěcej wó priwatnosći a wěstośe zgóniś a wuslěźiś, kak móžośo swój cas w interneśe nejlěpjej wužywaś.
-
-
-;You can unsubscribe anytime, for any reason.
-Móžośo jen kuždy cas bźez pśicyny wótskazaś.
-
-
-;We will not share, sell or use your email for any other purposes.
-Njebuźomy wašu e-mailowu adresu dalej dawaś, pśedawać abo za druge zaměry wužywaś.
-
-
-;Let’s do this!
-Zachopmy!
-
-
-;Sync up with Firefox on mobile:
-Synchronizacija z Firefox na mobilnem rěźe:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Dermotny webwobglědowak
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Ześěgniśo Mozilla Firefox, dermotny webwobglědowak. Firefox jo se wót za wše wužytneje organizacije wuwił, kótaraž so za to zasajźujo, až kuždy ma kontrolu online. Wobstarajśo se źinsa Firefox za Windows, macOS, Linux, Android a iOS!
-
-
-;Download the fastest Firefox ever
-Ześěgniśo nejmalsnjejšy Firefox
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Boki se malsnjej zacytaju, mjenjej składa se wužywa a z wjele funkcijami: Nowy Firefox jo wujšeł.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Mócnje priwatny
 
 ;Truly Private Browsing with Tracking Protection
 Napšawdu priwatny modus ze slědowańskim šćitom
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Witajśo k Firefox
-
-
-;Take Firefox with You
-Wzejśo Firefox sobu
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Wzejśo swóje cytańske znamjenja, historiju, gronidła a druge nastajenja na wšych wašych rědach sobu.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Wužywaśo južo Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Pśizjawśo se pla swójogo konta a buźomy cytańske znamjenja, gronidła a druge wjelicne wěcy synchronizěrowaś, kótarež sćo w Firefox na drugich rědach składł.
-
-
-;Learn more about Firefox Accounts
-Zgóńśo wěcej wó kontach Firefox
-
-
-;Skip this step
-Toś ten kšac pśeskócyś
-
-
-# Old firstrun page
-;Chart your own course
-Wugótujśo swój kurs
 
 

--- a/el/firefox/campaign.lang
+++ b/el/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Συγχαρητήρια! Χρησιμοποιείτε την πιο πρόσφατη έκδοση του Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Ενημερώστε</a> το Firefox για βελτιωμένη ταχύτητα και ιδιωτικότητα.
-
-
-;You’re using a pre-release version of Firefox.
-Χρησιμοποιείτε μια προ-έκδοση του Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Χρησιμοποιείτε ένα επισφαλές, παρωχημένο λειτουργικό σύστημα, <a href="%(url)s">που δεν υποστηρίζεται πλέον από το Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@
 
 ;Fast for good.
 Ακόμη πιο γρήγορο.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Γνωρίστε το Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Νέο. Γρήγορο. Για πάντα.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Λήψη τώρα
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Ανανεώστε τον Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Παρακαλώ ακολουθήστε <a href="%(url)s">αυτές τις οδηγίες</a> για εγκατάσταση του Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Προηγμένες επιλογές εγκατάστασης & άλλες πλατφόρμες
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Προηγμένες επιλογές εγκατάστασης & άλλες πλατφόρμες
-
-
-;Keep up with<br> all things Firefox.
-Μη χάσετε <br> τα νέα του Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Λήψη του Firefox <span>για Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Λήψη του Firefox <span>για macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Λήψη του Firefox <span>για Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Λήψη για άλλες πλατφόρμες & γλώσσες
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Λήψη σε μια άλλη γλώσσα
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Η λήψη θα ξεκινήσει αυτόματα. Δεν άρχισε; <a id="%(id)s" href="%(fallback_url)s">Νέα δοκιμή λήψης</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Η λήψη σας θα ξεκινήσει αυτόματα. Αν όχι, <a id="%(id)s" href="%(fallback_url)s">κάντε κλικ εδώ</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Μάθετε πώς να κάνετε το Firefox ακόμη πιο έξυπνο, ταχύ και ασφαλές.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Λάβετε χρήσιμες συμβουλές, κόλπα και ανακοινώσεις προϊόντων στα εισερχόμενά σας.
-
-
-;Enter your email address
-Εισάγετε τη διεύθυνση email σας
-
-
-;How will Mozilla use my email?
-Πώς θα χρησιμοποιήσει η Mozilla το email μου;
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Η Mozilla δεν σέβεται απλά το απόρρητο και την ασφάλεια του email σας – είναι μέρος του <a href="%(manifesto)s">μανιφέστου</a> μας: “Η ασφάλεια και το απόρρητο των ατόμων στο διαδίκτυο είναι θεμελιώδη και δεν πρέπει να αντιμετωπίζονται ως προαιρετικά.” <a href="%(principles)s">Μπορείτε να μάθετε σχετικά με τις αρχές απορρήτου δεδομένων εδώ</a>.
-
-
-;What we want you to know:
-Τι θέλουμε να γνωρίζετε:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Δεν χρειάζεται να μας δώσετε το email σας για να κάνετε λήψη και χρήση του Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Ζητήσαμε το email σας, επειδή η έρευνά μας δείχνει ότι τα άτομα που λαμβάνουν μια εισαγωγική εμπειρία κάνουν περισσότερα και καλύτερα με το Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Μπορείτε να αναμένετε emails που έχουν σχεδιαστεί για να σάς βοηθήσουν να βελτιστοποιήσετε το Firefox έτσι, ώστε να λειτουργεί καλύτερα για εσάς, για να μαθαίνετε περισσότερα σχετικά με το απόρρητο & την ασφάλεια και για να μάθετε πώς να αξιοποιήσετε στο έπακρο το χρόνο σας στο διαδίκτυο.
-
-
-;You can unsubscribe anytime, for any reason.
-Μπορείτε να καταργήσετε την εγγραφή σας ανά πάσα στιγμή, για οποιοδήποτε λόγο.
-
-
-;We will not share, sell or use your email for any other purposes.
-Δεν θα κοινοποιήσουμε, πωλήσουμε ή χρησιμοποιήσουμε το email σας για οποιοδήποτε άλλο σκοπό.
-
-
-;Let’s do this!
-Ας το κάνουμε!
-
-
-;Sync up with Firefox on mobile:
-Συγχρονίστε με το Firefox στις κινητές σας συσκευές:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Κάντε λήψη του Mozilla Firefox, ένα δωρεάν πρόγραμμα περιήγησης του Ιστού. Το Firefox δημιουργήθηκε από ένα παγκόσμιο, μη κερδοσκοπικό ίδρυμα με σκοπό να έχει ο χρήστης τον έλεγχο της ψηφιακής ζωής του. Αποκτήστε σήμερα το Firefox για Windows, macOS, Linux, Android και iOS!
-
-
-;Download the fastest Firefox ever
-Λήψη του πιο γρήγορου Firefox
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Ταχύτερη φόρτωση σελίδων, λιγότερη χρήση μνήμης και γεμάτο με λειτουργίες, το νέο Firefox έφτασε.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@
 
 ;Truly Private Browsing with Tracking Protection
 Πραγματικά ιδιωτική περιήγηση με προστασία από καταγραφή
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Καλώς ορίσατε στο Firefox
-
-
-;Take Firefox with You
-Πάρτε μαζί σας το Firefox
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Κρατήστε τα αγαπημένα, το ιστορικό, τους κωδικούς πρόσβασης και άλλες ρυθμίσεις σας σε όλες σας τις συσκευές.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Χρησιμοποιείτε ήδη το Firefox;
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Συνδεθείτε στο λογαριασμό σας και θα συγχρονίσουμε τους σελιδοδείκτες, τους κωδικούς κι άλλα σπουδαία πράγματα που αποθηκεύσατε στο Firefox σε άλλες συσκευές.
-
-
-;Learn more about Firefox Accounts
-Μάθετε περισσότερα για τους λογαριασμούς Firefox
-
-
-;Skip this step
-Παράβλεψη βήματος
-
-
-# Old firstrun page
-;Chart your own course
-Χαράξτε τη δική σας πορεία
 
 

--- a/el/firefox/campaign.lang
+++ b/el/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/en-CA/firefox/campaign.lang
+++ b/en-CA/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Congrats! You’re using the latest version of Firefox. {ok}
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy. {ok}
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox. {ok}
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>. {ok}
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ The new <strong>Firefox</strong> {ok}
 
 ;Fast for good.
 Fast for good. {ok}
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum {ok}
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good. {ok}
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now {ok}
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refresh Firefox {ok}
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox. {ok}
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms {ok}
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms {ok}
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox. {ok}
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span> {ok}
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span> {ok}
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span> {ok}
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages {ok}
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language {ok}
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>. {ok}
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>. {ok}
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure. {ok}
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox. {ok}
-
-
-;Enter your email address
-Enter your email address {ok}
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email? {ok}
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>. {ok}
-
-
-;What we want you to know:
-What we want you to know: {ok}
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox. {ok}
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox. {ok}
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web. {ok}
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason. {ok}
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes. {ok}
-
-
-;Let’s do this!
-Let’s do this! {ok}
-
-
-;Sync up with Firefox on mobile:
-Synchronize with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Free Web Browser {ok}
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today! {ok}
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever {ok}
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here. {ok}
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Powerfully private {ok}
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection {ok}
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox {ok}
-
-
-;Take Firefox with You
-Take Firefox with You {ok}
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices. {ok}
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox? {ok}
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll synchronize the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts {ok}
-
-
-;Skip this step
-Skip this step {ok}
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course {ok}
 
 

--- a/en-CA/firefox/campaign.lang
+++ b/en-CA/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/en-GB/firefox/campaign.lang
+++ b/en-GB/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/en-GB/firefox/campaign.lang
+++ b/en-GB/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Congrats! You’re using the latest version of Firefox. {ok}
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy. {ok}
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox. {ok}
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>. {ok}
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ The new <strong>Firefox</strong> {ok}
 
 ;Fast for good.
 Fast for good. {ok}
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum {ok}
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good. {ok}
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now {ok}
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refresh Firefox {ok}
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox. {ok}
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms {ok}
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms {ok}
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox. {ok}
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span> {ok}
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span> {ok}
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span> {ok}
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages {ok}
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language {ok}
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>. {ok}
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>. {ok}
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure. {ok}
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox. {ok}
-
-
-;Enter your email address
-Enter your email address {ok}
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email? {ok}
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>. {ok}
-
-
-;What we want you to know:
-What we want you to know: {ok}
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox. {ok}
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox. {ok}
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimise Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason. {ok}
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes. {ok}
-
-
-;Let’s do this!
-Let’s do this! {ok}
-
-
-;Sync up with Firefox on mobile:
-Synchronise up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Free Web Browser {ok}
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today! {ok}
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever {ok}
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here. {ok}
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Powerfully private {ok}
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection {ok}
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox {ok}
-
-
-;Take Firefox with You
-Take Firefox with You {ok}
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices. {ok}
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox? {ok}
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll synchronise the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts {ok}
-
-
-;Skip this step
-Skip this step {ok}
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course {ok}
 
 

--- a/en-US/firefox/campaign.lang
+++ b/en-US/firefox/campaign.lang
@@ -2,12 +2,10 @@
 ## URL: https://www-dev.allizom.org/%LOCALE%/firefox/campaign/
 
 
-## TAG: firefox_quantum_new_headline
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
-## TAG: firefox_quantum_new_headline
 ;Fast for good.
 Fast for good.
 

--- a/en-US/firefox/campaign.lang
+++ b/en-US/firefox/campaign.lang
@@ -1,26 +1,5 @@
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 ## URL: https://www-dev.allizom.org/%LOCALE%/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Congrats! You’re using the latest version of Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
 
 
 ## TAG: firefox_quantum_new_headline
@@ -31,146 +10,6 @@ The new <strong>Firefox</strong>
 ## TAG: firefox_quantum_new_headline
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refresh Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-## TAG: firefox_new_platform_link_text
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-## TAG: firefox_new_try_again_link_020818
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-## TAG: download_thanks_newsletter_092018
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-## TAG: download_thanks_newsletter_092018
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-## TAG: download_thanks_newsletter_092018
-;Enter your email address
-Enter your email address
-
-
-## TAG: download_thanks_newsletter_092018
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-## TAG: download_thanks_newsletter_092018
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-## TAG: download_thanks_newsletter_092018
-;What we want you to know:
-What we want you to know:
-
-
-## TAG: download_thanks_newsletter_092018
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-## TAG: download_thanks_newsletter_092018
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-## TAG: download_thanks_newsletter_092018
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-## TAG: download_thanks_newsletter_092018
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-## TAG: download_thanks_newsletter_092018
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -186,14 +25,6 @@ Free Web Browser
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -218,41 +49,3 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-## TAG: firstrun_email_only_form
-;Take Firefox with You
-Take Firefox with You
-
-
-## TAG: firstrun_email_only_form
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course

--- a/en-ZA/firefox/campaign.lang
+++ b/en-ZA/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Congrats! You’re using the latest version of Firefox. {ok}
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refresh Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Free Web Browser {ok}
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox {ok}
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/eo/firefox/campaign.lang
+++ b/eo/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/eo/firefox/campaign.lang
+++ b/eo/firefox/campaign.lang
@@ -1,25 +1,4 @@
-## active ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Gratulon! Vi nun uzas la lastan version de Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Ĝisdatigi</a> vian Firefox kun la lastaj rapidecaj kaj privatecaj plibonigoj.
-
-
-;You’re using a pre-release version of Firefox.
-Vi nun uzas provan version de Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Vi uzas nesekuran kaj malnovan mastruman sistemon, kiu <a href="%(url)s">ne estas plu subtenata de Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -28,133 +7,6 @@ La nova <strong>Firefox</strong>
 
 ;Fast for good.
 Bonfare rapida.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Konatiĝu kun Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nova. Rapida. Por ĉiam.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Elŝuti nun
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refreŝigi Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Bonvolu sekvi <a href="%(url)s">tiujn ĉi instrukciojn</a> por instali Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Spertulaj instalaj elektebloj kaj aliaj platformoj
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Spertulaj instalaj elektebloj kaj aliaj platformoj
-
-
-;Keep up with<br> all things Firefox.
-Ĉiam la lastaj<br> novaĵoj pri Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Elŝuti Firefox <span>por Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Elŝuti Firefox <span>por macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Elŝuti Firefox <span>por Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Elŝuti por aliaj sistemoj kaj lingvoj
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Elŝuti en alia lingvo
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Via elŝuto devus aŭtomate komenciĝi. Ĉu tio ne funkciis? <a id="%(id)s" href="%(fallback_url)s">Klopodu elŝuti denove</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Viŝ elŝuto devus aŭtomate komenciĝi. Se tio ne okazas <a id="%(id)s" href="%(fallback_url)s">alklaku ĉi tie</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Pliaj informoj pri kiel igi Firefox pli inteligenta, rapida kaj sekura.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Tajpu vian retpoŝtan adreson
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Ek!
-
-
-;Sync up with Firefox on mobile:
-Speguli kun Firefox en poŝaparatoj:
 
 
 # HTML page title prefix
@@ -170,14 +22,6 @@ Senpaga retumilo
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Elŝuti Mozilla Firefox, kiu estas libera retumilo. Firefox estas kreata de tutmonda neprofitcela organizo, kiu sin dediĉas al la transdono de regado al la individuoj en la reto. Ricevi Firefox por Windows, macOS, Linux, Android kaj iOS nun!
-
-
-;Download the fastest Firefox ever
-Elŝuti la ĝisnune plej rapidan Firefox
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Pli rapida ŝargado de paĝoj, malpli da memoruzo kaj amaso da trajtoj, jen la nova Firefox.
 
 
 ;2x Faster
@@ -202,41 +46,5 @@ Pove privata
 
 ;Truly Private Browsing with Tracking Protection
 Vere privata retumo kun protekto kontraŭ spurado
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Bonvenon al Firefox
-
-
-;Take Firefox with You
-Portu Firefox kun vi
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Ricevu viajn legosignojn, historion, pasvortojn kaj aliajn agordojn en ĉiuj viaj aparatoj.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Ĉu vi jam uzas Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Komencu vian seancon per via konto kaj ni spegulos la legosignojn, pasvortojn kaj aliajn bonegajn aferojn, kiujn vi konservis en Firefox en aliaj aparatoj.
-
-
-;Learn more about Firefox Accounts
-Pli da informo pri la Kontoj de Firefox
-
-
-;Skip this step
-Pretersalti tiun ĉi paŝon
-
-
-# Old firstrun page
-;Chart your own course
-Faru vian propran vojon
 
 

--- a/es-AR/firefox/campaign.lang
+++ b/es-AR/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-¡Felicitaciones! Estás usando la versión más nueva de Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Actualizá</a> Firefox para tener las últimas mejoras en velocidad y privacidad.
-
-
-;You’re using a pre-release version of Firefox.
-Estás usando una versión aún no lanzada de Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Estás usando un sistema operativo antiguo e inseguro <a href="%(url)s">que ya no recibe actualizaciones de Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ El nuevo <strong>Firefox</strong>
 
 ;Fast for good.
 Rápido para siempre.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Conocé Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nuevo. Rápido. Para siempre.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Descargar ahora
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refrescá Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Seguí <a href="%(url)s">estas instrucciones</a> para instalar Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Opciones de instalación avanzadas y otras plataformas
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Opciones de instalación avanzadas y otras plataformas
-
-
-;Keep up with<br> all things Firefox.
-Seguí las novedades<br> sobre Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Descargá Firefox<span>para Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Descargá Firefox <span>para macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Descargá Firefox <span>para Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Descargar para otras plataformas e idiomas
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Descargar en otro idioma
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-La descarga debería comenzar automáticamente. ¿no lo hizo? <a id="%(id)s" href="%(fallback_url)s">Probá descargarlo nuevamente</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-La descarga debería empezar automáticamente. Si no lo hace, <a id="%(id)s" href="%(fallback_url)s">hacé clic acá</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Aprendé a hacer Firefox aún más inteligente, rápido y seguro.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Obtené consejos informativos, trucos y novedades del producto entregados en tu Bandeja de entrada.
-
-
-;Enter your email address
-Ingresá tu dirección de correo electrónico
-
-
-;How will Mozilla use my email?
-¿Cómo utilizará Mozilla mi correo electrónico?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla no sólo valora la privacidad de tu correo electrónico y seguridad – es parte de nuestro <a href="%(manifesto)s">Manifiesto</a>: “La seguridad y privacidad en Internet de las personas son fundamentales y no deben ser tratadas como opcionales’. <a href="%(principles)s">Podés aprender más acerca de nuestros principios de privacidad de datos aquí</a>.
-
-
-;What we want you to know:
-Queremos que sepas lo siguiente:
-
-
-;You don’t need to give us your email to download and use Firefox.
-No necesitás darnos tu correo electrónico para descargar y usar Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Pedimos tu correo electrónico porque nuestras investigaciones muestran que la gente que recibe una introducción trabaja más y mejor con Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Es posible que te lleguen correos electrónicos diseñados para ayudarte a optimizar Firefox para que funcione mejor para vos, para aprender más acerca de privacidad y seguridad y saber cómo aprovechas mejor tu tiempo en la web.
-
-
-;You can unsubscribe anytime, for any reason.
-Podés darte de baja en cualquier momento, por cualquier razón.
-
-
-;We will not share, sell or use your email for any other purposes.
-No compartiremos, venderemos ni usaremos tu correo electrónico para ningún otro propósito.
-
-
-;Let’s do this!
-¡Manos a la obra!
-
-
-;Sync up with Firefox on mobile:
-Sincronizar con Firefox en móvil:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Navegador Web gratuito
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Descargá Mozilla Firefox, un navegador de Internet gratuito. Firefox está creado por una organización mundial sin fines de lucro dedicada a que las personas tengan el control de su navegación por Internet. ¡Conseguí Firefox para Windows, macOS, Linux, Android y iOS hoy mismo!
-
-
-;Download the fastest Firefox ever
-Descargá el Firefox más rápido de la historia
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Carga de páginas más rápida, menos uso de memoria y lleno de funcionalidades, acá está el nuevo Firefox.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Poderosamente privado
 
 ;Truly Private Browsing with Tracking Protection
 Navegación verdaderamente privada con protección de rastreo
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Bienvenido a Firefox
-
-
-;Take Firefox with You
-Llevá Firefox con vos
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Llevá tus marcadores, historial, contraseñas y otras configuraciones en todos tus dispositivos.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-¿Ya estás usando Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Ingresá con tu cuenta y sincronizaremos los marcadores, contraseñas y otras grandes cosas que tenés en Firefox en otros dispositivos.
-
-
-;Learn more about Firefox Accounts
-Conocé más sobre Cuentas de Firefox
-
-
-;Skip this step
-Saltear este paso
-
-
-# Old firstrun page
-;Chart your own course
-Programá tu propio camino
 
 

--- a/es-AR/firefox/campaign.lang
+++ b/es-AR/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/es-CL/firefox/campaign.lang
+++ b/es-CL/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/es-CL/firefox/campaign.lang
+++ b/es-CL/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-¡Felicitaciones! Estás usando la última versión de Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Actualiza</a> tu Firefox para tener lo último en velocidad y privacidad.
-
-
-;You’re using a pre-release version of Firefox.
-Estás usando una versión en desarrollo de Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Estás usando un sistema operativo inseguro y desactualizado  <a href="%(url)s">que ya no tiene soporte por parte de Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ El nuevo <strong>Firefox</strong>
 
 ;Fast for good.
 Rápido para siempre.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Conoce Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nuevo. Rápido. Para mejor.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Descargar ahora
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refrescar Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Por favor, sigue <a href="%(url)s">estas instrucciones</a> para instalar Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Opciones de instalación avanzadas y otras plataformas
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Opciones de instalación avanzadas y otras plataformas
-
-
-;Keep up with<br> all things Firefox.
-Mantente al día<br> con Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Descargar Firefox <span>para Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Descargar Firefox <span>para macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Descargar Firefox <span>para Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Bajar para otras plataformas e idiomas
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Descargar en otro idioma
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Tu descarga debiera empezar automáticamente. ¿No funcionó?, <a id="%(id)s" href="%(fallback_url)s">Intenta a bajarlo nuevamente</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Tu descarga debiera empezar automáticamente. Si no lo hace, <a id="%(id)s" href="%(fallback_url)s">haz clic aquí</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Aprende cómo hacer Firefox aún más inteligente, rápido y seguro.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Obtén consejos informativos, trucos y novedades del producto en tu bandeja de entrada.
-
-
-;Enter your email address
-Ingresa tu email
-
-
-;How will Mozilla use my email?
-¿Cómo usará Mozilla mi email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla no solo valora la privacidad y seguridad de tu correo – es parte de nuestro<a href="%(manifesto)s">Manifiesto</a>: " La seguridad y la privacidad de la gente en internet son fundamentales y no deben considerarse como algo opcional." <a href="%(principles)s">Puedes aprender sobre nuestros principios de privacidad de datos aquí</a>.
-
-
-;What we want you to know:
-Queremos que sepas:
-
-
-;You don’t need to give us your email to download and use Firefox.
-No necesitas darnos tu correo para bajar y usar Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Solicitamos tu correo porque nuestra investigación muestra que las personas que reciben una introducción sacan más provecho a Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Puedes esperar correos diseñados para ayudarte a optimizar Firefox para que se adapte mejor a ti, aprender más sobre privacidad y seguridad y saber cómo aprovechar mejor tu tiempo en la web.
-
-
-;You can unsubscribe anytime, for any reason.
-Puedes darte de baja en cualquier momento, por cualquier razón.
-
-
-;We will not share, sell or use your email for any other purposes.
-No compartiremos, venderemos o usaremos tu correo para ningún otro propósito.
-
-
-;Let’s do this!
-¡Hagámoslo!
-
-
-;Sync up with Firefox on mobile:
-Sincroniza con Firefox en el celular:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Navegador web libre
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Descarga Mozilla Firefox, un navegador Web libre. Firefox es creado por una organización sin fines de lucro dedicada a poner a los individuos al control en línea. ¡Obtén Firefox para Windows, macOS, Linux, Android e iOS hoy!
-
-
-;Download the fastest Firefox ever
-Descarga el Firefox más rápido a la fecha
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Carga de páginas más rápida, menos uso de memoria y lleno de funcionalidades, el nuevo Firefox está aquí.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Poderosamente privado
 
 ;Truly Private Browsing with Tracking Protection
 Navegación realmente privada con protección de seguimiento
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Bienvenido a Firefox
-
-
-;Take Firefox with You
-Lleva a Firefox contigo
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Ten tus marcadores, historial, contraseñas y otros ajustes en todos tus dispositivos.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-¿Ya usas Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Conéctate a tu cuenta y nosotros sincronizaremos los marcadores, contraseñas y otras cosas que has guardado en Firefox en otros dispositivos.
-
-
-;Learn more about Firefox Accounts
-Aprende más sobre las cuentas de Firefox
-
-
-;Skip this step
-Saltar este paso
-
-
-# Old firstrun page
-;Chart your own course
-Planifica tu camino
 
 

--- a/es-ES/firefox/campaign.lang
+++ b/es-ES/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-¡Felicidades! Estás usando la última versión de Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Actualiza</a> Firefox para obtener lo último en velocidad y privacidad.
-
-
-;You’re using a pre-release version of Firefox.
-Estás usando una versión preliminar de Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Estás usando un sistema operativo inseguro y obsoleto <a href="%(url)s">que ya no es compatible con Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ El nuevo <strong>Firefox</strong>
 
 ;Fast for good.
 Rápido para siempre.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Conoce Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nuevo. Rápido. Para bien.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Descargar ahora
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Restablecer Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Para instalar Firefox, <a href="%(url)s">sigue estas instrucciones</a>.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Opciones avanzadas de instalación y otras plataformas
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Opciones avanzadas de instalación y otras plataformas
-
-
-;Keep up with<br> all things Firefox.
-Sigue la actualidad<br> de Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Descarga Firefox <span>para Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Descarga Firefox <span>para macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Descarga Firefox <span>para Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Descargar para otras plataformas e idiomas
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Descargar en otro idioma
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Tu descarga debería empezar automáticamente. ¿No se ha iniciado? <a id="%(id)s" href="%(fallback_url)s">Intenta descargarla otra vez</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Tu descarga debería comenzar automáticamente. Si no, <a id="%(id)s" href="%(fallback_url)s">haz clic aquí</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Descubre cómo hacer Firefox más inteligente, rápido y seguro.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Recibe consejos informativos, trucos y novedades del producto directamente en tu bandeja de entrada.
-
-
-;Enter your email address
-Escribe tu correo electrónico
-
-
-;How will Mozilla use my email?
-¿Cómo utilizará Mozilla mi correo electrónico?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla no solo valora la privacidad y seguridad de tu correo electrónico – es parte de nuestro <a href="%(manifesto)s">Manifiesto</a>: “La seguridad y privacidad en Internet de las personas son fundamentales y no deben ser tratadas como opcionales”. <a href="%(principles)s">Puedes aprender más acerca de nuestros principios de privacidad de datos aquí</a>.
-
-
-;What we want you to know:
-Queremos que sepas:
-
-
-;You don’t need to give us your email to download and use Firefox.
-No necesitas darnos tu correo electrónico para descargar y usar Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Pedimos tu correo electrónico porque nuestras investigaciones muestran que la gente que recibe una introducción trabaja más y mejor con Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Puedes recibir correos electrónicos diseñados para ayudarte a optimizar Firefox para que funcione mejor para ti, aprender más sobre privacidad y seguridad y descubrir cómo aprovechar mejor tu tiempo en la web.
-
-
-;You can unsubscribe anytime, for any reason.
-Puedes darte de baja en cualquier momento, por cualquier razón.
-
-
-;We will not share, sell or use your email for any other purposes.
-No compartiremos, venderemos ni usaremos tu correo electrónico para ningún otro propósito.
-
-
-;Let’s do this!
-¡Hagámoslo!
-
-
-;Sync up with Firefox on mobile:
-Sincroniza con Firefox en tu dispositivo móvil:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Navegador gratuito
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Descarga Mozilla Firefox, el navegador gratuito desarrollado por una organización mundial sin ánimo de lucro cuyo objetivo es darle a los usuarios el control de su vida digital. ¡Hazte con Firefox para Windows, macOS, Linux, Android e iOS!
-
-
-;Download the fastest Firefox ever
-Descarga el Firefox más rápido de la historia
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Mayor rapidez cargando páginas, menor uso de memoria y con muchos recursos, el nuevo Firefox ya está aquí.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Poderosamente privado
 
 ;Truly Private Browsing with Tracking Protection
 Navegación verdaderamente privada con protección contra el rastreo
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Bienvenido a Firefox
-
-
-;Take Firefox with You
-Llévate Firefox contigo
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Accede a tus marcadores, historial, contraseñas y otros ajustes en todos tus dispositivos.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-¿Ya usas Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Inicia sesión en tu cuenta y sincronizaremos tus marcadores, contraseñas y más cosas increíbles que hayas guardado en Firefox en tus otros dispositivos.
-
-
-;Learn more about Firefox Accounts
-Descubre más sobre Firefox Accounts
-
-
-;Skip this step
-Saltar este paso
-
-
-# Old firstrun page
-;Chart your own course
-Traza tu propio camino
 
 

--- a/es-ES/firefox/campaign.lang
+++ b/es-ES/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/es-MX/firefox/campaign.lang
+++ b/es-MX/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/es-MX/firefox/campaign.lang
+++ b/es-MX/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-¡Felicidades! Estás usando la última versión de Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Actualiza</a> tu Firefox para lo último en velocidad y privacidad.
-
-
-;You’re using a pre-release version of Firefox.
-Estás usando una versión aún no lanzada de Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Estás usando un sistema operativo inseguro y desactualizado <a href="%(url)s">el cual ya no tiene soporte de Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ El nuevo <strong>Firefox</strong>
 
 ;Fast for good.
 Rápido y realmente bueno.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Conoce Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nuevo. Rápido. Para siempre.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Descargar ahora
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refresca Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Por favor, sigue <a href="%(url)s">estas instrucciones</a> para instalar Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Opciones de instalación avanzada y otras plataformas
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Opciones de instalación avanzada y otras plataformas
-
-
-;Keep up with<br> all things Firefox.
-Mantente al día con<br> todas las cosas de Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Descarga Firefox <span>para Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Descarga Firefox <span>para macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Descarga Firefox <span>para Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Descargar para otras plataformas e idiomas
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Descargar en otro idioma
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Tu descarga debe iniciar automáticamente. De no ser así. <a id="%(id)s" href="%(fallback_url)s">Intenta de nuevo</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Tu descarga debe comenzar automáticamente. Si no es así, <a id="%(id)s" href="%(fallback_url)s">haz clic aquí</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Aprende cómo hacer Firefox aún más inteligente, más rápido y más seguro.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Obtén consejos informativos, trucos y novedades de producto entregados a tu bandeja de entrada.
-
-
-;Enter your email address
-Ingresa tu dirección de correo electrónico
-
-
-;How will Mozilla use my email?
-¿Cómo utilizará Mozilla mi correo?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla no solo valora la privacidad y seguridad de correo electrónico: forma parte de nuestro <a href="%(manifesto)s">Manifiesto</a>: "la seguridad y privacidad en internet de las personas es un derecho fundamental y no deben ser considerados opcionales". <a href="%(principles)s">Puedes aprender acerca de nuestros principios de privacidad de datos aquí</a>.
-
-
-;What we want you to know:
-Queremos que sepas:
-
-
-;You don’t need to give us your email to download and use Firefox.
-No necesitas darnos tu correo electrónico para descargar y usar Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Te pedimos tu correo electrónico para mostrarle a la gente una introducción al navegador y cómo hacer más y mejores cosas con Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Puedes recibir correos diseñados para ayudarte a optimizar Firefox y trabajar como tu quieras, saber más acerca de la privacidad y seguridad y descubrir cómo utilizar mejor tu tiempo en la web.
-
-
-;You can unsubscribe anytime, for any reason.
-Puedes cancelar la suscripción en cualquier momento por cualquier razón.
-
-
-;We will not share, sell or use your email for any other purposes.
-No compartiremos, venderemos ni usaremos tu correo electrónico para ningún otro propósito.
-
-
-;Let’s do this!
-¡Hagámoslo!
-
-
-;Sync up with Firefox on mobile:
-Sincronizar con Firefox en móvil:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Navegador gratuito
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Descarga Mozilla Firefox, un navegador web libre. Firefox es creado por una comunidad global sin fines de lucro, dedicados a darle el control a las personas de su actividad en línea. ¡Obtén Firefox para Windows, macOS, Linux, Android e iOS hoy mismo!
-
-
-;Download the fastest Firefox ever
-Descargar el Firefox más rápido que nunca
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Ya llegó el nuevo Firefox: carga de páginas más rápida, menos uso de memoria y lleno de características.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Poderosamente privado
 
 ;Truly Private Browsing with Tracking Protection
 Un navegador verdaderamente privado con protección de rastreo
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Bienvenido a Firefox
-
-
-;Take Firefox with You
-Lleva Firefox contigo
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Obtén tus marcadores, historial, contraseñas y otros ajustes en todos tus dispositivos.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-¿Ya estás usando Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Inicia sesión en tu cuenta y sincronizaremos tus marcadores, contraseñas y otras geniales cosas que has guardado en Firefox en otros dispositivos.
-
-
-;Learn more about Firefox Accounts
-Conoce más acerca de Firefox Accounts
-
-
-;Skip this step
-Omitir este paso
-
-
-# Old firstrun page
-;Chart your own course
-Programa tu camino
 
 

--- a/et/firefox/campaign.lang
+++ b/et/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/et/firefox/campaign.lang
+++ b/et/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Õnnitleme! Kasutad Firefoxi uusimat versiooni.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-Parima kiiruse ja privaatsuse nimel <a href="%(url)s">uuenda</a> Firefoxi.
-
-
-;You’re using a pre-release version of Firefox.
-Kasutad Firefoxi eelväljalaset.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Kasutad aegunud ja ebaturvalist operatsioonisüsteemi, mida <a href="%(url)s">Firefox enam ei toeta</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Uus <strong>Firefox</strong>
 
 ;Fast for good.
 Kiire igavesti, avalikkuse hüvanguks.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Kohtu Firefox Quantumiga
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Uus. Kiire. Igavesti. Avalikkuse hüvanguks.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Laadi kohe alla
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Värskenda Firefoxi
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Firefoxi paigaldamiseks järgi <a href="%(url)s">neid juhtnööre</a>.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Täpsemad paigaldusvalikud ja teised platvormid
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Täpsemad paigaldusvalikud ja teised platvormid
-
-
-;Keep up with<br> all things Firefox.
-Hoia end <br>Firefoxi puutuvaga kursis.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Laadi alla Firefox <span>Windowsile</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Laadi alla Firefox <span>macOS-ile</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Laadi alla Firefox <span>Linuxile</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Allalaadimine teistele platvormidele ja keeltele
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Teises keeles allalaadimine
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Allalaadimine peaks algama automaatselt. Ei töötanud? <a id="%(id)s" href="%(fallback_url)s">Proovi uuesti alla laadida</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Allalaadimine peaks algama automaatselt. Kui seda ei juhtu, <a id="%(id)s" href="%(fallback_url)s">klõpsa siia</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Saa rohkem teavet Firefoxi nutikamaks, kiiremaks ja turvalisemaks muutmiseks.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Saa postkasti kasulikke nippe, trikke ja tooteteadaandeid.
-
-
-;Enter your email address
-Sisesta e-posti aadress
-
-
-;How will Mozilla use my email?
-Kuidas Mozilla mu e-posti aadressi kasutab?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla ei väärtusta lihtsalt sinu e-posti privaatsust ja turvalisust – see on osa meie <a href="%(manifesto)s">manifestist</a>: “Üksikisiku turvalisus ja privaatsus internetis on põhiõigus ning seda ei tohi käsitleda valikulisena.” <a href="%(principles)s">Meie andmeprivaatsuse põhimõtete kohta võid rohkem uurida siit</a>.
-
-
-;What we want you to know:
-Me tahame, et teaksid:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Firefoxi alla laadimiseks ja kasutamiseks ei pea sa meile enda e-posti aadressi andma.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Küsisime su e-posti aadressi, sest meie uuringu põhjal kasutavad tutvustuse saanud inimesed Firefoxi enam ja paremini.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Võid oodata kirju, mis aitavad sul Firefoxi optimeerida enda jaoks paremini töötama, saada rohkem teavet privaatsuse ja turvalisuse kohta ning võtta veebis veedetud ajast parim.
-
-
-;You can unsubscribe anytime, for any reason.
-Saad mis tahes põhjusel igal ajal loobuda.
-
-
-;We will not share, sell or use your email for any other purposes.
-Me ei jaga, müü ega kasuta su e-posti aadressi muudel eesmärkidel.
-
-
-;Let’s do this!
-Teeme ära!
-
-
-;Sync up with Firefox on mobile:
-Sünkrooni Firefoxiga telefonis:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Tasuta veebilehitseja
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Laadi alla Mozilla Firefox, tasuta veebilehitseja. Firefoxi arendab globaalne mittetulundusorganisatsioon, mis on pühendunud üksikisikutele internetis juhtohjade andmisele. Hangi Firefox Windowsile, macOS-ile, Linuxile, Androidile ja iOS-ile täna!
-
-
-;Download the fastest Firefox ever
-Laadi alla kiireim Firefox üldse
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Koos kiire lehtede laadimise, väiksema mälukasutuse ja paljude võimalustega on uus Firefox kohal.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Võimsalt privaatne
 
 ;Truly Private Browsing with Tracking Protection
 Tõeliselt privaatne veebilehitsemine jälitamisvastase kaitsega
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Tere tulemast Firefoxi
-
-
-;Take Firefox with You
-Võta Firefox endaga kaasa
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Kasuta järjehoidjaid, ajalugu, paroole ja muid sätteid kõigil enda seadmetel.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Kasutad juba Firefoxi?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Logi sisse ja me sünkroonime su järjehoidjad, paroolid ja muu suurepärase, mille oled Firefoxi teistel seadmetel salvestanud.
-
-
-;Learn more about Firefox Accounts
-Rohkem teavet Firefoxi kontost
-
-
-;Skip this step
-Jäta samm vahele
-
-
-# Old firstrun page
-;Chart your own course
-Märgi enda kurss ise
 
 

--- a/eu/firefox/campaign.lang
+++ b/eu/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/eu/firefox/campaign.lang
+++ b/eu/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Bejondeizula! Firefoxen azken bertsioa darabilzu.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Eguneratu</a> Firefox puntako abiadura eta pribatutasuna lortzeko.
-
-
-;You’re using a pre-release version of Firefox.
-Firefoxen aurreargitalpen bertsio bat darabilzu.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-<a href="%(url)s">Dagoeneko Firefoxek onartzen ez duen</a> sistema eragile ez-seguru eta zaharkitu bat darabilzu.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Firefoxen aurreargitalpen bertsio bat darabilzu.
 
 ;Fast for good.
 Benetan bizkorra.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Ezagutu Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Berria. Bizkorra. Benetan.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Deskargatu orain
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Biziberritu Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Jarraitu <a href="%(url)s">argibideok</a> Firefox instalatzeko.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Instalazio-aukera aurreratuak eta beste plataformak
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Instalatzeko aukera aurreratuak eta beste plataformak
-
-
-;Keep up with<br> all things Firefox.
-Jarraitu<br> Firefoxen aktualitatea.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Deskargatu Firefox <span>Windowserako</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Deskargatu Firefox <span>macOSerako</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Deskargatu Firefox <span>Linuxerako</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Deskargatu beste plataforma eta hizkuntzetarako
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Deskargatu beste hizkuntza batean
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Deskarga automatikoki abiatuko da. Ez da hala? <a id="%(id)s" href="%(fallback_url)s">Saiatu berriro deskargatzen</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Deskarga automatikoki hasiko da. Hala ez bada, <a id="%(id)s" href="%(fallback_url)s">egin klik hemen</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Ikasi nola bihurtu Firefox adimentsuago, bizkorrago eta seguruagoa.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Jaso aholkuak, trikimailuak eta produktuen iragarpenak zure sarrera-ontzian.
-
-
-;Enter your email address
-Sartu helbide elektronikoa
-
-
-;How will Mozilla use my email?
-Nola erabiliko du Mozillak nire helbide elektronikoa?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozillan zure postaren pribatutasuna eta segurtasuna baloratzen dugu – gure <a href="%(manifesto)s">Manifestua</a>ren baitan dago: "Gizabanakoen segurtasuna eta pribatutasuna Interneten funtsezkoak dira eta ezin dira hautazkotzat hartu." <a href="%(principles)s">Gure datuen pribatutasun-printzipioei buruz irakur dezakezu hemen</a>.
-
-
-;What we want you to know:
-Zuk jakitea nahi duguna:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Ez diguzu zure helbide elektronikoa eman behar Firefox deskargatzeko eta erabiltzeko.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Zure e-posta helbidea eskatu dizugu gure ikerketek erakusten dutelako sarrerako azalpen bat jasotzen duten erabiltzaileek Firefoxekin gauza gehiago eta hobeto lortzen dituztela.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Firefox zure beharretara ahalik eta ondoen egokitzera, pribatutasuna eta segurtasunari buruz gehiago jakitera eta Webean pasatzen duzun denborari zukua ateratzera bideratutako emailak bidaliko dizkizugu.
-
-
-;You can unsubscribe anytime, for any reason.
-Edonoiz eten dezakezu harpidetza, edozein dela arrazoia.
-
-
-;We will not share, sell or use your email for any other purposes.
-Ez dugu zure helbide elektronikoa beste edozein helburutarako partekatu, saldu edo erabiliko.
-
-
-;Let’s do this!
-Goazen aurrera!
-
-
-;Sync up with Firefox on mobile:
-Sinkronizatu Firefox mugikorrarekin:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Doako web-nabigatzailea
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Deskargatu Mozilla Firefox, web-nabigatzaile librea. Firefox norbanakoei online kontrola emateaz arduratzen den irabazi-asmorik gabeko erakunde global batek garatzen du. Eskuratu Windows, macOs, Linux, Android eta iOSerako Firefox orain!
-
-
-;Download the fastest Firefox ever
-Deskargatu inoizko Firefoxik bizkorrena
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Orrien karga bizkorragoa, memoria-erabilera txikiagoa eta eginbidez betea. Firefox berria hemen da.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Pribatutasun boteretsua
 
 ;Truly Private Browsing with Tracking Protection
 Benetako nabigazio pribatua jarraipenaren aurkako babesarekin
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Ongi etorri Firefoxera
-
-
-;Take Firefox with You
-Eraman Firefox aldean
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Izan laster-markak, historia, pasahitzak eta beste ezarpenak eskura zure gailu guztietatik.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Dagoeneko Firefox darabilzu?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Hasi saioa zure kontuarekin eta laster-markak, pasahitzak eta beste gailuetako Firefoxen gorde dituzun beste hainbat gauza sinkronizatuko ditugu.
-
-
-;Learn more about Firefox Accounts
-Ikasi gehiago Firefox kontuei buruz
-
-
-;Skip this step
-Saltatu urrats hau
-
-
-# Old firstrun page
-;Chart your own course
-Hartu zure bidea
 
 

--- a/fa/firefox/campaign.lang
+++ b/fa/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/fa/firefox/campaign.lang
+++ b/fa/firefox/campaign.lang
@@ -1,25 +1,4 @@
-## active ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-تبریک! شما از آخرین نسخه فایرفاکس استفاده می‌کنید.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-فایرفاکس خود را برای داشتن آخرین سرعت و امنیت <a href="%(url)s">بروزرسانی</a> کنید.
-
-
-;You’re using a pre-release version of Firefox.
-شما در حال استفاده از یک نسخه پیش از انتشارِ فایرفاکس هستید.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-شما از یک سیستم عامل تاریخ گذشته و غیر امن استفاده می‌کنید<a href="%(url)s"> که دیگر توسط فایرفاکس پشتیبانی نمی شود</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -28,133 +7,6 @@
 
 ;Fast for good.
 سریع برای همیشه.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-با فایرفاکس کوآنتوم ملاقات کنید
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-جدید. سریع. برای بهترین‌ها.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-هم‌اکنون دریافت کنید
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-نوسازی فایرفاکس
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-لطفا <a href="%(url)s">این دستور العمل‌ها</a> را برای نصب فایرفاکس دنبال کنید.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-گزینه‌های نصبِ پیشرفته و سایر سکوها
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-گزینه‌های نصبِ پیشرفته و سایر سکوها
-
-
-;Keep up with<br> all things Firefox.
-با آخرین اخبار فایرفاکس<br> به‌روز باشید.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-دریافت فایرفاکس <span>برای ویندوز</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-دریافت فایرفاکس <span>برای macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-دریافت فایرفاکس <span>برای لینوکس</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-بارگیری برای سایر پلتفرم‌ها و زبان‌ها
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-دریافت به زبان‌های دیگر
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-بارگیری شما باید به زودی شروع شود. شروع نشد؟ <a id="%(id)s" href="%(fallback_url)s">دوباره تلاش کنید</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-بارگیری شما باید تا لحظاتی دیگر بطور خودکار شروع شود. اگر شروع نشد، اینجا <a id="%(id)s" href="%(fallback_url)s">کلیک کنید</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-یاد بگیرید چگونه فایرفاکس را حتی دقیق‌تر، سریع‌تر و امن‌تر بسازید.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-راهنمایی‌های مفید، ترفندها و اعلان‌های محصولات را در رایانامه خود دریافت کنید.
-
-
-;Enter your email address
-نشانی رایانامه خود را وارد کنید
-
-
-;How will Mozilla use my email?
-موزیلا چگونه از رایانامه من استفاده می‌کند؟
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-آنچه می‌خواهیم شما بدانید:
-
-
-;You don’t need to give us your email to download and use Firefox.
-نیازی نیست رایانامه خود را برای دریافت و استفاده از فایرفاکس به ما بدهید.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-رایانامه شما را خواسته‌ایم زیرا تحقیقات ما نشان می‌دهد افرادی که تجربه مقدماتی را دریافت می‌کنند با فایرفاکس بیشتر و بهتر عمل می‌کنند.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-شما می توانید در هر زمان، به هر دلیلی، اشتراک خود را لغو کنید.
-
-
-;We will not share, sell or use your email for any other purposes.
-ما برای هیچ هدف دیگری، رایانامه شما را به اشتراک نخواهیم گداشت، نخواهیم فروحت یا از آن استفاده دیگری نخواهیم کرد.
-
-
-;Let’s do this!
-بیایید شروع کنیم!
-
-
-;Sync up with Firefox on mobile:
-همگام‌سازی با فایرفاکس موبایل:
 
 
 # HTML page title prefix
@@ -170,14 +22,6 @@ You can expect emails designed to help you optimize Firefox to work best for you
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 موزیلا فایرفاکس، یک مرورگر آزاد را دریافت کنید. فایرفاکس توسط یک موسسه غیرانتفاعی جهانی که افراد را در کنترل زندگی برخط خود قرار می‌دهند، ساخته شده است. امروز فایرفاکس را برای ویندوز، macOS، لینوکس، اندروید و iOS دریافت کنید!
-
-
-;Download the fastest Firefox ever
-سریع‌ترین فایرفاکس را دریافت کنید
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-بارگیری سریع‌تر صفحات، استفاده کمتر از مموری و مملو از امکانات جدید، فایرفاکس جدید اینجاست.
 
 
 ;2x Faster
@@ -202,41 +46,5 @@ You can expect emails designed to help you optimize Firefox to work best for you
 
 ;Truly Private Browsing with Tracking Protection
 مرور ناشناسِ واقعی با امکان محافظت در برابر ردگیری
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-به فایرفاکس خوش آمدید
-
-
-;Take Firefox with You
-فایرفاکس را همراه خود داشته باشید
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-نشانک‌ها، تاریخچه، گذرواژه‌ها و تنظیماتِ دیگر خود را بر روی دستگاه‌های دیگر خود همراه داشته باشید.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-در حال حاضر از فایرفاکس استفاده می‌کنید؟
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-به حساب کاربری خود وارد شوید و ما همه چیز را هم گام سازی می‌کنیم. نشانک‌ها،‌کلمه‌های عبور و چیزهای ارزشمندی که شما بر روی فایرفاکس دستگاه‌های خود ذخیره کرده‌اید.
-
-
-;Learn more about Firefox Accounts
-درباره حساب‌های کاربری فایرفاکس بیشتر بدانید
-
-
-;Skip this step
-از این مرحله بگذر
-
-
-# Old firstrun page
-;Chart your own course
-برای خود مستقل تصمیم بگیرید
 
 

--- a/ff/firefox/campaign.lang
+++ b/ff/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Woyyoo! Njogi-ɗaa ko yamre sakkitiinde Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Hesɗitin</a> Firefox maa ngam heɓde ko sakkitii e jaawgol e suturo.
-
-
-;You’re using a pre-release version of Firefox.
-Ngon-ɗaa e huutoraade ko yamre Firefox nde bayyinaaka.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 Firefox <strong>Keso oo</strong>
 
 
 ;Fast for good.
 Yaawii hankadi.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Hawru e Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Keso. Jaawɗo. Hankadi.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Aawto jooni
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Hesɗitin Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Tiiɗno rew e <a href="%(url)s">ɗee tinndinooje</a> ngam aafde Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Cuɓe aaftogol dowrowe & tammbordɗe goɗɗe
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Cuɓe aaftogol dowrowe & tammbordɗe goɗɗe
-
-
-;Keep up with<br> all things Firefox.
-Humpito<br> geɗe Firefox fof.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Aawto Firefox <span>ngam Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Aawto Firefox <span>ngam macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Aawto Firefox <span>ngam Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Aawto ngam dinndeeje & ɗemɗe goɗɗe
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Aawto e ɗemngal goɗngal
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Gaawtogol maa ina foti fuɗɗaade ɗoon e ɗoon. So ɗuum alaa, <a id="%(id)s" href="%(fallback_url)s">dobo ɗoo</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Mbaɗen ɗum ɗoo!
-
-
-;Sync up with Firefox on mobile:
-Yahdin e Firefox dow cinndel:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Wanngorde Geese Alla meho
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Aawto Mozilla, wanngorde Geese nde yoɓetaake. Firefox sosiɗum ko renndo ko ɗaɓɓaani dañal daraniingo reende yimɓe e geese. Heɓ Firefox hannde ngam Windows, macOS, Linux, Android kam e iOS!
-
-
-;Download the fastest Firefox ever
-Aawto Firefox ɓurɗo yaawde abada
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Loowgol hello ɓurngol yaawde, kuutorogol tesko pamɗungol kadi coomdangol e faannuuji, Firefox keso oo nani ɗoo.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Suturo wonndungo e semmbe
 
 ;Truly Private Browsing with Tracking Protection
 Banngogol suturo tigi wonndungo e Ndeenka Dewindol
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-A jaɓɓaama e Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Aɗa huutoroo Firefox kisa?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Seŋo e konte maa Firefox ma min njahdin maantore ɗee, finndeeji ɗii kam e geɗe goɗɗe ɗe dannduɗaa e Firefox e masiŋon ngoɗ-kon.
-
-
-;Learn more about Firefox Accounts
-Ɓeydu humpito e baɗte Konte Firefox
-
-
-;Skip this step
-Diw nhal daawal
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/ff/firefox/campaign.lang
+++ b/ff/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/fi/firefox/campaign.lang
+++ b/fi/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Onnittelut! Käytössäsi on Firefoxin uusin versio.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Päivitä</a> Firefox, niin pysyt vauhdissa ja turvassa.
-
-
-;You’re using a pre-release version of Firefox.
-Käytössäsi on Firefoxin ennakkoversio.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Sinulla on turvaton ja vanhentunut käyttöjärjestelmä, <a href="%(url)s">jota Firefox ei enää tue</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Uusi <strong>Firefox</strong>
 
 ;Fast for good.
 Pysyvästi nopea.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Tapaa Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Uusi. Nopea. Pysyvästi.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Lataa nyt
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Palauta Firefox uudeksi
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Voit asentaa Firefoxin seuraamalla <a href="%(url)s">näitä ohjeita</a>.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Asentamisen lisävalinnat ja muut alustat
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Asentamisen lisävalinnat ja muut alustat
-
-
-;Keep up with<br> all things Firefox.
-Pysy ajan tasalla<br> Firefox-jutuista.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Lataa Firefox <span>Windowsille</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Lataa Firefox <span>macOS:lle</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Lataa Firefox <span>Linuxille</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Lataa muille ympäristöille ja kielille
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Lataa toisella kielellä
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Latauksen tulisi alkaa itsestään. Eikö se alkanut? <a id="%(id)s" href="%(fallback_url)s">Yritä ladata uudestaan</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Latauksen tulisi alkaa itsestään. Jos se ei ala, <a id="%(id)s" href="%(fallback_url)s">paina tästä</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Katso, kuinka Firefoxista tehdään jopa aiempaa älykkäämpi, nopeampi ja turvallisempi.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Vastaanota vinkkejä ja tuotetiedotteita suoraan sähköpostiisi.
-
-
-;Enter your email address
-Kirjoita sähköpostiosoitteesi
-
-
-;How will Mozilla use my email?
-Miten Mozilla käyttää sähköpostiosoitettani?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla ei vain arvosta sähköpostisi yksityisyyttä ja tietoturvaa - se on osa <a href="%(manifesto)s">Manifestiamme</a>: “Yksilöiden turvallisuus ja yksityisyys internetissä ovat olennaisia ja niitä ei saa käsitellä valinnaisina.” <a href="%(principles)s">Lue lisää tietosuojaperiaatteistamme</a>.
-
-
-;What we want you to know:
-Mitä haluamme sinun tietävän:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Sähköpostiosoitetta ei tarvita Firefoxin lataamiseen ja käyttämiseen.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Pyysimme sähköpostiosoitettasi, koska tutkimuksemme osoittavat, että johdannon saaneet henkilöt saavat enemmän ja paremmin aikaan Firefoxin kanssa.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Tulet saamaan sähköpostiviestejä, joiden avulla voit optimoida Firefoxin omiin tarpeisiisi parhaaksi, oppia lisää tietosuojasta ja tietoturvasta ja selvittää, miten voit parhaiten hyödyntää aikaasi verkossa.
-
-
-;You can unsubscribe anytime, for any reason.
-Voit lopettaa tilauksen milloin tahansa mistä tahansa syystä.
-
-
-;We will not share, sell or use your email for any other purposes.
-Me emme jaa, myy tai käytä sähköpostiosoitettasi mihinkään muuhun tarkoitukseen.
-
-
-;Let’s do this!
-Aloitetaan!
-
-
-;Sync up with Firefox on mobile:
-Synkronoi Firefoxin mobiiliversioiden kanssa:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Ilmainen verkkoselain
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Lataa Mozilla Firefox, ilmainen verkkoselain. Firefoxia tekee maailmanlaajuinen voittoa tavoittelematon yhteisö, jonka tavoitteena on antaa ihmisten hallita verkkoelämäänsä. Lataa Firefox Windowsille, macOS:lle, Linuxille, Androidille ja iOS:lle tänään!
-
-
-;Download the fastest Firefox ever
-Lataa nopein Firefox koskaan
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Nopeampi sivunlataus. Pienempi muistinkäyttö. Täynnä ominaisuuksia. Uusi Firefox on täällä.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Kunnioittaa yksityisyyttä
 
 ;Truly Private Browsing with Tracking Protection
 Oikeasti yksityinen selaus seurannan suojauksen kanssa
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Tervetuloa Firefoxiin
-
-
-;Take Firefox with You
-Ota Firefox matkalle mukaan
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Käytä kirjanmerkkejä, historiaa, salasanoja ja muita asetuksia kaikilla laitteillasi.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Käytätkö jo Firefoxia?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Kirjaudu tilillesi, niin synkronoimme kirjanmerkit, salasanat ja muut tärkeät asiat, jotka olet tallentanut Firefoxiin muilla laitteilla.
-
-
-;Learn more about Firefox Accounts
-Lue lisää Firefox-tilistä
-
-
-;Skip this step
-Ohita tämä vaihe
-
-
-# Old firstrun page
-;Chart your own course
-Kulje omaa polkuasi
 
 

--- a/fi/firefox/campaign.lang
+++ b/fi/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/fr/firefox/campaign.lang
+++ b/fr/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Félicitations ! Vous utilisez la version la plus récente de Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Mettez Firefox à jour</a> pour bénéficier des dernières avancées en matière de rapidité et de vie privée.
-
-
-;You’re using a pre-release version of Firefox.
-Vous utilisez une préversion de Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Vous utilisez un système d’exploitation obsolète et vulnérable <a href="%(url)s">qui n’est plus pris en charge par Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Le nouveau <strong>Firefox</strong>
 
 ;Fast for good.
 Toujours plus rapide.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Découvrez Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nouveau, rapide, et pour de bon.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Télécharger maintenant
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Réparer Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Veuillez suivre <a href="%(url)s">ces instructions</a> pour installer Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Options d’installation avancées et autres plateformes
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Options d’installation avancées et autres plateformes
-
-
-;Keep up with<br> all things Firefox.
-Tenez-vous informé<br> de l’actualité Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Téléchargez Firefox <span>pour Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Téléchargez Firefox <span>pour macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Téléchargez Firefox <span>pour Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Télécharger Firefox pour d’autres langues et plateformes
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Télécharger dans une autre langue
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Votre téléchargement devrait commencer automatiquement. Cela n’a pas fonctionné ? Essayez de <a id="%(id)s" href="%(fallback_url)s">relancer le téléchargement</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Votre téléchargement devrait commencer automatiquement. Si ce n’est pas le cas, <a id="%(id)s" href="%(fallback_url)s">cliquez ici</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Découvrez comment rendre Firefox plus intelligent, plus rapide et plus sûr.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Recevez des informations, des astuces et des nouvelles sur les produits directement dans votre boîte de réception.
-
-
-;Enter your email address
-Saisissez votre adresse de courrier électronique
-
-
-;How will Mozilla use my email?
-Comment mon adresse sera-t-elle utilisée par Mozilla ?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla n’accorde pas seulement de l’importance à la confidentialité et à la sécurité de votre adresse électronique — cela fait partie de notre <a href="%(manifesto)s">Manifeste</a> : « La sécurité et la vie privée de chacun sur Internet sont fondamentales et ne doivent pas être facultatives. » <a href="%(principles)s">Apprenez-en davantage sur nos principes de confidentialité des données</a>.
-
-
-;What we want you to know:
-Ce que vous devez savoir :
-
-
-;You don’t need to give us your email to download and use Firefox.
-Il n’est pas nécessaire de nous donner votre adresse pour télécharger et utiliser Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Nous vous avons demandé votre adresse parce que nos recherches montrent que les personnes auxquelles nous présentons une introduction arrivent à faire plus de choses avec Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Vous recevrez des courriels destinés à vous aider à optimiser le fonctionnement de Firefox pour votre utilisation personnelle, des informations sur la vie privée et la sécurité et sur la manière de profiter à fond de votre temps passé sur le Web.
-
-
-;You can unsubscribe anytime, for any reason.
-Vous pouvez vous désinscrire à tout moment, quelle qu’en soit la raison.
-
-
-;We will not share, sell or use your email for any other purposes.
-Nous ne partagerons, ne vendrons ni n’utiliserons votre adresse pour aucun autre usage.
-
-
-;Let’s do this!
-C’est parti !
-
-
-;Sync up with Firefox on mobile:
-Synchronisez Firefox sur mobile :
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Navigateur web gratuit
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Téléchargez Mozilla Firefox, un navigateur Web gratuit. Firefox est créé par une communauté mondiale, à but non lucratif, qui œuvre pour que les utilisateurs gardent le contrôle de leur vie en ligne. Téléchargez Firefox pour Windows, macOS, Linux, Android et iOS dès maintenant&nbsp;!
-
-
-;Download the fastest Firefox ever
-Téléchargez la version la plus rapide de Firefox
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Un chargement des pages plus rapide, une consommation mémoire réduite et plein de fonctionnalités, le nouveau Firefox est là.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Champion de la confidentialité
 
 ;Truly Private Browsing with Tracking Protection
 Une navigation résolument privée avec la protection contre le pistage
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Bienvenue dans Firefox
-
-
-;Take Firefox with You
-Emportez Firefox avec vous
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Accédez à vos marque-pages, votre historique, vos mots de passe et d’autres paramètres sur l’ensemble de vos appareils.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Vous utilisez déjà Firefox ?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Connectez-vous à votre compte et nous synchroniserons les marque-pages, mots de passe et les autres choses que vous conservez dans Firefox sur d’autres appareils.
-
-
-;Learn more about Firefox Accounts
-En savoir plus sur les comptes Firefox
-
-
-;Skip this step
-Ignorer cette étape
-
-
-# Old firstrun page
-;Chart your own course
-Suivez votre propre voie
 
 

--- a/fr/firefox/campaign.lang
+++ b/fr/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/fy-NL/firefox/campaign.lang
+++ b/fy-NL/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/fy-NL/firefox/campaign.lang
+++ b/fy-NL/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Lokwinske! Jo brûke de nijste ferzje fan Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Wurkje jo Firefox by</a> foar it nijste yn faasje en privacy.
-
-
-;You’re using a pre-release version of Firefox.
-Jo brûke in pre-releaseferzje fan Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Jo brûke in ûnfeilich, ferâldere bestjoeringssysteem dat <a href="%(url)s">net mear troch Firefox stipe wurdt</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ De nije <strong>Firefox</strong>
 
 ;Fast for good.
 Fluch foar it goede.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Moetsje Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nij. Fluch. Foar it goed.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-No downloade
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox fernije
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Folgje <a href="%(url)s">dizze ynstruksjes</a> om Firefox te ynstallearjen.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Avansearre ynstallaasjeopsjes & oare platfoarms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Avansearre ynstallaasjeopsjes & oare platfoarms
-
-
-;Keep up with<br> all things Firefox.
-Bliuw op 'e hichte<br> fan alles yn Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>foar Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>foar macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>foar Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Firefox foar oare platfoarmen & talen downloade
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download yn in oare taal
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-It downloaden soe automatysk begjinne moatte. Net slagge?<a id="%(id)s" href="%(fallback_url)s">Probearje nochris</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-It downloaden begjint automatysk. <a id="%(id)s" href="%(fallback_url)s">Klik hjir</a> as dit net sa is.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Lês hoe't jo Firefox noch tûker, flugger en feiliger meitsje kinne.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Untfang ynformative tips, trúks en produktoankundigingen yn jo mailbox.
-
-
-;Enter your email address
-Fier jo e-mailadres yn
-
-
-;How will Mozilla use my email?
-Hoe brûkt Mozilla myn e-mailadres?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla wurdearret net allinnich de privacy en befeiliging fan jo e-mailadres – it is ûnderdiel fan ús <a href="%(manifesto)s">Manifest</a>: “De feilichheid en privacy fan persoanen op it ynternet binne fundaminteel en moatte net as opsjoneel beskôge wurde.” <a href="%(principles)s">Hjir kinne jo mear oer ús Prinsipen oer gegevensprivacy lêze</a>.
-
-
-;What we want you to know:
-Wat wy wolle dat jo witte:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Jo hoege ús net jo e-mailadres te jaan om Firefox te downloaden en te brûken.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Wy hawwe om jo e-mailadres frege omdat ús ûndersyk oantoant dat minsken dy't in ynliedende ûnderfining krije, mear en bettere dingen dogge mei Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Jo kinne e-mails ferwachtsje dy't opsteld binne om jo te helpen Firefox sa goed mooglik te optimalisearjen, mear oer privacy en befeiliging te lêzen, en te ûntdekken hoe't jo it bêste út it web helje kinne.
-
-
-;You can unsubscribe anytime, for any reason.
-Jo kinne jo altyd útskriuwe, om hokker reden dan ek.
-
-
-;We will not share, sell or use your email for any other purposes.
-Wy sille jo e-mailadres net foar oare doelen diele, ferkeapje of brûke.
-
-
-;Let’s do this!
-Oan de slach!
-
-
-;Sync up with Firefox on mobile:
-Syngronisaasje mei Firefox foar mobyl:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Fergese webbrowser
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, in frije webbrowser. Firefox wurdt makke troch in wrâldwide non-profitorganisaasje dy't harre ynset om brûkers online de kontrôle hâlde te litten. Download no Firefox foar Windows, macOS, Linux, Android en iOS!
-
-
-;Download the fastest Firefox ever
-Download de fluchste Firefox ea
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Flugger siden lade, minder ûnthâldgebrûk en fol mei funksjes: de nije Firefox is hjir.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Krêftich privee
 
 ;Truly Private Browsing with Tracking Protection
 Echt privee surfe mei beskerming tsjin folgjen
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Wolkom by Firefox
-
-
-;Take Firefox with You
-Nim Firefox mei jo mei
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Krij jo blêdwizers, skiednis, wachtwurden en oare ynstellingen op al jo apparaten.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Brûke jo al Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Meld jo oan by jo account en wy syngronisearje de blêdwizers, wachtwurden en oare aardige saken dy't jo yn Firefox op oare apparaten bewarre hawwe.
-
-
-;Learn more about Firefox Accounts
-Mear ynfo oer Firefox Accounts
-
-
-;Skip this step
-Dizze stap oerslaan
-
-
-# Old firstrun page
-;Chart your own course
-Bepaal jo eigen koers
 
 

--- a/ga-IE/firefox/campaign.lang
+++ b/ga-IE/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Comhghairdeas! Tá an leagan is déanaí de Firefox agat.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Nuashonraigh</a> Firefox chun an brabhsálaí is tapúla is príobháidí a fháil.
-
-
-;You’re using a pre-release version of Firefox.
-Tá tú ag úsáid réamhleagan de Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Athnuaigh Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-<a href="%(url)s">Na treoracha</a> le leanúint chun Firefox a shuiteáil.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Bí ar an eolas<br> faoi Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Íoslódáil Firefox <span>ar Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Íoslódáil Firefox <span>ar macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Íoslódáil Firefox <span>ar Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Brabhsálaí Saor in Aisce
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Íoslódáil Mozilla Firefox, brabhsálaí Gréasáin saor in aisce. Tá Firefox forbartha ag eagraíocht dhomhanda neamhbhrabúis a chuireann daoine in uachtar ar an Idirlíon. Faigh Firefox ar Windows, macOS, Linux, Android agus iOS inniu!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Fáilte go Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-An bhfuil Firefox agat cheana?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Logáil isteach i do chuntas agus sioncronóimid na leabharmharcanna, focail fhaire, agus rudaí iontacha eile a shábháil tú le Firefox ar do chuid gléasanna eile.
-
-
-;Learn more about Firefox Accounts
-Tuilleadh eolais faoi Chuntais Firefox
-
-
-;Skip this step
-Ná bac leis an gcéim seo
-
-
-# Old firstrun page
-;Chart your own course
-Lean do bhealach féin
 
 

--- a/gd/firefox/campaign.lang
+++ b/gd/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Meal do naidheachd! Tha an tionndadh as ùire de Firefox agad.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Ùraich</a> am Firefox agad airson na gleusan prìobhaideachd is astair as fhearr.
-
-
-;You’re using a pre-release version of Firefox.
-Tha tionndadh ro-sgaoilidh de Firefox agad.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Ath-nuadhaich Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Lean ris <a href="%(url)s">an stiùireadh seo</a> gus Firefox a stàladh.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Brabhsair-lìn saor an-asgaidh
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/gl/firefox/campaign.lang
+++ b/gl/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/gl/firefox/campaign.lang
+++ b/gl/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Parabéns! Está usando a última versión do Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Actualice</a> o seu Firefox para obter o último en velocidade e privacidade.
-
-
-;You’re using a pre-release version of Firefox.
-Está usando unha versión preliminar do Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Está usando un sistema operativo inseguro e obsoleto <a href="%(url)s">que xa non é compatíbel con Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ O novo <strong>Firefox</strong>
 
 ;Fast for good.
 Sempre máis rápido.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Coñeza Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Novo, rápido, e para sempre.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Descargar agora
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Reiniciar Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Para instalar Firefox, <a href="%(url)s">siga estas instrucións</a>.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Opcións avanzadas de instalación e outras plataformas
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Opcións avanzadas de instalación e outras plataformas
-
-
-;Keep up with<br> all things Firefox.
-Siga a actualidade<br> de Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Descargue Firefox <span>para Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Descargue Firefox <span>para macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Descargue Firefox <span>para Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Descargar para outras plataformas e idiomas
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Descargar noutro idioma
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-A súa descarga debería iniciarse automaticamente. Non se iniciou? <a id="%(id)s" href="%(fallback_url)s">Tente descargala de novo</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-A súa descarga debería iniciarse automaticamente. Se non é así, <a id="%(id)s" href="%(fallback_url)s">prema aquí</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Descubra como facer o Firefox máis intelixente, máis rápido e máis seguro.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Reciba consellos informativos, trucos e novidades do produto directamente na súa caixa de entrada.
-
-
-;Enter your email address
-Escriba o seu correo electrónico
-
-
-;How will Mozilla use my email?
-Como usará Mozilla o meu correo electrónico?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla non só valora a privacidade e a seguranza do seu correo electrónico – é parte do noso <a href="%(manifesto)s">Manifesto</a>: «A seguranza e a privacidade dos individuos na Internet son fundamentais e non se deben tratar como opcionais.» <a href="%(principles)s">Pode obter máis información sobre os nosos principios sobre privacidade de datos aquí</a>.
-
-
-;What we want you to know:
-Queremos que saiba:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Non precisa darnos o seu correo electrónico para descargar e usar Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Pedímoslle o seu correo electrónico porque os nosos estudios amosan que os usuarios poden ser máis produtivos con Firefox se reciben suxestións sobre como empezar.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Recibirá correos electrónicos para axudalo a optimizar o funcionamento de Firefox para o seu uso persoal, información sobre privacidade e seguranza, e como aproveitar ao máximo o tempo que pasa na Web.
-
-
-;You can unsubscribe anytime, for any reason.
-Pode darse de baixa en calquera momento, por calquera razón.
-
-
-;We will not share, sell or use your email for any other purposes.
-Non compartiremos, nin venderemos nin usaremos o seu correo para ningún outro propósito.
-
-
-;Let’s do this!
-Próbeo agora!
-
-
-;Sync up with Firefox on mobile:
-Sincronice co Firefox no móbil:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Navegador de balde
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Descargue Mozilla Firefox, un navegador web de balde. Firefox é desenvolvido por unha organizacións sen fins de lucro para pór nos individuos o control da súa vida en liña. Obteña o Firefox para Windows, macOS, Linux, Android e iOS xa!
-
-
-;Download the fastest Firefox ever
-Descargue o Firefox  máis rápido de sempre
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-O novo Firefox xa está aquí: carga as páxinas máis rápido, menos uso de memoria e un montón de funcionalidades.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Privacidade absoluta
 
 ;Truly Private Browsing with Tracking Protection
 Navegación realmente privada con protección contra o seguimento
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Benvida ao Firefox
-
-
-;Take Firefox with You
-Leve o Firefox consigo
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Acceda aos seus marcadores, historial, contrasinais e outras configuracións en todos os seus dispositivos.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Xa usa Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Acceda a súa conta e sincronizaremos os seus marcadores, contrasinais e outras cousas que gardara no Firefox noutros dispositivos.
-
-
-;Learn more about Firefox Accounts
-Obteña máis información sobre as contas Firefox
-
-
-;Skip this step
-Ignorar este paso
-
-
-# Old firstrun page
-;Chart your own course
-Siga o seu propio camiño
 
 

--- a/gn/firefox/campaign.lang
+++ b/gn/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/gn/firefox/campaign.lang
+++ b/gn/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-¡Vy'apavẽ! Eipuruhína Firefox rehegua ipyahuetevéva.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Embohekopyahu</a> Firefox eguereko hag̃ua ipya’e hekorosãva.
-
-
-;You’re using a pre-release version of Firefox.
-Eipuru hína peteĩ Firefox rembiapokue oĩmba’ỹva gueteri.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Eipuruhína peteĩ apopyvusu ytuja ha hekorosã’ỹva <a href="%(url)s">Firefox nombohekopyahuvéima chupe</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Ipyahúva <strong>Firefox</strong>
 
 ;Fast for good.
 Ipya’éta tapiaite.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Eikuaa Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Ipyahu. Ipya’e. Tapiaitéta.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Emboguejy ko'ág̃a
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox mbopiro'y
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Ehapykueho <a href="%(url)s">ko’ã ñembo’epy</a> emboguejy hag̃ua Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Ñemboguejy poravorã oikopátamava ha ambue jehechaukaha.
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Ñemboguejy poravorã oikopátamava ha ambue jehechaukaha.
-
-
-;Keep up with<br> all things Firefox.
-Ehapykueho mba’epyahu<br> Firefox rehegua.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Emboguejy Firefox <span>Windows peg̃uarã</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Emboguejy Firefox <span>macOS peg̃uarã</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Emboguejy Firefox <span>Linux peg̃uarã</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Emboguejy ambue jehechaukaha ha ñe’ẽnguérape g̃uarã
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Emboguejy ambue ñe’ẽme
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Ko ñemboguejy oñepyrũta ijeheguiete. ¿Noñepyrũi? <a id="%(id)s" href="%(fallback_url)s">Eha’ãjey emboguejy</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Ñemboguejy oñepyrũva’erã ijeheguiete. ¿Noñepyrũiramo? <a id="%(id)s" href="%(fallback_url)s">Eikutu ápe</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Ejapo Firefox-gui ha’eve, ipya’e ha hekorosãvéva.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Eguereko marandu iporãva, apokuaa ha mba’e pyahu oikéva ne Ñandutiveve g̃uahẽhápe.
-
-
-;Enter your email address
-Ehai ne ñanduti veve kundaharape
-
-
-;How will Mozilla use my email?
-¿Mba’éicha oipurúta Mozilla che ñanduti veve?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla ohecharamo ne ñanduti veve ñemigua ha hekorosã – ha’e ore <a href="%(manifesto)s">He’ipyre</a>: “Tekorosã ha ñemigua ñanduti tapicha mba’éva tuichamba’e ha ndaha’eiva’erã japoseguireínte.” <a href="%(principles)s">Ikatu eikuaave mba’ekuaarã ñemigua rehegua ko’ápe</a>.
-
-
-;What we want you to know:
-Roipota reikua ko’ãva:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Natekotevẽi eme’ẽ ne ñanduti veve emboguejy ha eipuru hag̃ua Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Rojerure ne ñanduti veve ore jehapykueho ohechauka rupi pe tapicha oguerekóva ñe’ẽñepyrũgua omba’apo ha porãve Firefox ndive.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Ikatu hína og̃uahẽ ndéve ñanduti veve nepytyvõkuaáva Firefox eipuru porã hag̃ua, eikuaave hag̃ua avei ñemigua ha tekorosã rehegua ha eikuaa hag̃ua mba’eichaitépa eipurúta nde aravo ñandutípe.
-
-
-;You can unsubscribe anytime, for any reason.
-Ikatu esẽte eipota vovénte, nderehéntema oĩ.
-
-
-;We will not share, sell or use your email for any other purposes.
-Noromoherakuã, hepyme’ẽ térã ndoroipurumo’ãi ne ñanduti veve mba’eveicharã.
-
-
-;Let’s do this!
-¡Eñepyrũ emba’apo!
-
-
-;Sync up with Firefox on mobile:
-Embojuehe Firefox ndive pumbyrýpe:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Kundahára reiguáva
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Embojuehe Firefox, peteĩ kundaha reiguáva ñandutípe. Firefox omoheñói peteĩ atyguasu arapyguáva viru’ỹ rehegua oñeha’ãva opavave tapicha oikundaha hag̃ua ñanduti rupi ojaposeháicha. ¡Eguerekóke Firefox Windows, macOS, Linux, Android ha iOS ko arapete!
-
-
-;Download the fastest Firefox ever
-Emboguejy Firefox ipya’evéva tembiasakuépe
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Emyenyhẽ kuatiarogue pya’e, sa’ive oipuru mandu’arenda ha heta hembiapoite, ko’ápe oĩma Firefox pyahu.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Oipuru 30% sa’ive mandu’arenda Chrome-gui
 
 ;Truly Private Browsing with Tracking Protection
 Kundaha ñemigua añetéva tapykuere mo'ãha ndive
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Tereg̃uahẽporãote Firefox-pe
-
-
-;Take Firefox with You
-Egueraha Firefox nendive
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Egueraha nde rechaukaha, tembiasakue, ñe’ẽñemi ha ambue ñemboheko opaite ne mba’e’okápe.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-¿Eipurúma hína Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Emoinge ne mba’ete ha rombojuehéta umi techaukaha, ñe’ẽñemi ha ambue mba’e tuicha mba’éva Firefox ambue mba’e’okápe.
-
-
-;Learn more about Firefox Accounts
-Eikuaave Firefox mba’ete rehegua
-
-
-;Skip this step
-Epónte ápe
-
-
-# Old firstrun page
-;Chart your own course
-Emboguata ndete nde rape
 
 

--- a/gu-IN/firefox/campaign.lang
+++ b/gu-IN/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-અભિનંદન! તમે Firefox ની તાજેતરની આવૃત્તિ વાપરી રહ્યા છો.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">સુધારા</a> ઝડપ અને ગોપનીયતા માટે તમારા તાજેતર Firefox.
-
-
-;You’re using a pre-release version of Firefox.
-તમે Firefoxના પ્રિ-પ્રકાશન આવૃત્તિનો ઉપયોગ કરી રહ્યા છો.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-તમે અસુરક્ષિત, જૂની ઓપરેટિંગ સિસ્ટમનો ઉપયોગ કરી રહ્યાં છો <a href="%(url)s">જે હવે Firefox દ્વારા સપોર્ટેડ નથી </a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@
 
 ;Fast for good.
 સારા કાર્યો માટે ઝડપી.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Firefox Quantum ને જાણો
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-નવું. ઝડપી. સારા કાર્યો માટે.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-હમણાં ડાઉનલોડ કરો
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-તાજું Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-કૃપા કરીને Firefox ને ઇન્સ્ટોલ કરવા માટે <a href="%(url)s">આ સૂચનો</a> ને અનુસરો.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-અદ્યતન ઇન્સ્ટોલ વિકલ્પો અને અન્ય પ્લેટફોર્મ્સ
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-અદ્યતન ઇન્સ્ટોલ વિકલ્પો અને અન્ય પ્લેટફોર્મ્સ
-
-
-;Keep up with<br> all things Firefox.
-સાથે રાખવા <br> બધી વસ્તુઓ Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-<span>Windows માટે</span> Firefox ડાઉનલોડ કરો
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-<span>macOS માટે</span> Firefox ડાઉનલોડ કરો
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-<span>Linux માટે</span> Firefox ડાઉનલોડ કરો
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-અન્ય પ્લેટફોર્મ અને ભાષાઓ માટે ડાઉનલોડ કરો
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-બીજી ભાષામાં ડાઉનલોડ કરો
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-તમારું ડાઉનલોડ આપમેળે શરૂ થવું જોઈએ. નથી થતુ? <a id="%(id)s" href="%(fallback_url)s">ફરીથી ડાઉનલોડ કરવાનો પ્રયાસ કરો</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-તમારું ડાઉનલોડ આપમેળે શરૂ થવું જોઈએ. જો તે નથી, તો <a id="%(id)s" href="%(fallback_url)s">અહીં ક્લિક કરો</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-કેવી રીતે Firefoxને વધુ સ્માર્ટ, ઝડપી અને વધુ સુરક્ષિત બનાવવું તે જાણો.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-તમારા ઇનબોક્સમાં વિતરિત માહિતીપ્રદ ટિપ્સ, યુક્તિઓ અને ઉત્પાદનની જાહેરાતઓ મેળવો.
-
-
-;Enter your email address
-તમારું ઇ-મેઇલ સરનામું દાખલ કરો
-
-
-;How will Mozilla use my email?
-Mozilla મારું ઇ-મેઇલ કેવી રીતે વાપરશે?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla ફક્ત તમારી ઇમેઇલ ગોપનીયતા અને સલામતીનું મૂલ્ય લેતું નથી – તે અમારા <a href="%(manifesto)s">Mainfesto</a>નો ભાગ છે: ઇન્ટરનેટ પર “વ્યક્તિગત સુરક્ષા અને ગોપનીયતા મૂળભૂત છે અને તેની સારવાર થવી જોઈએ નહીં વૈકલ્પિક રૂપે.” <a href="%(principles)s">તમે અહીં અમારા ડેટા ગોપનીયતા સિદ્ધાંતો વિશે જાણી શકો છો</a>.
-
-
-;What we want you to know:
-અમે તમને શું જણાવવાં માંગીએ છીએ:
-
-
-;You don’t need to give us your email to download and use Firefox.
-તમારે Firefox ડાઉનલોડ કરવા કે વાપરવાં અમને તમારું ઇ-મેઇલ સરનામું આપવાની જરુર નથી.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-અમે તમારા ઇમેઇલ માટે પૂછ્યું છે કારણ કે અમારા સંશોધન બતાવે છે કે લોકો જે પ્રારંભિક અનુભવ મેળવે છે તે Firefox સાથે વધુ સારી રીતે કાર્ય કરે છે.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-તમે Firefoxને તમારા માટે શ્રેષ્ઠ કામ કરવા માટે ઑપ્ટિમાઇઝ કરવામાં મદદ માટે રચાયેલ ઇમેઇલ્સની અપેક્ષા રાખી શકો છો, ગોપનીયતા અને સુરક્ષા વિશે વધુ જાણો અને વેબ પર તમારા શ્રેષ્ઠ સમયને કેવી રીતે બનાવવો તે જાણો.
-
-
-;You can unsubscribe anytime, for any reason.
-કોઈપણ કારણોસર, તમે કોઈપણ સમયે અનસબ્સ્ક્રાઇબ કરી શકો છો.
-
-
-;We will not share, sell or use your email for any other purposes.
-અમે કોઈપણ અન્ય હેતુઓ માટે તમારા ઇમેઇલને શેર, વેચાણ અથવા ઉપયોગ કરીશું નહીં.
-
-
-;Let’s do this!
-ચાલો આ કરીએ!
-
-
-;Sync up with Firefox on mobile:
-મોબાઇલ પર Firefox સાથે સમન્વયન કરો:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Firefox ડાઉનલોડ કરો
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Mozilla Firefox ડાઉનલોડ કરો, એક મફત વેબ બ્રાઉઝર. Firefox વ્યક્તિઓને ઑનલાઇન નિયંત્રણમાં મૂકવા માટે સમર્પિત વૈશ્વિક બિન નફાકારક દ્વારા બનાવવામાં આવે છે. આજે Windows, macOS, Linux, Android અને iOS માટે Firefox મેળવો!
-
-
-;Download the fastest Firefox ever
-અત્યાર સુધીનુ સૌથી ઝડપી Firefox ડાઉનલોડ કરો
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-ઝડપી પૃષ્ઠ લોડ કરવું, ઓછું મેમરી વપરાશ અને સુવિધાઓ સાથે પેક, નવુ Firefox અહીં છે.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Chrome કરતાં 30% અોછી મેમરીનો ઉપયોગ �
 
 ;Truly Private Browsing with Tracking Protection
 વિશેષ ટ્રેકિંગ સુરક્ષા સાથે ખાનગી બ્રાઉઝર
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Firefox માં તમારું સ્વાગત છે
-
-
-;Take Firefox with You
-તમારી સાથે Firefox લો
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-તમારા બધા ઉપકરણો પર તમારા બુકમાર્ક્સ, ઇતિહાસ, પાસવર્ડ્સ અને અન્ય સેટિંગ્સ મેળવો.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-પહેલેથી જ Firefox નો ઉપયોગ કરી રહ્યાં છો?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-તમારા ખાતામાં સાઇન ઇન કરો અને અમે બુકમાર્ક્સ, પાસવર્ડ્સ અને તમે અન્ય ઉપકરણો પર Firefox માં સચવાયેલી અન્ય મહાન વસ્તુઓનો સમન્વય કરીશું.
-
-
-;Learn more about Firefox Accounts
-Fireofox ખાતા વિશે વધુ જાણો
-
-
-;Skip this step
-આ પગલું છોડી દો
-
-
-# Old firstrun page
-;Chart your own course
-તમારા પોતાના કોર્સ નકશો
 
 

--- a/gu-IN/firefox/campaign.lang
+++ b/gu-IN/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/he/firefox/campaign.lang
+++ b/he/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-הידד! ברשותך הגרסה העדכנית ביותר של Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-עליכם <a href="%(url)s">לעדכן</a> את Firefox כדי ליהנות מהירות מרבית ופרטיות.
-
-
-;You’re using a pre-release version of Firefox.
-גרסת ה־Firefox שברשותך הינה קדם הפצה.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-גאים להציג את Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-חדש. מהיר. למען מטרות טובות.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-להוריד כעת
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-רענון Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-נא לעקוב אחר <a href="%(url)s">ההנחיות האלו</a> כדי להתקין את Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-אפשרויות התקנה מתקדמות ופלטפורמות אחרות
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-אפשרויות התקנה מתקדמות ופלטפורמות אחרות
-
-
-;Keep up with<br> all things Firefox.
-להתעדכן בכל<br> מה ש־Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-הורדת Firefox <span>עבור Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-הורדת Firefox <span>עבור macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-הורדת Firefox <span>עבור Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-הורדה בשפה אחרת
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-ההורדה שלך אמורה להתחיל אוטומטית. אם זה לא קרה, <a id="%(id)s" href="%(fallback_url)s">יש ללחוץ כאן</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-יאללה, מתקדמים!
-
-
-;Sync up with Firefox on mobile:
-סנכרון עם Firefox לנייד:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ We will not share, sell or use your email for any other purposes.
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 הורדת Mozilla Firefox, הדפדפן החופשי. Firefox נוצר על־ידי ארגון ללא כוונת רווח עולמי המוקדש כדי לתת לאנשים פרטיים שליטה בנוכחות המקוונת שלהם. הורידו את Firefox עבור Windows,‏ macOS,‏ Linux,‏ Android ו־iOS עוד היום!
-
-
-;Download the fastest Firefox ever
-הורידו את ה־Firefox המהיר ביותר אי פעם
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-טעינת דפים מהירה יותר, פחות שימוש בזיכרון ושלל תכונות חדשות, ה־Firefox החדש כאן.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ We will not share, sell or use your email for any other purposes.
 
 ;Truly Private Browsing with Tracking Protection
 גלישה פרטית באמת עם הגנת מעקב
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-ברוך בואך ל־Firefox
-
-
-;Take Firefox with You
-Firefox אתך בכל מקום
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-כבר יש לך Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-ניתן להיכנס לחשבון שלך ואנו נסנכרן את הסימניות, הססימאות ואת שאר הדברים הנהדרים ששמרת ב־Firefox בהתקנים אחרים.
-
-
-;Learn more about Firefox Accounts
-מידע נוסף על חשבונות Firefox
-
-
-;Skip this step
-דילוג על השלב הזה
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/hi-IN/firefox/campaign.lang
+++ b/hi-IN/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/hi-IN/firefox/campaign.lang
+++ b/hi-IN/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-बधाई! आप Firefox के हालिया संस्करण का उपयोग कर रहे हैं.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-गति और गोपनीयता में नयेपन के लिए अपने Firefox को <a href="%(url)s">अद्यतन करे</a>
-
-
-;You’re using a pre-release version of Firefox.
-आप Firefox के पूर्व लोकार्पण संस्करण का उपयोग कर रहे हैं.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-आप एक असुरक्षित, व पुराना ऑपरेटिंग सिस्टम इस्तेमाल कर रहे हैं <a href="%(url)s"> जो Firefox द्वारा अब समर्थित नहीं है</a>l
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@
 
 ;Fast for good.
 अच्छे के लिए तेज़.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-मिलिए Firefox क्वांटम से
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-नवीन. तीव्र. सदा के लिए.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-अभी डाउनलोड करें
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox रिफ्रेश करें
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-कृपया Firefox इंस्टॉल करने के लिए <a href="%(url)s">इन निर्देशों</a> का पालन करें.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-उन्नत स्थापना विकल्प & अन्य प्लेटफार्मों
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-उन्नत स्थापना विकल्प & अन्य प्लेटफार्मों
-
-
-;Keep up with<br> all things Firefox.
-सभी कुछ Firefox पर<br> रखें.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-<span>Windows के लिए</span> Firefox डाउनलोड करें
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-<span>macOS के लिए</span> Firefox डाउनलोड करें
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-<span>Linux के लिए</span> Firefox डाउनलोड करें
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-दुसरे प्लेटफार्म और भाषाओं के लिए डाउनलोड करें
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-किसी अन्य भाषा में डाउनलोड करें
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-आपका डाउनलोड स्वचालित रूप से शुरू होना चाहिए. अगर ऐसा नहीं होता, तो <a id="%(id)s" href="%(fallback_url)s"> यहाँ क्लिक करें</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-आपका डाउनलोड स्वतः शुरू होना चाहिए. अगर ऐसा नहीं होता, तो <a id="%(id)s" href="%(fallback_url)s">यहाँ क्लिक करें</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-जानें कि Firefox को कैसे और भी स्मार्ट, तीव्र एवं अधिक सुरक्षित बनाएँ।
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-जानकारीयुक्त सुझाव, तरकीब एवं प्रोडक्ट घोषणाओं को अपने इनबॉक्स में पहुँचा हुआ पायें।
-
-
-;Enter your email address
-अपना ईमेल पता दर्ज करें
-
-
-;How will Mozilla use my email?
-Mozilla मेरे ईमेल का किस प्रकार इस्तेमाल करेगा?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla ना केवल आपके ईमेल कि गोपनीयता एवं सुरक्षा को महत्व देती है – बल्कि यह हमारे <a href="%(manifesto)s"> घोषणापत्र </a> का एक हिस्सा है: “इंटरनेट पर लोगों कि सुरक्षा एवं गोपनीयता मौलिक चीजें हैं और इन्हें वैकल्पिक तौर पर ना लिया जाए।” <a href="%(principles)s"> द्वारा आप डेटा गोपनीयता सिद्धांतों के बारे में सीख सकते हैं</a>।
-
-
-;What we want you to know:
-जो हम चाहते हैं कि आप जानें:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Firefox को डाउनलोड और इस्तेमाल करने के लिए आपको अपना ईमेल हमे देने कि जरुरत नहीं है।
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-हमने आपके ईमेल के लिए इसलिए पूछा क्योंकि हमारे रिसर्च बतलाते हैं कि जो लोग शुरूआती अनुभव प्राप्त करते हैं वो Firefox के साथ अधिक एवं बेहतर करते हैं।
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Firefox का अपने लिए बेहतरीन रूप से काम लेने के लिए आप डिज़ाइन किये गए ईमेल की अपेक्षा कर सकते हैं, गोपनीयता एवं सुरक्षा के बारे में अधिक जानें और पता लगायें की वेब पर अपने समय का बेहतरीन इस्तेमाल कैसे करें।
-
-
-;You can unsubscribe anytime, for any reason.
-आप किसी भी कारण से, किसी भी समय सदस्यता समाप्त कर सकते हैं।
-
-
-;We will not share, sell or use your email for any other purposes.
-हम कसी अन्य उद्देश्य के लिए आपके ईमेल को साझा, बिक्री या इस्तेमाल नहीं करेंगे।
-
-
-;Let’s do this!
-चलो इसे कर दिखाएँ!
-
-
-;Sync up with Firefox on mobile:
-मोबाइल पर सिंक करें Firefox के साथः
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Firefox डाउनलोड करें
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 एक मुफ्त वेब ब्राउज़र, Mozilla Firefox डाउनलोड करें. Firefox का निर्माण एक वैश्विक गैर-लाभ ऑनलाइन नियंत्रण समर्पित व्यक्तियो ने किया है. आज ही Windows, Mac OS X, Linux, Android और iOS के लिए फायरफॉक्स डाउनलोड करें!‌
-
-
-;Download the fastest Firefox ever
-अब तक के सबसे तेज Firefox डाउनलोड करें
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-तीव्र पृष्ठ लोड, कम मेमोरी उपयोगिता और सुबिधाओं से भरपूर के साथ नया Firefox यहाँ मौजूद है.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Chrome की तुलना में 30% कम मेमोरी का उ
 
 ;Truly Private Browsing with Tracking Protection
 सही मायने में निजी ब्राउज़िंग ट्रैकिंग संरक्षण के साथ
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Firefox में आपका स्वागत है
-
-
-;Take Firefox with You
-अपने साथ Firefox चुने
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-अपने सभी उपकरणों पर अपना पुस्तचिह्न, इतिहास, कूटशब्द और अन्य सेटिंग प्राप्त करें.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-पहले से ही Firefox का उपयोग कर रहे हैं?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-अपने खाते में साइन इन करें और हम बुकमार्क, पासवर्ड और अन्य बड़ी चीज़ों को सिंक करेंगे जिन्हें आपने अन्य डिवाइसों के Firefox पर सहेज रखा है.
-
-
-;Learn more about Firefox Accounts
-Firefox खातों के बारे में अधिक जानें
-
-
-;Skip this step
-इस चरण को छोड़ दें
-
-
-# Old firstrun page
-;Chart your own course
-अपने खुद के कोर्स को तैयार करें
 
 

--- a/hr/firefox/campaign.lang
+++ b/hr/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/hr/firefox/campaign.lang
+++ b/hr/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Čestitamo! Koristite najnoviju inačicu Firefoxa.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Ažurirajte</a> svoj Firefox za najbolje iskustvo brzine i privatnosti.
-
-
-;You’re using a pre-release version of Firefox.
-Koristite inačicu Firefox predizdanja.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 Novi <strong>Firefox</strong>
 
 
 ;Fast for good.
 Brz zauvijek.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Upoznajte Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nov. Brz. Za dobro.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Preuzmite sada
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Osvježite Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Pratite <a href="%(url)s">ova uputstva</a> za instalaciju Firefoxa.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Budite u toku<br> s Firefoxom.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Preuzmite Firefox <span>za Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Preuzmite Firefox <span>za macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Preuzmite Firefox <span>za Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Preuzmite za druge platforme i jezike
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Preuzmite na drugom jeziku
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Vaše preuzimanje će započeti automatski. Ukoliko ne započne, <a id="%(id)s" href="%(fallback_url)s">kliknite ovdje</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Idemo!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Besplatan web preglednik
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Preuzmite Mozilla Firefox, besplatni web preglednik. Firefox je stvoren od strane globalne neprofitne organizacije posvećene stavljanju kontrole u ruke pojedinca. Preuzmite Firefox za Windows, macOS, Linux, Android i iOS još danas!
-
-
-;Download the fastest Firefox ever
-Preuzmite najbrži Firefox ikad
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ U potpunosti privatan
 
 ;Truly Private Browsing with Tracking Protection
 Istinsko privatno pretraživanje sa zaštitom od praćenja
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Dobrodošli u Firefox
-
-
-;Take Firefox with You
-Uzmite Firefox sa sobom
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Već koristite Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Saznajte više o Firefox računima
-
-
-;Skip this step
-Preskočite ovaj korak
-
-
-# Old firstrun page
-;Chart your own course
-Zacrtajte si put
 
 

--- a/hsb/firefox/campaign.lang
+++ b/hsb/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/hsb/firefox/campaign.lang
+++ b/hsb/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Zbožopřeće! Wužiwaće najnowšu wersiju Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Aktualizujće</a> swój Firefox za najnowše w spěšnosći a priwatnosći.
-
-
-;You’re using a pre-release version of Firefox.
-Wužiwaće předwersiju Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Wužiwaće njewěsty, zestarjeny dźěłowy system, kotryž <a href="%(url)s">so hižo wot Firefox njedpodpěruje</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Nowy <strong>Firefox</strong>
 
 ;Fast for good.
 Spěšny a dobry.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Zeznajće z Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nowy. Spěšny. A dobry.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Nětko sćahnyć
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox aktualizować
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Prošu slědujće <a href="%(url)s">tutym instrukcijam</a> za instalowanje Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Rozšěrjene instalowanske nastajenja a druhe platformy
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Rozšěrjene instalowanske nastajenja a druhe platformy
-
-
-;Keep up with<br> all things Firefox.
-Wostańće ze<br> wšěm wo Firefox na běžnym.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Sćehńće Firefox <span>za Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Sćehńće Firefox <span>za macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Sćehńće Firefox <span>za Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Za druhe platformy a rěče sćahnyć
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-W druhej rěči sćahnyć
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Waše sćehnjenje dyrbjało so awtomatisce započeć. Njefunguje? <a id="%(id)s" href="%(fallback_url)s">Sćehńće znowa</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Waše sćehnjenje dyrbjało so awtomatisce započeć. Jeli nic, <a id="%(id)s" href="%(fallback_url)s">klikńće tu</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Zhońće, kak móžeće Firefox hišće bóle inteligentny, spěšniši a wěsćiši činić.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Dóstańće informatiwne pokiwy, triki a produktowe připowědźenja direktnje we swojim póstowym dochadźe.
-
-
-;Enter your email address
-Zapodajće swoju e-mejlowu adresu
-
-
-;How will Mozilla use my email?
-Kak budźe Mozilla moju e-mejlowu adresu wužiwać?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla sej nic jenož wašu e-mejlowu priwatnosć a wěstotu waži - je dźěl našeho <a href="%(manifesto)s">manifesta</a>: “Wěstota a priwatnosć jednotliwcow w interneće su fundamentalne a njesmědźa so za opcionalne měć.” <a href="%(principles)s">Tu móžeće wjace wo našich principach datoweje priwatnosće zhonić</a>.
-
-
-;What we want you to know:
-To wy měł wědźeć:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Njetrjebaće wašu e-mejlowu adresu podać, zo byšće Firefox sćahnył a wužiwał.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Smy so za wašej e-mejlowej adresu prašeli, dokelž naše slědźenje pokazuje, zo ludźo, kotřiž nawod dóstawaja, wjace a lěpje z Firefox dźěłaja.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Móžeće e-mejlki wočakować, kotrež wam maja pomhać, Firefox optimować, zo by nanajlěpje za was fungował, wjace wo priwatnosći a wěstoće zhonić a won namakać, kak móžeće swój čas w interneće najlěpje zwužiwać.
-
-
-;You can unsubscribe anytime, for any reason.
-Móžeće jón kóždy čas bjez přičiny wotskazać.
-
-
-;We will not share, sell or use your email for any other purposes.
-Njebudźemy wašu e-mejlowu adresu dale dawać, předawać abo za druhe zaměry wužiwać.
-
-
-;Let’s do this!
-Započmy!
-
-
-;Sync up with Firefox on mobile:
-Synchronizacija z Firefox na mobilnym graće:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Darmotny webwobhladowak
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Sćehńće Mozilla Firefox, darmotny webwobhladowak. Firefox je so wot wšěm wužitneje organizacije wuwił, kotraž se za to zasadźuje, zo kóždy ma kontrolu online. Wobstarajće sej dźensa Firefox za Windows, macOS, Linux, Android a iOS!
-
-
-;Download the fastest Firefox ever
-Sćehńće dotal najspěšniši Firefox
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Strony so spěšnišo začitaja, mjenje składa so wužiwa a z wjele funkcijemi: Nowy Firefox je wušoł.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Mócnje priwatny
 
 ;Truly Private Browsing with Tracking Protection
 Woprawdźe priwatny modus ze slědowanskim škitom
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Witajće k Firefox
-
-
-;Take Firefox with You
-Wzmiće Firefox sobu
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Wzmiće swoje zapołožki, historiju, hesła a druhe nastajenja na wšěch wašich gratach sobu.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Wužiwaće hižo Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Přizjewće so pola swojeho konta a budźemy zapołožki, hesła a druhe wulkotne wěcy synchronizować, kotrež sće w Firefox na druhich gratach składował.
-
-
-;Learn more about Firefox Accounts
-Zhońće wjace wo kontach Firefox
-
-
-;Skip this step
-Tutón krok přeskočić
-
-
-# Old firstrun page
-;Chart your own course
-Wuhotujće swój kurs
 
 

--- a/hto/firefox/campaign.lang
+++ b/hto/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Congrats! You’re using the latest version of Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refresh Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Free Web Browser
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/hu/firefox/campaign.lang
+++ b/hu/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/hu/firefox/campaign.lang
+++ b/hu/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Gratulálunk! A legfrissebb Firefox verziót használja.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Frissítse</a> Firefoxát, hogy megkapja a legfrissebb, sebességet és a magánszférát érintő fejlesztéseket.
-
-
-;You’re using a pre-release version of Firefox.
-A Firefox egy előzetes kiadási verzióját használja.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Egy nem biztonságos, elavult operációs rendszert használ, amit <a href="%(url)s">már nem támogat a Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Az új <strong>Firefox</strong>
 
 ;Fast for good.
 Gyors, a jó célért.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Ismerje meg a Firefox Quantumot
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Új. Gyors. A jó célért.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Letöltés most
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox frissítése
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-A Firefox telepítéséhez kövesse <a href="%(url)s">ezeket az utasításokat</a>.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Speciális telepítési beállítások és más platformok
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Speciális telepítési beállítások és más platformok
-
-
-;Keep up with<br> all things Firefox.
-Tartson lépést<br> mindennel, ami Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-A Firefox letöltése <span>Windowsra</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-A Firefox letöltése <span>macOS-re</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-A Firefox letöltése <span>Linuxra</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Letöltés más platformokra és nyelveken
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Töltse le egy másik nyelven
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-A letöltés automatikusan elindul. Nem működött? <a id="%(id)s" href="%(fallback_url)s">Próbálja újra letölteni</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-A letöltés automatikusan elindul. Ha nem, akkor <a id="%(id)s" href="%(fallback_url)s">kattintson ide</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Tudja meg hogyan teheti a Firefoxt még okosabbá, gyorsabbá és biztonságosabbá.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Kapjon tanulságos tippeket, trükköket és termékbejelentéséket a postaládájába.
-
-
-;Enter your email address
-Írja be az e-mail címét
-
-
-;How will Mozilla use my email?
-Hogyan használja a Mozilla az e-mail címemet?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-A Mozilla nem csak értékeli az e-mailes adatvédelmét és biztonságát – része a <a href="%(manifesto)s">Kiáltványunknak</a>: „Az egyének adatainak védelme és biztonsága az interneten alapvető fontosságú, nem kezelhető mellékes szempontként.” <a href="%(principles)s">Többet tudhat meg az Adatvédelmi irányelveinkről itt</a>.
-
-
-;What we want you to know:
-Amit szeretnénk, hogy tudjon:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Nem kell megadni az e-mail címét, hogy letöltse és használja a Firefoxot.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Azért kértük el az e-mail címét, mert a kutatásaink azt mutatják, hogy azok az emberek, akik bevezető élményeket kapnak, sokkal jobban boldogulnak a Firefoxszal.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Olyan e-mailekre számíthat, amelyből megtudhatja hogyan optimalizálhatja a Firefoxot, hogy az Önnek a legjobb legyen, tudjon meg többet az adatvédelemről és biztonságról, és tudja meg hogyan hozhatja ki a legtöbbet a weben töltött időből.
-
-
-;You can unsubscribe anytime, for any reason.
-Bármikor leiratkozhat, bármilyen okból.
-
-
-;We will not share, sell or use your email for any other purposes.
-Nem osztjuk meg, adjuk el vagy használjuk bármilyen más célra az e-mail címét.
-
-
-;Let’s do this!
-Csináljuk!
-
-
-;Sync up with Firefox on mobile:
-Szinkronizáljon a mobilos Firefoxával:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Ingyenes böngésző
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Töltse le a Mozilla Firefoxot, a szabad webböngészőt. A Firefoxot egy globális nonprofit szervezet készíti, amely elkötelezett abban, hogy az egyének kezében adja az irányítást. Szerezze be a Firefoxot Windows, macOS, Linux, Android és iOS rendszerekre még ma!
-
-
-;Download the fastest Firefox ever
-A valaha volt leggyorsabb Firefox letöltése
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Gyorsabb oldalbetöltés, kisebb memóriahasználat és egy csokor új funkció, az új Firefox megérkezett.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Hatékony adatvédelem
 
 ;Truly Private Browsing with Tracking Protection
 Valóban privát böngészés, követés elleni védelemmel
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Üdvözli a Firefox
-
-
-;Take Firefox with You
-Vigye magával a Firefoxot
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Kapja meg a könyvjelzőit, előzményeit, jelszavait és egyéb beállításait az összes eszközén.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Már Firefoxot használ?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Jelentkezzen be a fiókjába, és szinkronizáljuk a könyvjelzőit, jelszavat és egyéb dolgait, amit más eszközein mentett a Firefoxba.
-
-
-;Learn more about Firefox Accounts
-Ismerje meg a Firefox fiókokat
-
-
-;Skip this step
-Lépés kihagyása
-
-
-# Old firstrun page
-;Chart your own course
-Járja a saját útját
 
 

--- a/hy-AM/firefox/campaign.lang
+++ b/hy-AM/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/hy-AM/firefox/campaign.lang
+++ b/hy-AM/firefox/campaign.lang
@@ -1,25 +1,4 @@
-## active ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Շնորհավորում ենք: Դուք օգտագործում եք Firefox-ի վերջին տարբերակը:
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Թարմացրեք</a> ձեր Firefox-ը՝ արագության և գաղտնիության ապահովման համար:
-
-
-;You’re using a pre-release version of Firefox.
-Դուք օգտագործում եք Firefox-ի նախաթողարկված տարբերակը:
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -28,133 +7,6 @@ You’re using an insecure, outdated operating system <a href="%(url)s">no longe
 
 ;Fast for good.
 Լավն է:
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Դիմավորեք Firefox Quantum-ը
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Նոր: Արագ: Լավը:
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Ներբեռնել հիմա
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Թարմացնել Firefox-ը
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Firefox-ը տեղադրելու համար հետևեք <a href="%(url)s">այս հրահանգներին</a>:
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Տեղադրելու լրացուցիչ ընտրանքներ և այլ հարթակներ
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Տեղադրելու լրացուցիչ ընտրանքներ և այլ հարթակներ
-
-
-;Keep up with<br> all things Firefox.
-Պահպանեք <br> ամենը Firefox-ի հետ:
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Ներբեռնեք Firefox-ը <span>Windows-ի համար</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Ներբեռնեք Firefox-ը <span>macOS-ի համար</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Ներբեռնեք Firefox-ը <span>Linux-ի համար</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Ներբեռնել այլ հարթակների համար և տարբեր լեզուներով
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Ներբեռնել այլ լեզվով
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Ներբեռնումը շուտով կսկսի: Չի՞ սկսվել: <a id="%(id)s" href="%(fallback_url)s">Կրկին փորձեք</a>:
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Ներբեռնումը շուտով կսսվի: Եթե չի սկսվել,<a id="%(id)s" href="%(fallback_url)s">սեղմեք այստեղ</a>:
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Եկե՛ք անենք դա:
-
-
-;Sync up with Firefox on mobile:
-Համաժամեցրեք Firefox-ը բջջայինում.
 
 
 # HTML page title prefix
@@ -170,14 +22,6 @@ We will not share, sell or use your email for any other purposes.
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Ներբեռնեք Mozilla Firefox-ը՝ անվճար վեբ դիտարկիչ: Firefox-ը ստեղծվել է ընդհանրական, ոչ առևտրային՝ առցանց կառավարումը անհատներին թողնելու նպատակով: Ստացեք Firefox-ը Windows-ի, macOS-ի, Linux-ի, Android-ի և iOS-ի համար:
-
-
-;Download the fastest Firefox ever
-Ներբեռնեք ամենարագ Firefox-ը, որ երբևէ եղել է
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-էջերի արագ բեռնում, հիշողության քիչ օգտագործում և նորանոր յուրահատկություններ Firefox-ում: Այն արդեն այստեղ է:
 
 
 ;2x Faster
@@ -202,41 +46,5 @@ We will not share, sell or use your email for any other purposes.
 
 ;Truly Private Browsing with Tracking Protection
 Իրապես անձնական դիտարկիչ՝ Հետագծման պաշտպանությամբ
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Բարի գալուստ Firefox
-
-
-;Take Firefox with You
-Վերցրեք Firefox-ը ձեզ հետ
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Ստացեք ձեր էջանիծերը, պատմությունը, գաղտնաբառերը և այլ կարգավորումներ ձեր բոլոր սարքերում:
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Արդեբ օգտագործո՞ւմ եք Firefox-ը:
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Մուտք գործեք ձեր հաշիվ ու մենք կհամաժամեցնենք էջանիշերը, գաղտնաբառերը և այլ ամենը, ինչ դուք պահպանել եք ձեր Firefox-ում՝ տարբեր սարքերում:
-
-
-;Learn more about Firefox Accounts
-Իմանալ ավելին Firefox Հաշիվների մասին
-
-
-;Skip this step
-Բաց թողնել այս քայլը
-
-
-# Old firstrun page
-;Chart your own course
-Գծեք ձեր սեփական ընթացքը
 
 

--- a/ia/firefox/campaign.lang
+++ b/ia/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/ia/firefox/campaign.lang
+++ b/ia/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Felicitationes! Tu usa le ultime version de Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Actualisa</a> tu Firefox pro le maxime velocitate e confidentialitate disponibile.
-
-
-;You’re using a pre-release version of Firefox.
-Tu usa le version de pre-edition de Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Tu usa un systema operative non secur, obsolete <a href="%(url)s">non plus supportate per Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Le nove <strong>Firefox</strong>
 
 ;Fast for good.
 Veloce per sempre.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Discoperi Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nove. Veloce. Per sempre.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Discargar ora
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Restabili Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Per favor seque <a href="%(url)s">iste instructiones</a> pro installar Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Optiones de installation avantiate & altere platteformas
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Optiones de installation avantiate & altere platteformas
-
-
-;Keep up with<br> all things Firefox.
-Mantene te informate con<br> tote le novas de Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Discarga Firefox <span>pro Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Discarga Firefox <span>pro macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Discarga Firefox <span>pro Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Discarga pro altere platteformas & linguas
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Discarga lo in un altere lingua
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Tu discarga deberea initiar automaticamente. Non functiona? <a id="%(id)s" href="%(fallback_url)s">Prova a lo discargar de novo</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Tu discargamento comenciara automaticamente. Si non, <a id="%(id)s" href="%(fallback_url)s">clicca ci</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Apprende como render Firefox mesmo plus intelligente, plus veloce e ancora plus secur.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Obtene suggestiones informative, astutias e annuncios de productos, livrate a tu cassa de ingresso.
-
-
-;Enter your email address
-Insere tu adresse email
-
-
-;How will Mozilla use my email?
-Como usara Mozilla mi email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla non solo valorisa confidentialitate de tu email e securitate – illo es parte de nostre <a href="%(manifesto)s">Manifesto</a>: “Le securitate e le confidentialitate del personas sur internet es fundamental e non debe esser tractate como optional.” <a href="%(principles)s">Tu pote apprender circa nostre Principios de confidentialitate del datos ci</a>.
-
-
-;What we want you to know:
-Lo que nos vole que tu sape:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Tu non debe dar nos tu email pro discargar e usar Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Nos demandava tu email pois que nostre recerca monstras que personas qui recipe un experientia introductive face plus e melio con Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Tu pote expectar emails designate pro te adjutar a optimisar Firefox pro laborar al melio pro te, saper plus circa confidentialitate & securitate e discoperir como render melior tu tempore sur le web.
-
-
-;You can unsubscribe anytime, for any reason.
-Tu pote remover tu inrolamento quando tu lo vole, pro ulle ration.
-
-
-;We will not share, sell or use your email for any other purposes.
-Nos non compartira, vendera o usara tu email pro ulle altere propositos.
-
-
-;Let’s do this!
-Que nos lo face!
-
-
-;Sync up with Firefox on mobile:
-Synchronisa te per Firefox sur telephonos e tablettas:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Navigator web libere e gratuite
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Discarga Mozilla Firefox, un navigator web libere e gratuite. Firefox es create per un organisation mundial sin fin de lucro dedicate a poner le individuos in controlo del rete. Discarga hodie Firefox pro Windows, macOS, Linux, Android e iOS!
-
-
-;Download the fastest Firefox ever
-Discarga le plus rapide Firefox de sempre
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Cargamento paginas plus rapide, minor uso de memoria e functionalitates incorporate, ecce le nove Firefox.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Potentemente confidential
 
 ;Truly Private Browsing with Tracking Protection
 Navigation vermente private con protection contra le traciamento
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Benvenite in Firefox
-
-
-;Take Firefox with You
-Porta Firefox con te
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Tene tu marcapaginas, chronologia, contrasignos e alie configurationes sur tote tu apparatos.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Usa tu jam Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Accede a tu conto e tu synchronisa tu marcapaginas, contrasignos e altere grande cosas tu salvava per Firefox sur altere apparatos.
-
-
-;Learn more about Firefox Accounts
-Saper plus super le contos Firefox
-
-
-;Skip this step
-Salta iste grado
-
-
-# Old firstrun page
-;Chart your own course
-Decide tu via
 
 

--- a/id/firefox/campaign.lang
+++ b/id/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Selamat! Anda telah menggunakan versi terbaru Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Perbarui</a> Firefox Anda untuk pembaruan dalam hal kecepatan dan privasi.
-
-
-;You’re using a pre-release version of Firefox.
-Anda sedang menggunakan versi prarilis Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Anda menggunakan sistem operasi usang dan tidak aman yang <a href="%(url)s">tidak didukung lagi oleh Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Anda menggunakan sistem operasi usang dan tidak aman yang <a href="%(url)s">tida
 
 ;Fast for good.
 Cepat untuk kebaikan.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Mari Berjumpa dengan Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Baru. Cepat. Untuk kebaikan.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Unduh Sekarang
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Segarkan Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Silakan ikuti <a href="%(url)s">instruksi ini</a> untuk memasang Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Pilihan Pemasangan & Platform Lain Tingkat Lanjut
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Pilihan pemasangan & platform lain tingkat lanjut
-
-
-;Keep up with<br> all things Firefox.
-Dapatkan semua kabar terkini<br>tentang Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Unduh Firefox <span>untuk Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Unduh Firefox <span>untuk macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Unduh Firefox <span>untuk Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Unduh untuk platform & bahasa lain
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Unduh dalam bahasa lain
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Unduhan Anda seharusnya sudah dimulai secara otomatis. Tidak bekerja? <a id="%(id)s" href="%(fallback_url)s">Coba unduh kembali</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Unduhan Anda seharusnya sudah dimulai secara otomatis. Jika tidak, <a id="%(id)s" href="%(fallback_url)s">klik di sini</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Pelajari bagaimana menjadikan Firefox lebih pintar, lebih cepat, dan lebih aman.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Dapatkan kiat, saran, dan pengumuman produk informatif yang disampaikan ke kotak masuk Anda.
-
-
-;Enter your email address
-Masukkan alamat surel Anda
-
-
-;How will Mozilla use my email?
-Bagaimana Mozilla akan menggunakan surel saya?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla tidak hanya menghargai privasi dan keamanan surel Anda – namun menjadi bagian dari <a href="%(manifesto)s">Manifesto</a> kami: “Keamanan dan privasi individu di Interne menjadi hal yang fundamental dan tidak boleh perlakukan sebagai sebuah opsi.” <a href="%(principles)s">Anda dapat pelajari tentang Prinsip Privasi Data kami di sini</a>.
-
-
-;What we want you to know:
-Apa yang kami ingin Anda ketahui:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Anda tidak perlu memberikan surel Anda kepada kami untuk mengunduh dan menggunakan Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Kami menanyakan surel Anda karena penelitian kami menunjukkan bahwa orang yang menerima pengalaman pengantar melakukan lebih banyak dan lebih baik dengan Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Anda dapat mengharapkan surel yang dirancang untuk membantu Anda mengoptimalkan Firefox agar bekerja prima untuk Anda, mengetahui lebih jau mengenai privasi dan keamanan dan mengetahui bagaimana menggunakan waktu sebaik-baiknya di web.
-
-
-;You can unsubscribe anytime, for any reason.
-Anda dapat berhenti berlangganan kapan pun, untuk alasan apa pun.
-
-
-;We will not share, sell or use your email for any other purposes.
-Kami tidak akan membagikan, menjual, atau menggunakan surel Anda untuk tujuan-tujuan lain.
-
-
-;Let’s do this!
-Mari lakukan!
-
-
-;Sync up with Firefox on mobile:
-Sinkronkan dengan Firefox di ponsel:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Peramban Web Gratis
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Unduh Mozilla Firefox, peramban Web gratis. Firefox dibuat oleh nirlaba global yang berdedikasi menempatkan individu dalam mengontrol daring. Dapatkan Firefox untuk Windows, macOS, Linux, Android, dan iOS sekarang juga!
-
-
-;Download the fastest Firefox ever
-Unduh Firefox tercepat yang pernah ada
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Memuat laman lebih cepat, menggunakan lebih sedikit memori, dan disertai dengan berbagai fitur. Ya, Firefox baru ada di sini.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Sangat pribadi
 
 ;Truly Private Browsing with Tracking Protection
 Penjelajahan Pribadi yang Sebenarnya dengan Perlindungan Pelacakan
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Selamat datang di Firefox
-
-
-;Take Firefox with You
-Bawa Firefox bersama Anda
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Dapatkan markah, riwayat, sandi, dan setelan lainnya di semua peranti Anda.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Sudah menggunakan Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Masuk ke akun Anda dan kami akan menyinkronkan markah, sandi, dan hal menakjubkan lainnya yang tersimpan di Firefox pada perangkat lainnya.
-
-
-;Learn more about Firefox Accounts
-Pelajari selengkapnya tentang Firefox Accounts
-
-
-;Skip this step
-Lewati langkah ini
-
-
-# Old firstrun page
-;Chart your own course
-Buat perjalanan Anda sendiri
 
 

--- a/id/firefox/campaign.lang
+++ b/id/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/is/firefox/campaign.lang
+++ b/is/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Til hamingju! Þú ert að nota nýjustu útgáfu af Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Uppfærðu</a> Firefox fyrir meiri afköst og öryggi.
-
-
-;You’re using a pre-release version of Firefox.
-Þú ert að nota forútgáfu af Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Uppfæra Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Fylgdu þessum <a href="%(url)s">leiðbeiningum</a> til að setja inn Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Hala niður Firefox <span>fyrir Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Hala niður Firefox <span>fyrir macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Hala niður Firefox <span>fyrir Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Download Firefox
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Halaðu niður Mozilla Firefox, sem er ókeypis vafri. Firefox er búið til af fyrirtæki sem er ekki rekin í hagnaðarskyni og setur í forgang að einstaklingar séu við stjórnvölin á netinu. Náðu í Firefox fyrir Windows, macOS, Linux, Android og iOS strax í dag!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/it/firefox/campaign.lang
+++ b/it/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Complimenti. Stai utilizzando l’ultima versione di Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Aggiorna Firefox</a> per la massima velocità e privacy disponibili.
-
-
-;You’re using a pre-release version of Firefox.
-Stai utilizzando una versione preliminare di Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Stai utilizzando un sistema operativo insicuro, obsoleto e <a href="%(url)s">non più supportato da Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Il nuovo <strong>Firefox</strong>
 
 ;Fast for good.
 Veloce per il bene comune.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Scopri Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nuovo. Veloce. Definitivo.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Scarica ora
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Ripristina Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Segui <a href="%(url)s">queste istruzioni</a> per installare Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Opzioni di installazione avanzate e altre piattaforme
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Opzioni di installazione avanzate e altre piattaforme
-
-
-;Keep up with<br> all things Firefox.
-Tieniti sempre al passo<br>con le innovazioni di Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Scarica Firefox <span>per Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Scarica Firefox <span>per macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Scarica Firefox <span>per Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Scarica versione per altre piattaforme e lingue
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Scarica in un’altra lingua
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Il download dovrebbe iniziare automaticamente. In caso contrario, <a id="%(id)s" href="%(fallback_url)s">fai clic qui</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Grazie per aver scelto Firefox. Il download dovrebbe iniziare automaticamente. In caso contrario, <a id="%(id)s" href="%(fallback_url)s">fare clic qui</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Scopri come rendere Firefox ancora più intelligente, veloce e sicuro.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Ricevi consigli utili, trucchi e annunci di nuovi prodotti direttamente nella tua casella di posta.
-
-
-;Enter your email address
-Inserisci il tuo indirizzo email
-
-
-;How will Mozilla use my email?
-In che modo Mozilla utilizza il mio indirizzo email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla ha a cuore la privacy e la sicurezza della tua email, come indicato nel nostro <a href="%(manifesto)s">Manifesto</a>: “La sicurezza e la privacy di ogni persona su Internet sono prerogative fondamentali e non devono essere considerate facoltative”. <a href="%(principles)s">Approfondisci i nostri principi sulla privacy dei dati in questa pagina</a>.
-
-
-;What we want you to know:
-Ecco che cosa devi sapere:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Non è obbligatorio fornire la tua email per scaricare o utilizzare Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Ti chiediamo l’email perché i nostri studi dimostrano che gli utenti riescono ad essere più produttivi con Firefox se ricevono suggerimenti su come iniziare.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Riceverai email pensate per aiutarti a personalizzare Firefox al meglio per le tue esigenze, comunicarti informazioni relative a privacy e sicurezza e suggerirti come sfruttare al massimo il tempo che trascorri online.
-
-
-;You can unsubscribe anytime, for any reason.
-Puoi annullare l’iscrizione in ogni momento, per qualsiasi ragione.
-
-
-;We will not share, sell or use your email for any other purposes.
-La tua email non verrà condivisa, venduta o utilizzata per altri scopi.
-
-
-;Let’s do this!
-Provalo subito.
-
-
-;Sync up with Firefox on mobile:
-Mantieni Firefox sincronizzato su tutti i tuoi dispositivi:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Il browser libero e gratuito
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Scarica Mozilla Firefox, il browser libero e gratuito. Realizzato da un’organizzazione non-profit diffusa in tutto il mondo che si impegna a garantire all’utente il pieno controllo online. Scarica Firefox per Windows, macOS, Linux, Android e iOS oggi stesso!
-
-
-;Download the fastest Firefox ever
-Scarica la versione di Firefox più veloce di sempre
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Caricamento pagine più veloce, consumo di memoria ridotto e tante nuove funzioni, il nuovo Firefox è qui.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Privacy all’ennesima potenza
 
 ;Truly Private Browsing with Tracking Protection
 Una navigazione davvero anonima con la protezione antitracciamento
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Benvenuto in Firefox
-
-
-;Take Firefox with You
-Porta Firefox con te
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Ritrova segnalibri, cronologia, password e altre impostazioni su tutti i tuoi dispositivi.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Sei già un utente Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Accedi al tuo account per sincronizzare segnalibri, password e altre preferenze che hai salvato su uno dei tuoi dispositivi con Firefox.
-
-
-;Learn more about Firefox Accounts
-Scopri di più sull’account Firefox
-
-
-;Skip this step
-Ignora questo passaggio
-
-
-# Old firstrun page
-;Chart your own course
-Decidi tu la rotta
 
 

--- a/it/firefox/campaign.lang
+++ b/it/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/ja/firefox/campaign.lang
+++ b/ja/firefox/campaign.lang
@@ -1,25 +1,4 @@
-## active ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-安心してください！ あなたは Firefox の最新版をお使いです。
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-高速化とプライバシー強化を実現した最新の Firefox へ <a href="%(url)s">今すぐ更新</a>。
-
-
-;You’re using a pre-release version of Firefox.
-あなたは Firefox のプレリリース版をお使いです。
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-安全でない古い OS をご利用です。<a href="%(url)s">Firefox はサポートされていません</a>。
 
 
 ;The new <strong>Firefox</strong>
@@ -28,133 +7,6 @@
 
 ;Fast for good.
 この速さ、どこまでも。
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Firefox Quantum、誕生
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-最新。高速。どこまでも。
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-今すぐダウンロード
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox をリフレッシュ
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Firefox をインストールするには <a href="%(url)s">こちらの手順</a> に従ってください。
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-高度なインストールオプションと他の OS 版
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-高度なインストールオプションと他の OS 版
-
-
-;Keep up with<br> all things Firefox.
-Firefox の最新情報をお手元に。
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-<span>Windows 版</span> Firefox をダウンロード
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-<span>macOS 版</span> Firefox をダウンロード
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-<span>Linux 版</span> Firefox をダウンロード
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-他のプラットフォームと言語向けのダウンロード
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-他の言語でダウンロード
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-ダウンロードは自動的に始まります。もし始まらない場合は <a id="%(id)s" href="%(fallback_url)s">再度ダウンロードしてみてください</a>。
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-ダウンロードは自動的に始まります。もし始まらない場合は <a id="%(id)s" href="%(fallback_url)s">こちらをクリックしてください</a>。
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Firefox をよりスマートに、より速く、より安全にする方法を学びましょう。
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-有益なヒント、活用法、製品のお知らせを受信トレイに届ける。
-
-
-;Enter your email address
-メールアドレスを入力してください
-
-
-;How will Mozilla use my email?
-Mozilla は私のメールをどのように扱いますか？
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-知っておいていただきたいこと:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Firefox をダウンロードして使用するのに、あなたのメールアドレスを私たちに知らせる必要はありません。
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-メールアドレスをお尋ねしているのは、私たちの調査により、初心者の経験を積んだ人は Firefox でさらに多くのことができるようになることが分かったからです。
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-これからお送りするメールは、あなたが Firefox を使いこなすのに役立つ情報やプライバシーとセキュリティについて学ぶための情報、ウェブ上での有効な時間の使い方を見つけるための情報を提供します。
-
-
-;You can unsubscribe anytime, for any reason.
-購読はいつでも、その理由に関わらず解除できます。
-
-
-;We will not share, sell or use your email for any other purposes.
-私たちはあなたのメールアドレスを共有したり売ったり、他のいかなる目的にも使用しません。
-
-
-;Let’s do this!
-ぜひ始めましょう！
-
-
-;Sync up with Firefox on mobile:
-モバイルの Firefox とも同期:
 
 
 # HTML page title prefix
@@ -170,14 +22,6 @@ Firefox をダウンロード
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 自由なウェブブラウザー Mozilla Firefox をダウンロード。Firefox は、個人の尊重にひたむきに活動するグローバルな非営利団体によって作られています。Windows、macOS、Linux、Android、iOS 版の Firefox を今すぐダウンロード！
-
-
-;Download the fastest Firefox ever
-史上最速の Firefox をダウンロード
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-ページ読み込みの高速化、メモリー使用量の削減、さらに豊富な機能を兼ね備えた、まったく新しい Firefox、誕生。
 
 
 ;2x Faster
@@ -202,41 +46,5 @@ Chrome よりも 30% 省メモリー
 
 ;Truly Private Browsing with Tracking Protection
 トラッキング防止機能で真のプライベートブラウジング
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Firefox へようこそ
-
-
-;Take Firefox with You
-Firefox を持ち歩こう
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-ブックマーク、履歴、パスワード、その他の設定を、お使いのすべての端末で共有しましょう。
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-既に Firefox をお使いですか？
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Firefox アカウントへログインすれば、他の端末上の Firefox で保存したブックマークやパスワードなどのデータを簡単に同期できます。
-
-
-;Learn more about Firefox Accounts
-Firefox アカウントの詳細はこちら
-
-
-;Skip this step
-この手順をスキップ
-
-
-# Old firstrun page
-;Chart your own course
-自分の未来図を描こう
 
 

--- a/ja/firefox/campaign.lang
+++ b/ja/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/ka/firefox/campaign.lang
+++ b/ka/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-გილოცავთ! თქვენ Firefox უახლესი ვერსიით სარგებლობთ.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">განაახლეთ</a> თქვენი Firefox უახლეს ვერსიამდე, გაუმჯობესებული სიჩქარისა და უსაფრთხოების მისაღებად.
-
-
-;You’re using a pre-release version of Firefox.
-თქვენ სარგებლობთ Firefox-ის წინასწარი გამოშვებით.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-თქვენ გიყენიათ დაუცველი, მოძველებული საოპერაციო სისტემა, რომელიც <a href="%(url)s">აღარაა მხარდაჭერილი Firefox-ის მიერ</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@
 
 ;Fast for good.
 სწრაფი და მეტად შედეგიანი.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-იხილეთ Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-ახალი. სწრაფი. შედეგიანი.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-ჩამოტვირთეთ ახლავე
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-გაასუფთავეთ Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-გთხოვთ, Firefox-ის დასაყენებლად მიჰყვეთ <a href="%(url)s">ამ მითითებებს</a>.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-სხვა ვერსიები და სისტემები
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-სხვა ვერსიები და სისტემები
-
-
-;Keep up with<br> all things Firefox.
-არ ჩამორჩეთ Firefox-სთან<br> დაკავშირებულ სიახლეებს.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-ჩამოტვირთეთ Firefox <span>Windows</span> სისტემისთვის
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-ჩამოტვირთეთ Firefox <span>macOS</span> სისტემისთვის
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-ჩამოტვირთეთ Firefox <span>Linux</span> სისტემისთვის
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-გადმოწერა სხვა სისტემებსა და ენებზე
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-ჩამოტვირთვები სხვა ენებზე
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-თქვენი ჩამოტვირთვა თავისით დაიწყება. არ იმუშავა? <a id="%(id)s" href="%(fallback_url)s">სცადეთ ჩამოტვირთვა ხელახლა</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-თქვენი ჩამოტვირთვა თავისით დაიწყება. თუ ასე არ მოხდა, <a id="%(id)s" href="%(fallback_url)s">დააწკაპეთ აქ</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-იხილეთ თუ როგორ უნდა გახადოთ Firefox კიდევ უფრო მოსახერხებელი, სწრაფი და მეტად დაცული.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-მიიღეთ გამოსადეგი რჩევები, ხრიკები და სიახლეების შესახებ ინფორმაცია, პირდაპირ თქვენს საფოსტო ყუთში.
-
-
-;Enter your email address
-მიუთითეთ თქვენი ელფოსტა
-
-
-;How will Mozilla use my email?
-როგორ გამოიყენებს Mozilla ჩემს ელფოსტას?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla არა მხოლოდ დიდ მნიშვნელობას ანიჭებს თქვენი ელფოსტის პირადულობასა და უსაფრთხოებას – არამედ მის ძირითად <a href="%(manifesto)s">დებულებებშიც</a> აქვს გაწერილი: „ინტერნეტში უსაფრთხოება და პირადი ინფორმაციის ხელშეუხებლობა წარმოადგენს ადამიანის ძირითად უფლებებს და ვერ ჩაითვლება მეორეხარისხოვნად“. <a href="%(principles)s">ვრცლად, პირადი მონაცემების დაცვის საფუძვლებს შეგიძლიათ გაეცნოთ აქ</a>.
-
-
-;What we want you to know:
-რა უნდა იცოდეთ:
-
-
-;You don’t need to give us your email to download and use Firefox.
-არაა საჭირო ელფოსტის მითითება, Firefox-ის ჩამოტვირთვის ან გამოყენებისთვის.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-ელფოსტის მითითებას ვითხოვთ იმიტომ, რომ ჩვენ მიერ ჩატარებული კვლევების მიხედვით, ხალხი რომელიც საწყის ინფორმაციას იღებს ჩვენგან, უფრო უკეთ და შედეგიანად იყენებს Firefox-ს.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-მიღებულ წერილებში იქნება გამოსადეგი ინფორმაცია, რომელიც დაგეხმარებათ Firefox-ის საკუთარ მოთხოვნილებებზე უკეთ მორგებაში, პირადულობისა და უსაფრთხოების დაცვასა და ინტერნეტის მეტად ნაყოფიერად გამოყენებაში.
-
-
-;You can unsubscribe anytime, for any reason.
-ნებისმიერ დროს შეგიძლიათ გამოწერის გაუქმება, ნებისმიერი მიზეზით.
-
-
-;We will not share, sell or use your email for any other purposes.
-ჩვენ არ გავაზიარებთ, არ გავყიდით და არ გამოვიყენებთ თქვენს ელფოსტას, რამე სხვა დანიშნულებით.
-
-
-;Let’s do this!
-დაიწყეთ!
-
-
-;Sync up with Firefox on mobile:
-Firefox დასინქრონება მობილურზე:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Firefox დასინქრონება მობილურზე:
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 ჩამოტვირთეთ Mozilla Firefox, უფასო ბრაუზერი. Firefox შექმნილია საერთაშორისო არამომგებიანი დაწესებულების მიერ, რომელსაც სურს ხალხს დაუბრუნოს, თავიანთი ინტერნეტცხოვრების სრულად განკარგვის უფლება. გადმოწერეთ Firefox Windows-ზე, macOS-ზე, Linux-ზე, Android-სა და iOS-ზე ახლავე!
-
-
-;Download the fastest Firefox ever
-ჩამოტვირთეთ უსწრაფესი Firefox
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-გვერდების მეტად სწრაფი გახსნა, მეხსიერების ნაკლები მოხმარება, უამრავ დამატებით შესაძლებლობებთან ერთად, ახალი Firefox გელოდებათ.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Firefox დასინქრონება მობილურზე:
 
 ;Truly Private Browsing with Tracking Protection
 სრულყოფილი დაცვა პირადი მონაცემების აღრიცხვისა და თვალთვალისგან
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-მოგესალმებათ Firefox
-
-
-;Take Firefox with You
-თან წაიყოლეთ Firefox
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-მიიღეთ წვდომა თქვენს სანიშნებთან, ისტორიასთან, პაროლებსა და სხვა პარამეტრებთან, ყველა თქვენს მოწყობილობაზე.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-აქამდეც გამოგიყენებიათ Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-შედით თქვენს ანგარიშზე, დანარჩენ მოწყობილობებზე არსებული სანიშნების, პაროლებისა და თქვენ მიერ შენახული სხვა საჭირო მონაცემების დასინქრონებისთვის.
-
-
-;Learn more about Firefox Accounts
-იხილეთ ვრცლად, Firefox-ის ანგარიშების შესახებ
-
-
-;Skip this step
-გამოტოვება
-
-
-# Old firstrun page
-;Chart your own course
-იყავით დამოუკიდებლები
 
 

--- a/ka/firefox/campaign.lang
+++ b/ka/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/kab/firefox/campaign.lang
+++ b/kab/firefox/campaign.lang
@@ -1,25 +1,4 @@
-## active ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Ayyuz, aqla-k tesseqdaceḍ lqem aneggaru n Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Leqqem</a> Firefox inek ɣer umaynut n urured akked tudert tabaḍnit.
-
-
-;You’re using a pre-release version of Firefox.
-Aqlak tesseqdaceḍ lqem uzwir n Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Tseqdaceḍ anagraw n wammud d araɣelsan u d aqbuṛ <a href="%(url)s">ur yettusefrak ara di Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -28,133 +7,6 @@ Firefox<strong>amaynut</strong>
 
 ;Fast for good.
 Arurad i lebda.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Wali Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Amaynut, arurad. I lebda.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Sider tura
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Seggem Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Ma ulac aɣilif ḍfeṛ <a href="%(url)s"> tinaḍin agi</a> akken ad tesbeddeḍ Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Iγewwaṛen n telqayt n usebded & inagrawen nniḍen
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Iγewwaṛen n telqayt n usebded & inagrawen nniḍen
-
-
-;Keep up with<br> all things Firefox.
-Qqin deg isallen<br>imaynuten n Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Sider Firefox <span>i Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Sider Firefox <span>i masOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Sider Firefox <span>i Linux </span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Sider i yinagrawen & tutlayin-nniḍen
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Sider s tutlayt-ik
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Asider-ik ad yekker s wudem awurman. Ur yeddi ara? <a id="%(id)s" href="%(fallback_url)s">Ɛreḍ asider tikkelt nniḍen</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Asider-ik ad yekker s wudem awurman. Ma ulac, <a id="%(id)s" href="%(fallback_url)s">Sit dagi</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Issin amek ara terreḍ Firefow d uḥric, d arurad u aɣelsan ugar.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Sekcem tansa-inek imayl
-
-
-;How will Mozilla use my email?
-Amek ara tseqdec Mozilla imayl-iw?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-Dacu nebɣa ad tisinem:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Ur tesriḍ ara ad aɣ-d-muddeḍ imayl-ik/im akken ad tsidreḍ u ad tesqedceḍ Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-Tzemreḍ ad tefɣeḍ seg ujerred melmi ik/im-yehwa, akken tebɣu tili sebba.
-
-
-;We will not share, sell or use your email for any other purposes.
-Ur nbeṭṭu ara, ur neznuzu ara u ur nseqdac ara imayl-ik/im i yeswi nniḍen.
-
-
-;Let’s do this!
-Aya ihi!
-
-
-;Sync up with Firefox on mobile:
-Mtawi d Firefox ɣef uziraz:
 
 
 # HTML page title prefix
@@ -170,14 +22,6 @@ Iminig web n baṭel
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Sider Mozilla Firefox, iminig Web ilellli. Firefox tesnulfat-id tmezdagnut tamadlant ur yettnadin ara idrimen, i yesseḥbibiren akken iseqdacen ad ẓren ayen iḍerrun s srid. Awi Firefox i windows, macOS, Linux, Android akked iOS seg ass-a!
-
-
-;Download the fastest Firefox ever
-Sider lqem arurad Firefox
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Asali n isebtar arurad ugar, asuder n tkatut yenɣes, d ddeqs n timahilin, Firefox amaynut yewweḍ-d.
 
 
 ;2x Faster
@@ -202,41 +46,5 @@ Tabaḍnit iǧehden
 
 ;Truly Private Browsing with Tracking Protection
 Tunigin tusligt s ummesten mgal asfuɣel
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Anṣuf ar Firefox
-
-
-;Take Firefox with You
-Awi Firefox yid-k
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Awi ticraḍ-ik n yisebtar, amazray-ik, awalen-ik uffiren d yiɣewwaṛen-nniḍen ɣef ibenkan-ik meṛṛa.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Tseqdaceḍ yakan Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Kcem ar umiḍan-ik sakin ad nemtawi akk ticraḍ-ik, awalen-ik uffiren akked ddeqs-nniḍen n tɣawsiwin i teskelseḍ di Firefox neɣ ibenkan-nniḍen.
-
-
-;Learn more about Firefox Accounts
-Issin ugar ɣef Firefox Accounts
-
-
-;Skip this step
-Zgel amecwaṛ-agi
-
-
-# Old firstrun page
-;Chart your own course
-Sunneɣ abrid-ik
 
 

--- a/kab/firefox/campaign.lang
+++ b/kab/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/kk/firefox/campaign.lang
+++ b/kk/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Алақай! Сіз Firefox соңғы нұсқасын қолданып отырсыз.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-Firefox қолданбасын жылдамдық пен жекелік жақсартуларын алу мақсатында <a href="%(url)s">жаңартыңыз</a>.
-
-
-;You’re using a pre-release version of Firefox.
-Сіз Firefox қолданбасының шығарылымға дейінгі нұсқасын қолданудасыз.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Қазір жүктеп алу
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox қолданбасын жаңғырту
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Firefox қолданбасын орнату үшін <a href="%(url)s">осы нұсқаманы</a> қолданыңыз.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Орнатудың қосымша мүмкіндіктері және басқа платформалар
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Орнатудың қосымша мүмкіндіктері және басқа платформалар
-
-
-;Keep up with<br> all things Firefox.
-Firefox туралы барлығын<br> біліп отырыңыз.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-<span>Windows үшін</span> Firefox қолданбасын жүктеп алу
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-<span>macOS үшін</span> Firefox қолданбасын жүктеп алу
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-<span>Linux үшін</span> Firefox қолданбасын жүктеп алу
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Басқа тілде жүктеп алу
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Firefox қолданбасын жүктеп алу
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Mozilla Firefox, еркін веб браузерін, жүктеп алыңыз. Firefox глобалды коммерциялық емес ұйымымен жасалған, әр адамның қолына интернетте басқаруды қайтару мақсатымен жасалған. Windows, macOS, Linux, Android және iOS үшін Firefox қолданбасын бүгін алыңыз!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Firefox қолданбасына қош келдіңіз
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Firefox қолданудасыз ба?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Тіркелгіге кіріңіз, басқа құрылғыларыңыздағы Firefox ішінде сақталған барлық бетбелгілер, парольдер және басқа да тамаша нәрселер синхрондалады.
-
-
-;Learn more about Firefox Accounts
-Firefox тіркелгісі туралы көбірек білу
-
-
-;Skip this step
-Бұл қадамды аттап кету
-
-
-# Old firstrun page
-;Chart your own course
-Өз жолыңызды өзіңіз таңдаңыз
 
 

--- a/km/firefox/campaign.lang
+++ b/km/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-អបអរសាទរ! អ្នក​កំពុង​ប្រើ Firefox កំណែ​ចុងក្រោយ​បំផុត។
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refresh Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Download Firefox
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/kn/firefox/campaign.lang
+++ b/kn/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-ಅಭಿನಂದನೆಗಳು! ನೀವು ಫೈರ್ಫಾಕ್ಸ್‌ನ ಹೊಚ್ಚಹೊಸ ಆವೃತ್ತಿಯನ್ನು ಬಳಸುತ್ತಿದ್ದೀರಿ.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-ನಿಮ್ಮ Firefox <a href="%(url)s">ಅಪ್ಡೇಟ್</a> ಮಾಡಿ ಇತ್ತೀಚಿನ ವೇಗ ಮತ್ತು ಗೌಪ್ಯತೆಗೆ.
-
-
-;You’re using a pre-release version of Firefox.
-ನೀವು ಬಿಡುಗಡೆ-ಮುನ್ನದ ಫೈರ್ಫಾಕ್ಸ್ ಆವೃತ್ತಿಯನ್ನು ಬಳಸುತ್ತಿದ್ದೀರಿ.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 ಹೊಚ್ಚ ಹೊಸ <strong>ಫೈರ್ಫಾಕ್ಸ್</strong>
 
 
 ;Fast for good.
 ಒಳ್ಳೆಯದಕ್ಕಾಗಿ ವೇಗವಾಗಿದೆ.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-ಫೈರ್ಫಾಕ್ಸ್ ಕ್ವಾಂಟಮ್ ನೋಡಿ
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-ಹೊಸತು. ವೇಗ. ಒಳ್ಳೆಯದಕ್ಕಾಗಿ.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-ಈಗ ಡೌನ್‌ಲೋಡ್ ಮಾಡಿ
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox ಪುನಶ್ಚೇತನಗೊಳಿಸಿ
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Firefox ಅನುಸ್ಥಾಪಿಸಲು ದಯವಿಟ್ಟು <a href="%(url)s">ಈ ಸೂಚನೆಗಳನ್ನು</a> ಅನುಸರಿಸಿ.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-ಸುಧಾರಿತ ಸ್ಥಾಪನೆ ಆಯ್ಕೆಗಳು ಮತ್ತು ಇತರೆ ವೇದಿಕೆಗಳು
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-ಸುಧಾರಿತ ಸ್ಥಾಪನೆ ಆಯ್ಕೆಗಳು ಮತ್ತು ಇತರೆ ವೇದಿಕೆಗಳು
-
-
-;Keep up with<br> all things Firefox.
-ಜೊತೆಜೊತೆಯಾಗಿ ನೆಡೆಯಿರಿ<br> ಎಲ್ಲಾ ಫೈರ್ಫಾಕ್ಸ್.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-<span>ವಿಂಡೋಸ್‍ಗಾಗಿ</span> ಫೈರ್ಫಾಕ್ಸ್ ಡೌನ್ಲೋಡ್ ಮಾಡಿ
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-<span>macOS ಗಾಗಿ</span> ಫೈರ್ಫಾಕ್ಸ್ ಡೌನ್ಲೋಡ್ ಮಾಡಿ
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-<span>ಲಿನಕ್ಸ್‌ಗಾಗಿ</span> ಫೈರ್ಫಾಕ್ಸ್ ಡೌನ್ಲೋಡ್ ಮಾಡಿ
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-ಬೇರೆ ಭಾಷೆಯಲ್ಲಿ ಡೌನ್‌ಲೋಡ್ ಮಾಡಿ
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-ನಿಮ್ಮ ಡೌನ್ಲೋಡ್ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಆರಂಭವಾಗಬೇಕು. ಇಲ್ಲವಾದಲ್ಲಿ, <a id="%(id)s" href="%(fallback_url)s">ಇಲ್ಲಿ ಕ್ಲಿಕ್ ಮಾಡಿ</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-ಇದನ್ನು ಶುರು ಮಾಡೋಣ!
-
-
-;Sync up with Firefox on mobile:
-ಮೋಬೈಲ್‍ನಲ್ಲಿ ಫೈರ್ಫಾಕ್ಸ್ ನೊಂದಿಗೆ ಸಿಂಕ್ ಮಾಡಿ:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ We will not share, sell or use your email for any other purposes.
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-ಅತ್ಯಂತ ವೇಗದ ಫೈರ್ಫಾಕ್ಸ್ ಅನ್ನು ಡೌನ್ಲೋಡ್ ಮಾಡಿ
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Faster page loading, less memory usage and packed with features, the new Firefox
 
 ;Truly Private Browsing with Tracking Protection
 ನಿಜವಾಗಿಯೂ ಖಾಸಗಿ ಜಾಲಾಟ ಜಾಡುಹಿಡಿಯುವಿಕೆ ಸುರಕ್ಷತೆಯೊಂದಿಗೆ
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-ಫೈರ್‌ಫಾಕ್ಸಿಗೆ ಸ್ವಾಗತ
-
-
-;Take Firefox with You
-ನಿಮ್ಮೊಂದಿಗೆ Firefox ಕರೆದೊಯ್ಯಿರಿ
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-ಈಗಾಗಲೇ ಫೈರ್ಫಾಕ್ಸ್ ಬಳಸುತ್ತಿದ್ಧೀರಾ?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-ಫೈರ್ಫಾಕ್ಸ್ ಖಾತೆಗಳ ಬಗ್ಗೆ ಹೆಚ್ಚು ತಿಳಿಯಿರಿ
-
-
-;Skip this step
-ಈ ಹಂತವನ್ನು ಹಾರಿಸಿ
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/ko/firefox/campaign.lang
+++ b/ko/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/ko/firefox/campaign.lang
+++ b/ko/firefox/campaign.lang
@@ -1,25 +1,4 @@
-## active ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-축하합니다! Firefox 최신 버전을 사용하고 있습니다.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">업데이트!</a> 현재 Firefox를 더 빠르고 안전한 최신 버전으로 업데이트 하세요.
-
-
-;You’re using a pre-release version of Firefox.
-Firefox 정식 출시 전 버전을 사용하고 있습니다.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-<a href="%(url)s">Firefox가 더이상 지원하지 않는</a> 불안전하고, 오래된 운영체제를 사용하고 있습니다.
 
 
 ;The new <strong>Firefox</strong>
@@ -28,133 +7,6 @@ Firefox 정식 출시 전 버전을 사용하고 있습니다.
 
 ;Fast for good.
 매우 빠릅니다.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Firefox Quantum 만나보기
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-새롭습니다. 빠릅니다. 좋습니다.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-다운로드
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox 재설정
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Firefox <a href="%(url)s">설치 가이드</a>를 참고하세요.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-고급 설치 방법 및 기타 플랫폼
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-고급 설치 방법 및 기타 플랫폼
-
-
-;Keep up with<br> all things Firefox.
-Firefox에 대한<br> 소식을 전해드립니다.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Firefox 다운로드  <span>Windows용</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Firefox 다운로드 <span>macOS용</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Firefox 다운로드  <span>Linux용</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-다른 플랫폼과 언어에 대한 다운로드
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-언어별 다운로드
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-자동으로 다운로드가 시작됩니다. 그렇지 않으면 <a id="%(id)s" href="%(fallback_url)s">다시 시도해 보세요</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-자동으로 다운로드가 시작됩니다. 그렇지 않으면, <a id="%(id)s" href="%(fallback_url)s">여기를</a> 클릭하세요.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Firefox를 더 똑똑하고, 빠르고, 안전하게 만드는 방법을 알아보세요.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-이메일 주소 입력
-
-
-;How will Mozilla use my email?
-Mozilla는 나의 이메일을 어떻게 이용하나요?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla는 단순히 여러분의 이메일 개인정보와 보안을 가치있게 여기는 것만이 아닙니다 – 이것은 우리의 <a href="%(manifesto)s">선언</a>의 일부입니다: “인터넷에서 개인들의 보안과 개인정보는 근본적인 것이며 부수적으로 취급되어서는 안된다.” <a href="%(principles)s">여기서 우리의 데이터 개인정보 원칙에 대해 더 알아볼 수 있습니다</a>.
-
-
-;What we want you to know:
-사용자가 알아야 할 사항:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Firefox를 다운로드하고 사용하기 위해 이메일을 제공할 필요가 없습니다.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-언제든지 어떤 이유로든지 구독을 해제할 수 있습니다.
-
-
-;We will not share, sell or use your email for any other purposes.
-사용자의 이메일을 다른 목적으로 공유하거나 판매, 사용하지 않습니다.
-
-
-;Let’s do this!
-시작해요!
-
-
-;Sync up with Firefox on mobile:
-모바일용 Firefox와 동기화:
 
 
 # HTML page title prefix
@@ -170,14 +22,6 @@ Firefox 다운로드
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 자유로운 웹 브라우저인 Mozilla Firefox를 다운로드하세요. Firefox는 글로벌 비영리 조직에서 개발 중이며, 온라인 정보 통제 및 제어로 부터 개인의 자유를 위해 노력합니다. 윈도, macOS, 리눅스 및 안드로이드, iOS 등 다양한 운영 체제를 지원합니다.
-
-
-;Download the fastest Firefox ever
-이제까지 가장 빠른 Firefox 다운로드
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-더 빠른 페이지 로딩, 더 적은 메모리 사용량, 다양한 기능 탑재, 새로운 Firefox가 있습니다.
 
 
 ;2x Faster
@@ -202,41 +46,5 @@ Chrome보다 30% 더 적은 메모리 사용
 
 ;Truly Private Browsing with Tracking Protection
 추척 방지된 진정한 개인정보 보호 브라우징
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Firefox를 선택해 주셔서 감사합니다
-
-
-;Take Firefox with You
-Firefox와 함께 하세요
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-즐겨찾기와 방문기록, 비밀번호, 다른 설정을 모든 기기에서 사용해 보세요.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Firefox를 사용하고 계신가요?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-계정에 로그인하셔서 북마크, 암호 및 다른 정보들을 Firefox가 설치된 모든 기기에서 동기화 하고,이를 손쉽게 활용 가능합니다.
-
-
-;Learn more about Firefox Accounts
-Firefox 계정 자세히 알아보기
-
-
-;Skip this step
-단계 건너뛰기
-
-
-# Old firstrun page
-;Chart your own course
-나만의 코스 만들기
 
 

--- a/lij/firefox/campaign.lang
+++ b/lij/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/lij/firefox/campaign.lang
+++ b/lij/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Se conplimentemmo! Ti gh'æ l'urtima verscion de Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Agiorna</a> o teu Firefox pe 'na mêgio velocitæ e privacy.
-
-
-;You’re using a pre-release version of Firefox.
-Ti gh'æ ina verscion sperimentale de Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Ti deuvi 'n scistema operativo ch'o no l'é seguo, i vegi scistemi operativi <a href="%(url)s">no saian ciù soportæ da Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ O neuvo <strong>Firefox</strong>
 
 ;Fast for good.
 Veloce pe-o ben de tutti.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Descòvri Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Neuvo. Veloce. Bravo.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Descarega oua
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Repiggia Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Pe piaxéi ségoi <a href="%(url)s">ste istruçioin</a> pe instalâ Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Inpostaçioin de instalaçion e atre piataforme
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Inpostaçioin de instalaçion e atre piataforme
-
-
-;Keep up with<br> all things Firefox.
-Stanni a-o passo<br>con e cöse de Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Descarega Firefox <span>pe Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Descarega Firefox <span>pe macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Descarega Firefox <span>pe Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Descarega pe atre Piataforme e lengoe
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Scarega inte 'n atra lengoa
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-O descaregamento o dovieiva comensâ in aotomatico. O no vâ? <a id="%(id)s" href="%(fallback_url)s">Preuva a sciacâ torna</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-O descaregamento o dovieiva comensâ in aotomatico. Se o no vâ <a id="%(id)s" href="%(fallback_url)s">sciacca chi</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Descòvri comme fâ deventâ ancon ciù furbo, veloce e seguo o Firefox.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Piggite di conseggi, mastrussi e notiçie in sci produti diretamente da-a teu cazella de pòsta.
-
-
-;Enter your email address
-Scrivi l'indirisso email
-
-
-;How will Mozilla use my email?
-Comme o deuvia Mozilla a mæ email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla no solo se piggia a cheu a privacy e-a seguessa da teu email - l'é parte do nòstro <a href="%(manifesto)s">Manifesto</a>: “A seguessa e privacy de personn-e in sce l'internet en fondamentali e no devan ese pigiæ comme opçionali.” <a href="%(principles)s">Ti peu leze chi in sci nòstri prinçippi da privacy diæti</a>.
-
-
-;What we want you to know:
-Cöse voemmo che ti ti saviesci:
-
-
-;You don’t need to give us your email to download and use Firefox.
-No serve che ti ne dæ a teu email pe scaregâ e deuviâ Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Niatri te domandemmo a teu email pe e nòstre riçerche ne dixan che chi o reçeive ina introduçion o travaggia megio e fâ de ciù con Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Ti peu aspetâ de-e email pensæ pe agiutate a otimizâ o Firefox pe travagiâ megio con ti, vanni a leze informaçioin in ciù in sciâ privacy e seguessa e acapisci comme spende o tempo inta ræ inte 'n megio mòddo.
-
-
-;You can unsubscribe anytime, for any reason.
-Ti peu scancelate quande t'eu, pe quæ se sæ raxon.
-
-
-;We will not share, sell or use your email for any other purposes.
-Niatri no condividemmo, vendemmo ò deuviemmo a teu email pe atri fin.
-
-
-;Let’s do this!
-Preuvilo oua!
-
-
-;Sync up with Firefox on mobile:
-Scincronizza Firefox inte tutti i teu dispoxitivi mòbili:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ O navegatô de badda
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Descarega Mozilla Firefox, o navegatô de badda. Firefox o l'é fæto da na societæ globale sensa fin de goâgno ch'a se dedica a garantî a-a gente o pin contròllo in linea . Piggite Firefox pe Windows, macOS, Linux, Android e iOS ancheu!
-
-
-;Download the fastest Firefox ever
-Descarega o Firefox ciù veloce mai visto
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Caregamento de pagine ciù veloci, meno memöia e neuve fonçioin, o neuvo Firefox o l'é chi.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Privou pe dindavei
 
 ;Truly Private Browsing with Tracking Protection
 Ina navegaçion privâ pe davei con proteçion anti-traciamento
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Benvegnuo inte Firefox
-
-
-;Take Firefox with You
-Pòrta Firefox con ti
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Repiggia i teu segnalibbri, stöia, poule segrete e atre inpostaçioin in sce tutti i teu dispoxitivi.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Ti deuvi za Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Intra into teu account e niatri te scincronizemmo i segnalibbri, poule segrete e atre belle cöse che t'æ sarvou in Firefox inti atri dispoxitivi.
-
-
-;Learn more about Firefox Accounts
-Saccine de ciù in sce l'account Firefox
-
-
-;Skip this step
-Sata sto passo
-
-
-# Old firstrun page
-;Chart your own course
-Fanni a teu rotta
 
 

--- a/lo/firefox/campaign.lang
+++ b/lo/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/lo/firefox/campaign.lang
+++ b/lo/firefox/campaign.lang
@@ -1,25 +1,4 @@
-## active ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-ຍິນດີນຳ! ທ່ານກຳລັງໃຊ້ Firefox ເວີຊັ່ນໃຫມ່ຫລ້າສຸດຢູ່.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">ອັບເດດ</a> Firefox ຂອງທ່ານໄປເປັນລຸ້ນຫລ້າສຸດເພື່ອເຮັດໃຫ້ມັນໄວ ແລະ ມີຄວາມເປັນສ່ວນຕົວຫລາຍຂື້ນ.
-
-
-;You’re using a pre-release version of Firefox.
-ທ່ານກຳລັງໃຊ້ Firefox ເວີຊັ່ນກ່ອນເປີດຕົວ.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-ທ່ານກໍາລັງໃຊ້ລະບົບປະຕິບັດການທີ່ບໍ່ປອດໄພ, ລະບົບປະຕິບັດການທີ່ໝົດອາຍຸ <a href="%(url)s"> ບໍ່ສະຫນັບສະຫນູນໂດຍ Firefox </a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -28,133 +7,6 @@
 
 ;Fast for good.
 ວ່ອງໄວທັນໃຈ.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-ພົບກັບ Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-ໃໝ່. ໄວ. ສຳລັບສິ່ງທີ່ດີ.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-ດາວໂຫລດດຽວນີ້
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-ລ້າງ Firefox ໃຫມ່
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-ກະລຸນາເຮັດຕາມ <a href="%(url)s">ຄຳແນະນຳນີ້</a>ເພື່ອຕິດຕັ້ງ Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-ຕົວເລືອກການຕິດຕັ້ງຂັ້ນສູງ ແລະ ແພັດຟອມອື່ນໆ
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-ຕົວເລືອກການຕິດຕັ້ງຂັ້ນສູງ ແລະ ແພັດຟອມອື່ນໆ
-
-
-;Keep up with<br> all things Firefox.
-ຕາມທັນ<br>ເລື່ອງລາວທຸກຢ່າງຂອງ Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-ດາວໂຫລດ Firefox <span>ສຳລັບ Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-ດາວໂຫລດ Firefox <span>ສຳລັບ macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-ດາວໂຫລດ Firefox <span>ສຳລັບ Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-ດາວໂຫລດສຳລັບແພັດຟອມ & ພາສາອື່ນໆ
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-ດາວໂຫຼດໃນພາສາອື່ນ
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-ການດາວໂຫຼດຂອງທ່ານຄວນເລີ່ມຢ່າງອັດຕະໂນມັດ. ການດາວໂຫລດບໍ່ເລີ່ມຕົ້ນຫຼືບໍ່? <a id="%(id)s" href="%(fallback_url)s">ລອງດາວໂຫລດໃຫມ່ອີກຄັ້ງ</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-ການດາວໂຫຼດຂອງທ່ານຄວນເລີ່ມຢ່າງອັດຕະໂນມັດ. ຖ້າບໍ່, <a id="%(id)s" href="%(fallback_url)s">ຄິກບ່ອນນີ້</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-ມາເຮັດອັນນີ້ກັນ!
-
-
-;Sync up with Firefox on mobile:
-ຊິງຂໍ້ມູນກັບ Firefox ເທິງມືຖື:
 
 
 # HTML page title prefix
@@ -170,14 +22,6 @@ We will not share, sell or use your email for any other purposes.
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 ດາວໂຫຼດ Mozilla Firefox, ເວັບບາວເຊີຟຣີ. Firefox ຖືກສ້າງຂຶ້ນໂດຍອົງກອນລະດັບໂລກທີ່ບໍ່ສະແຫວງຫາຜົນກຳໄລ ຊື່ງອຸທິດຕົນເພື່ອພັກດັນການຄວບຄຸມໃນໂລກອອນລາຍໃຫ້ແຕ່ລະຕຄົນ. ລົງ Firefox ສຳລັບ Windows, macOS, Linux, Android ແລະ iOS ໄດ້ແລ້ວມື້ນີ້!
-
-
-;Download the fastest Firefox ever
-ດາວໂຫຼດ Firefox ທີ່ໄວທີ່ສຸດເທົ່າທີ່ເຄີຍມີມາ
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-ການໂຫຼດຫນ້າເວັບທີ່ໄວ, ໃຊ້ຫນ່ວຍຄວາມຈໍາຫນ້ອຍ ແລະ ບັນຈຸຄຸນນະສົມບັດທີ່ຄັບແໜ້ນ, Firefox ໃຫມ່ແມ່ນຢູ່ທີ່ນີ້ແລ້ວ.
 
 
 ;2x Faster
@@ -202,41 +46,5 @@ Firefox ທີ່ດີທີ່ສຸດເທົ່າທີ່ເຄີຍມ
 
 ;Truly Private Browsing with Tracking Protection
 ການທ່ອງເວັບສ່ວນຕົວຢ່າງແທ້ຈິງດ້ວຍການປ້ອງກັນການຕິດຕາມ
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-ຍິນດີຕ້ອນຮັບສູ່ Firefox
-
-
-;Take Firefox with You
-ເອົາ Firefox ໄປກັບທ່ານ
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-ເອົາບັນທຶກ, ປະຫວັດ, ລະຫັດຜ່ານແລະການຕັ້ງຄ່າອື່ນໆຂອງທ່ານໃນອຸປະກອນຕ່າງໆຂອງທ່ານ.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-ໃຊ້ Firefox ຢູ່ແລ້ວບໍ່?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-ເຂົ້າສູ່ລະບົບເຂົ້າໃນບັນຊີຂອງທ່ານ ແລະ ພວກເຮົາຈະຊິງ ບຸກມາກ, ລະຫັດຜ່ານ ແລະ ສິ່ງທີ່ດີທີ່ທ່ານໄດ້ບັນທຶກໄວ້ໃນ Firefox ກັບອຸປະກອນອື່ນໆ.
-
-
-;Learn more about Firefox Accounts
-ຮຽນຮູ້ເພີ່ມເຕີມກ່ຽວກັບບັນຊີ Firefox
-
-
-;Skip this step
-ຂ້າມຂັ້ນຕອນນິ້
-
-
-# Old firstrun page
-;Chart your own course
-ຈັດເຮັດຫຼັກສູດຂອງທ່ານເອງ
 
 

--- a/lt/firefox/campaign.lang
+++ b/lt/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/lt/firefox/campaign.lang
+++ b/lt/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Sveikiname! Jūs naudojatės paskiausia „Firefox“ naršyklės laida.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Atnaujinkite</a> savo „Firefox“ naršyklę ir mėgaukitės paskiausiais spartos ir privatumo patobulinimais.
-
-
-;You’re using a pre-release version of Firefox.
-Jūs naudojatės tarpine „Firefox“ laida.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Jūs naudojatės nesaugia ir pasenusia operacine sistema, <a href="%(url)s">kurios „Firefox“ naršyklė nebepalaiko</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Naujoji <strong>Firefox</strong>
 
 ;Fast for good.
 Sparti ir tauri.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Susipažinkite – „Firefox Quantum“
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nauja. Sparti. Puiki.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Parsiųsti dabar
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Atšviežinti „Firefox“
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-„Firefox“ galite įdiegti, vadovaudamiesi <a href="%(url)s">šia instrukcija</a>.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Papildomos diegimo parinktys ir kitos platfomos
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Papildomos diegimo parinktys ir kitos platformos
-
-
-;Keep up with<br> all things Firefox.
-Neatsilikite nuo<br> „Firefox“ naujienų.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Parsisiųskite „Firefox“ <span>„Windows“ platformai</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Parsisiųskite „Firefox“ <span>„macOS“ platformai</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Parsisiųskite „Firefox“ <span>„Linux“ platformai</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Parsisiųsti kitoms platformoms ir kalboms
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Parsisiųsti kita kalba
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Jūsų parsisiuntimas netrukus turėtų prasidėti automatiškai. Nepavyko? <a id="%(id)s" href="%(fallback_url)s">Pabandykite parsisiųsti dar kartą</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Parsisiuntimas turėtų prasidėti savaime. Jei tai neįvyktų, <a id="%(id)s" href="%(fallback_url)s">spustelėkite čia</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Sužinokite, kaip „Firefox“ paversti dar išmanesne, spartesne ir saugesne.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Gaukite naudingus patarimus ir informaciją apie mūsų produktus į savo el. pašto dėžutę.
-
-
-;Enter your email address
-Įveskite savo el. pašto adresą
-
-
-;How will Mozilla use my email?
-Kaip „Mozilla“ naudos mano el. pašto adresą?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-„Mozilla“ ne tik vertina jūsų el. pašto privatumą ir saugumą – tai apibrėžta mūsų <a href="%(manifesto)s">Manifeste</a>: „Individualus saugumas ir privatumas internete yra būtini ir negali būti traktuojami kaip neprivalomi.“ <a href="%(principles)s">Susipažinti su mūsų Duomenų privatumo principais galite čia</a>.
-
-
-;What we want you to know:
-Norime, kad žinotumėte štai ką:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Jūs neprivalote mums pateikti savo el. pašto adreso, norėdami parsisiųsti „Firefox“ naršyklę ir ja naudotis.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Mes paprašėme jūsų el. pašto, nes mūsų tyrimai rodo, jog tiems, kam savo kuriamą naršyklę trumpai pristatome, geriau sekasi ja naudotis.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Galite tikėtis laiškų, skirtų padėti jums optimizuoti „Firefox“ savo darbui, sužinoti daugiau apie privatumą ir saugumą ir išmokti naudingiau ir smagiau naudotis saitynu.
-
-
-;You can unsubscribe anytime, for any reason.
-Atsisakyti prenumeratos galite bet kada, dėl bet kokių priežasčių.
-
-
-;We will not share, sell or use your email for any other purposes.
-Jūsų el. pašto adreso neperduosime ir neparduosime kitiems bei nenaudosime jokiais kitais tikslais.
-
-
-;Let’s do this!
-Pradėkime!
-
-
-;Sync up with Firefox on mobile:
-Sinchronizuokite duomenis su mobiliąja „Firefox“:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Nemokama saityno naršyklė
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 „Mozilla Firefox“ – tai laisvoji naršyklė, kurią kuria pasaulinė ne pelno organizacija, siekianti kiekvienam suteikti svertus internete. Parsisiųskite „Firefox“ į savo „Windows“, „macOS“, „Linux“, „Android“ ar „iOS“ įrenginį jau šiandien!
-
-
-;Download the fastest Firefox ever
-Parsisiųskite sparčiausią „Firefox“ laidą
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Spartesnis tinklalapių įkėlimas, mažesnis atminties vartojimas, daugybė kitų savybių. Naujoji „Firefox“ – jau čia!
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Privatesnė nei kitos
 
 ;Truly Private Browsing with Tracking Protection
 Išties privatus naršymas su apsauga nuo stebėjimo
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Sveiki! Tai „Firefox“
-
-
-;Take Firefox with You
-Pasiimkite „Firefox“ su savimi
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Turėkite savo adresyną, žurnalą, slaptažodžius ir kitas nuostatas visuose savo įrenginiuose.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Jau naršote su „Firefox“?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Prisijunkite prie savo paskyros, kad sinchronizuotume adresyną, slaptažodžius ir kitus naudingus dalykus tarp jūsų „Firefox“ naršyklės kopijų.
-
-
-;Learn more about Firefox Accounts
-Sužinokite daugiau apie „Firefox“ paskyras
-
-
-;Skip this step
-Praleisti šį žingsnį
-
-
-# Old firstrun page
-;Chart your own course
-Kurkite savo kelią
 
 

--- a/ltg/firefox/campaign.lang
+++ b/ltg/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Apsveicam! Tu lītoj Firefox jaunōkū laidīni.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Atteirēt Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Bezmoksas porlyuks
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/lv/firefox/campaign.lang
+++ b/lv/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Apsveicam! Jums ir jaunākā Firefox versija.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Atjauno Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Bezmaksas tīmekļa pārlūks
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/mai/firefox/campaign.lang
+++ b/mai/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Congrats! You’re using the latest version of Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox रिफ्रेश करू
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Download Firefox
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-फ़ायरफ़ॉक्स मे अहाँक स्वागत अछि
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/mk/firefox/campaign.lang
+++ b/mk/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Честитки! Ја користите најновата верзија на Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refresh Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Download Firefox
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/ml/firefox/campaign.lang
+++ b/ml/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/ml/firefox/campaign.lang
+++ b/ml/firefox/campaign.lang
@@ -1,22 +1,4 @@
-## active ##
-## firefox_quantum_new_headline ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-അഭിനന്ദനങ്ങള്‍! ഫയര്‍ഫോക്സിന്റെ ഏറ്റവും പുതിയ പതിപ്പാണ്‌ നിങ്ങള്‍ ഉപയോഗിക്കുന്നത്.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-കൂടുതല്‍ വേഗതയ്ക്കും സ്വകാര്യതയ്കും നിങ്ങളുടെ ഫയര്‍ഫോക്സ് <a href="%(url)s">പുതുക്കുക</a>.
-
-
-;You’re using a pre-release version of Firefox.
-നിങ്ങളുടെ ഇപ്പോള്‍ ഉപയോഗിയ്ക്കുന്നതു് ഫയര്‍ഫോക്സിന്റെ ഇറക്കാത്ത പതിപ്പാണു്.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -25,133 +7,6 @@ You’re using an insecure, outdated operating system <a href="%(url)s">no longe
 
 ;Fast for good.
 ഇനിയെന്നും വേഗതയോടെ.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-ഫയർഫോക്സ് ക്വാണ്ടം കാണുക
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-പുതിയത്. വേഗമേറിയത്. നല്ലതിന്.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-ഇപ്പോള്‍ ഡൗണ്‍ലോഡ് ചെയ്യുക
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-ഫയര്‍ഫോക്സ് പുതുക്കുക
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-ഫയര്‍ഫോക്സ് ഇന്‍സ്റ്റാള്‍ ചെയ്യുന്നതിന് ദയവായി <a href="%(url)s">ഈ നിര്‍ദ്ദേശങ്ങള്‍</a> പിന്‍തുടരുക.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-കൂടുതല്‍ ഇന്‍സ്റ്റാളേഷന്‍ രീതികളും മറ്റു പ്ലാറ്റ്ഫോമുകളും
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-കൂടുതല്‍ ഇന്‍സ്റ്റാളേഷന്‍ രീതികളും മറ്റു പ്ലാറ്റ്ഫോമുകളും
-
-
-;Keep up with<br> all things Firefox.
-തുടരുക <br> എല്ലാ കാര്യങ്ങളും ഫയർഫോക്സിലൂടെ.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-ഫയര്‍ഫോക്സ് <span>വിന്റോസിന്</span> ഡൌണ്‍ലോഡ് ചെയ്യു
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-<span>മാക്ക് ഒഎസിനായി</span> ഡൌണ്‍ലോഡ് ചെയ്യൂ
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-ഫയര്‍ഫോക്സ് <span>ലിനക്സിന്</span> ഡൌണ്‍ലോഡ് ചെയ്യു
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-മറ്റു ഭാഷകളിൽ ഡൗണ്‍ലോഡ് ചെയ്യുക
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-നിങ്ങളുടെ ഡൌണ്‍ലോഡ് തനിയെ തുടങ്ങണം. അല്ലെങ്കില്‍, <a id="%(id)s" href="%(fallback_url)s">ഇവിടെ ക്ലിക്ക് ചെയ്യു</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-ഇത് ചെയ്യൂ!
-
-
-;Sync up with Firefox on mobile:
-മൊബൈലുമായി ഫയര്‍ഫോക്സ് സമന്വയിപ്പിക്കുക:
 
 
 # HTML page title prefix
@@ -167,14 +22,6 @@ We will not share, sell or use your email for any other purposes.
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 സ്വതന്ത്ര വൈബ് ബ്രൌസറായ മോസില്ല ഫയര്‍ഫോക്സ് ഡൌണ്‍ലോഡ് ചെയ്യു. ഓണ്‍ലൈനിലെ നിയന്ത്രണം വ്യക്തികള്‍ക്ക് തിരിച്ച് നല്‍കുക എന്ന ഉദ്ദേശത്തോടെ പ്രവര്‍ത്തിക്കുന്ന ലാഭേച്ഛയില്ലാത്ത സംഘടന ഉണ്ടാക്കിയതാണ് ഫയര്‍ഫോക്സ്. വിന്റോസ്, മാക്ക്, ലിനക്സ്, ആന്‍ഡ്രോയിഡ്, ഐഒഎസ് തുടങ്ങിയവയ്ക്കുള്ള ഫയര്‍ഫോക്സ് ഇന്നു തന്നെ നേടു!
-
-
-;Download the fastest Firefox ever
-ഫയര്‍ഫോക്സിന്റെ ഏറ്റവും വേഗതയേറിയ പരിപ്പ് ഡൌണ്‍ലോഡ് ചെയ്യു
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-വേഗതയേറിയ പേജ് ലോഡിങ്ങ്, കുറഞ്ഞ മെമ്മറി ഉപയോഗം, കൂടുതല്‍ സവിശേഷതകളുമായ് പുതിയ ഫയര്‍ഫോക്സ് ഇതാ എത്തി.
 
 
 ;2x Faster
@@ -199,41 +46,5 @@ We will not share, sell or use your email for any other purposes.
 
 ;Truly Private Browsing with Tracking Protection
 ശരിക്കും സ്വകാര്യമായ ബ്രൌസിങ്ങ്, ട്രാക്കിങ്ങ് സംരക്ഷണത്തോടൊപ്പെം
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-ഫയർഫോക്സിലേയ്ക്ക് സ്വാഗതം
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-ഫയർഫോക്സ് ഉപയോഗിക്കുന്നുണ്ടോ?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-നിങ്ങള്‍ അക്കൌണ്ടിലേയ്ക്ക പ്രവേശിച്ചാല്‍ മറ്റുള്ള ഉപകരണങ്ങളില്‍ സൂക്ഷിച്ചിട്ടുള്ള അടയാളകുറിപ്പുകള്‍, രഹസ്യവാക്കുകള്‍ തുടങ്ങിയ കാര്യങ്ങള്‍ ഇതുമായി സമന്വയിപ്പിക്കാം.
-
-
-;Learn more about Firefox Accounts
-ഫയർഫോക്സ് അക്കൗണ്ടിനെ കുറിച്ച് കൂടൂതൽ അറിയുക
-
-
-;Skip this step
-ഈ ഘട്ടം ഒഴിവാക്കുക
-
-
-# Old firstrun page
-;Chart your own course
-നിങ്ങളുടെ സ്വന്തം ഗൈഡ് ചാർട്ട് ചെയ്യുക
 
 

--- a/mr/firefox/campaign.lang
+++ b/mr/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/mr/firefox/campaign.lang
+++ b/mr/firefox/campaign.lang
@@ -1,25 +1,4 @@
-## active ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-अभिनंदन ! आपण Firefox ची नवीनतम आवृत्ती वापरत आहात
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-अधिक वेग व गोपनीयते साठी आपला Firefox <a href="%(url)s">अद्ययावत</a> करा.
-
-
-;You’re using a pre-release version of Firefox.
-तुम्ही Firefox ची प्रकाशन पूर्व आवृत्ती वापरत आहात.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-आपण <a href="%(url)s">Firefox ने यापुढे आधार ना दिलेली</a> असुरक्षित आणि कालबाह्य ऑपरेटिंग प्रणाली वापरत आहात.
 
 
 ;The new <strong>Firefox</strong>
@@ -28,133 +7,6 @@
 
 ;Fast for good.
 उत्तमासाठी जलद.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-भेटा Firefox Quantum ला
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-नवीन. जलद. चांगल्यासाठी.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-आत्ताच डाउनलोड करा
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox रिफ्रेश करा
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-FIrefox प्रस्थापित करण्यासाठी <a href="%(url)s">या सूचना</a> अनुसरा.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-प्रगत प्रतिष्ठापन पर्याय आणि इतर प्लॅटफॉर्म
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-प्रगत प्रतिष्ठापन पर्याय आणि इतर प्लॅटफॉर्म
-
-
-;Keep up with<br> all things Firefox.
-Firefox च्या सर्व गोष्टींसोबत<br> जाणकार व्हा.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-<span>Windows</span> साठी Firefox डाउनलोड करा
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-<span>macOS साठी </span> Firefox डाउनलोड करा
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-<span>Linux साठी</span> Firefox डाउनलोड करा
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-इतर यंत्रणा आणि भाषांसाठी डाउनलोड करा
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-इतर भाषेत डाउनलोड करा
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-आपले डाउनलोड आपोआप सुरू होईल. तसे झाले नाही? तर <a id="%(id)s" href="%(fallback_url)s">पुन्हा प्रयत्न करा</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-आपले डाउनलोड आपोआप सुरू होईल. जर तसे झाले नाही, तर <a id="%(id)s" href="%(fallback_url)s">येथे क्लिक करा</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Firefox ला अधिक स्मार्ट, वेगवान आणि अधिक सुरक्षित कसे बनवावे ते शिका.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-आपल्या इनबॉक्समध्ये माहितीपूर्ण टीप, युक्त्या आणि उत्पादन घोषणा मिळवा.
-
-
-;Enter your email address
-आपला ईमेल पत्ता प्रविष्ट करा
-
-
-;How will Mozilla use my email?
-Mozilla माझा ईमेल कसा वापरेल?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-आम्हास इच्छित आहे की आपण हे जाणून घ्यावे:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Firefox डाउनलोड करून वापरण्यासाठी आम्हाला आपला ईमेल देण्याची आवश्यकता नाही.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-आम्ही आपल्या ईमेलबद्दल विचारले कारण आमचा शोध दर्शवितो की ज्या लोकांना प्रारंभिक अनुभव प्राप्त होतो ते Firefox सह अधिक कार्यक्षम होतात.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-आपण कोणत्याही कारणासाठी, केव्हाही सभासदत्व रद्द करू शकता.
-
-
-;We will not share, sell or use your email for any other purposes.
-आम्ही आपला ई-मेल पत्त्याला शेअर किंवा विक्री वा इतर कोणत्याही कारणासाठी वापरणार नाही.
-
-
-;Let’s do this!
-चला हे करून दाखवू!
-
-
-;Sync up with Firefox on mobile:
-मोबाईलवर Firefox सह ताळमेळ करा:
 
 
 # HTML page title prefix
@@ -170,14 +22,6 @@ Firefox डाउनलोड करा
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Mozilla Firefox एक मुक्त वेब ब्राउझर डाउनलोड करा. Firefox एका वैश्विक विना-नफा संघटनेने बनविला आहे जी व्यक्तींना ऑनलाईन नियंत्रण देण्यास समर्पित आहे. आजच Windows, macOS, Linux, Android आणि iOS साठी Firefox डाउनलोड करा!
-
-
-;Download the fastest Firefox ever
-आतापर्यंतचा सर्वात जलद Firefox डाउनलोड करा
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-नवीन Firefox जलद पृष्ठ लोड करणे, कमी मेमरी वापर आणि वैशिष्ट्यांसह युक्त असे आहे.
 
 
 ;2x Faster
@@ -202,41 +46,5 @@ Chrome पेक्षा 30% कमी मेमरी वापरतो
 
 ;Truly Private Browsing with Tracking Protection
 खरंखुरं ट्रॅकिंग संरक्षणा सहित खाजगी ब्राउझिंग
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Firefox मध्ये स्वागत आहे
-
-
-;Take Firefox with You
-Firefox आपल्यासोबत न्या
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-आपले बुकमार्क्स, इतिहास, पासवर्ड आणि इतर सेटिंग आपल्या सर्व उपकरणांवर मिळवा.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Firefox आधीपासूनच वापरता का?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-आपल्या खात्यात साइन करा आणि आम्ही आपल्या इतर उपकरणांवरच्या Firefox मध्ये जतन केलेल्या वाचनखुणा, पासवर्डस व बऱ्याच इतर गोष्टी आपल्याला आणून देऊ.
-
-
-;Learn more about Firefox Accounts
-Firefox खात्यांविषयी अधिक जाणून घ्या
-
-
-;Skip this step
-ही पायरी वगळा
-
-
-# Old firstrun page
-;Chart your own course
-स्वतःचा गतिमार्ग स्वतः आखा
 
 

--- a/ms/firefox/campaign.lang
+++ b/ms/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Tahniah! Anda menggunakan versi Firefox yang terbaru.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Kemaskini</a> Firefox anda yang terbaru dalam kepantasan dan privasi.
-
-
-;You’re using a pre-release version of Firefox.
-Anda menggunakan versi pra-keluaran Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Anda menggunakan sistem pengoperasian yang lapuk dan tidak selamat, <a href="%(url)s">tidak lagi disokong oleh Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Anda menggunakan sistem pengoperasian yang lapuk dan tidak selamat, <a href="%(u
 
 ;Fast for good.
 Pantas selamanya.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Kenali Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Baru. Pantas. Selamanya.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Muat turun Sekarang
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Muat semula Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Sila izinkan <a href="%(url)s">arahan ini</a> untuk memasang Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Pilihan Pemasangan Lanjutan & Platform Lain
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Pilihan pemasangan lanjutan & platform lain
-
-
-;Keep up with<br> all things Firefox.
-Kekalkan hubungan dengan semua perkara <br> Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Muat turun Firefox <span>untuk Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Muat turun Firefox <span>untuk macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Muat turun Firefox <span>untuk Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Muat turun untuk platform & bahasa lain
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Muat turun dalam bahasa lain
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Muat turun sepatutnya dimulakan secara automatik. Tidak dimulakan? <a id="%(id)s" href="%(fallback_url)s">Cuba lagi</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Muat turun akan dimulakan secara automatik. Jika tidak, <a id="%(id)s" href="%(fallback_url)s"> klik di sini</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Ketahui selanjutnya cara membuatkan Firefox lebih pintar, lebih pantas dan lebih selamat.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Dapatkan paduan, helah dan pengumuman produk yang dihantar ke peti masuk anda.
-
-
-;Enter your email address
-Masukkan alamat e-mel anda
-
-
-;How will Mozilla use my email?
-Bagaimana Mozilla menggunakan e-mel saya?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla bukan sahaja menghargai privasi dan keselamatan e-mel anda – ini menjadi sebahagian <a href="%(manifesto)s">Manifesto</a>kami: keselamatan dan privasi “Individu’ dalam internet adalah asas dan tidak dianggap sebagai pilihan.” <a href="%(principles)s">Anda boleh baca perihal Prinsip Privasi Data di sini</a>.
-
-
-;What we want you to know:
-Apa yang kami mahu anda tahu:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Anda tidak perlu memberikan e-mel kepada kami untuk muat turun dan menggunakan Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Kami minta e-mel anda kerana kajian kami menunjukkan bahawa pengguna yang menerima pengenalan akan jadi pengguna Firefox yang lebih baik dan bijak.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Anda boleh jangkakan e-mel yang direka untuk membantu mengoptimumkan Firefox supaya menjadi yang terbaik untuk anda, ketahui perihal privasi & keselamatan dan cara terbaik untuk anda meluangkan masa dalam web.
-
-
-;You can unsubscribe anytime, for any reason.
-Anda boleh batalkan langganan pada bila-bila masa.
-
-
-;We will not share, sell or use your email for any other purposes.
-Kami tidak akan kongsi, jual atau guna e-mel anda untuk tujuan lain.
-
-
-;Let’s do this!
-Mari lakukannya!
-
-
-;Sync up with Firefox on mobile:
-Sync dengan Firefox dalam telefon bimbit:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Pelayar Web Percuma
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Muat turun Mozilla Firefox, pelayar Web percuma. Firefox dicipta oleh penyedia global bukan untung khusus untuk menjadikan setiap individu mempunyai kawalan dalam talian. Dapatkan Firefox untuk Windows, macOS, Linux, Android dan iOS sekarang!
-
-
-;Download the fastest Firefox ever
-Muat turun Firefox yang terpantas setakat ini
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Firefox yang baru ini memuatkan halaman dengan lebih pantas, kurang menggunakan memori dan dilengkapi dengan banyak ciri.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Lebih peribadi
 
 ;Truly Private Browsing with Tracking Protection
 Pelayaran Peribadi Sebenar dengan Perlindungan Penjejakan
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Selamat datang ke Firefox
-
-
-;Take Firefox with You
-Bawa Firefox bersama Anda
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Dapatkan tandabuku, sejarah, kata laluan dan tetapan lain dalam semua peranti anda.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Sudah menggunakan Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Daftar masuk ke akaun anda dan kami akan sync tandabuku, kata laluan dan perkara lain yang anda simpan dalam Firefox di peranti lain.
-
-
-;Learn more about Firefox Accounts
-Ketahui selanjutnya perihal Akaun Firefox
-
-
-;Skip this step
-Langkau langkah ini
-
-
-# Old firstrun page
-;Chart your own course
-Hala tuju anda sendiri
 
 

--- a/ms/firefox/campaign.lang
+++ b/ms/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/my/firefox/campaign.lang
+++ b/my/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-ဂုဏ်ယူပါတယ်! သင်ဟာ မီးမြေခွေး နောက်ဆုံးထွက် ကိုအသုံးပြုနေပြီး ဖြစ်ပါတယ်
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-လျင်မြန်စွာအသုံးပြုရန်နှင့် ပိုမိုကောင်းမွန်သော ကိုယ်ရေးအချက်အလက်ကာကွယ်မှု ရရှိရန် သင့်မီးမြေခွေးကို <a href="%(url)s">အဆင့်မြှင့်ပါ</a>။
-
-
-;You’re using a pre-release version of Firefox.
-သင်သည် Firefox တင်ကြိုဖြန့်ဖြူးမှု ဗားရှင်းကို အသုံးပြုနေသည်။
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-မီးမြေခွေးကို အသစ်ဖြစ်နေစေပါ
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-မီးမြေခွေးကို ထည့်သွင်းအသုံးပြုရန် ကျေးဇူးပြု၍ <a href="%(url)s">ဒီ လုပ်ဆောင်ချက်များ</a>အတိုင်း လိုက်နာဆောင်ရွက်ပါ။
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-<span>Windows အတွက်</span>Firefox ကို ဆွဲယူပါ
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-<span>macOS အတွက်</span>Firefox ကို ဆွဲယူပါ
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-<span>Linux အတွက်</span>Firefox ကို ဆွဲယူပါ
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-ဆောင်ရွက်ကြပါစို့။
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Firefox ကို ရယူပါ
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 လွတ်လပ်ပွင့်လင်းသော ဝဘ်ဘရောင်ဇာတစ်ခုဖြစ်သည့် Mozilla Firefox ကို ဆွဲယူအသုံးပြုပါ။ Firefox ကို ကမ္ဘာလုံးဆိုင်ရာ အကျိုးအမြတ်အတွက် မဟုတ်သော၊ အွန်လိုင်းအသုံးပြုမှုကို တစ်ဦးချင်းစီတွင် မိမိလိုအပ်သလို ထိန်းချုပ်မှု ရှိနေစေရန် တွန်းအားပေးနေသည့် အဖွဲ့အစည်းမှ ဖန်တီးပါသည်။ Windows, macOS, Linux, Android နှင့် iOS တို့အတွက် Firefox ကို ယနေ့ပင် ရယူအသုံးပြုပါ။
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/nb-NO/firefox/campaign.lang
+++ b/nb-NO/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/nb-NO/firefox/campaign.lang
+++ b/nb-NO/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Gratulerer! Du bruker den nyeste versjonen av Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Oppdater</a> Firefox og få det siste innenfor hastighet og personvern.
-
-
-;You’re using a pre-release version of Firefox.
-Du bruker en forhåndsutgivelse av Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Du bruker et usikkert, foreldet operativsystem, <a href="%(url)s">som ikke lenger støttes av Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Den nye <strong>Firefox</strong>
 
 ;Fast for good.
 Raskest til nå.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Møt Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Ny. Rask. For alltid.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Last ned nå
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Nullstill Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Følg <a href="%(url)s">denne veiledningen</a> for å installere Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Avanserte installasjonsalternativer og andre plattformer
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Avanserte installasjonsalternativer og andre plattformer
-
-
-;Keep up with<br> all things Firefox.
-Få nyheter<br> om Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Last ned Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Last ned Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Last ned Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Last ned for andre plattformer og språk
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Last ned på et annet språk
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Nedlastingen din bør starte automatisk. Fungerte det ikke? <a id="%(id)s" href="%(fallback_url)s">Prøv å laste ned på nytt</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Nedlastingen din skal starte automatisk. Hvis den ikke gjør det, <a id="%(id)s" href="%(fallback_url)s">klikk her</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Lær deg hvordan du gjør Firefox enda smartere, raskere og sikrere.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Få informative tips og triks samt produktnyheter levert til innboksen din.
-
-
-;Enter your email address
-Skriv inn e-postadressen din
-
-
-;How will Mozilla use my email?
-Hvordan vil Mozilla bruke e-postadressen min?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla verdsetter ikke bare personvern og sikkerhet for din e-postadresse - det er en del av vår <a href="%(manifesto)s">manifest</a>: «Sikkerhet og personvern for individet på nettet er fundamentalt, og må på ingen måte sees på som valgfritt.» <a href="%(principles)s">Du kan lese mer om våre prinsipper om datapersonvern her</a>.
-
-
-;What we want you to know:
-Hva vi vil at du skal vite:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Du trenger ikke å gi oss din e-postadressen for å laste ned Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Vi bad om e-postadressen din fordi forskningen vår viser at personer som får en introduksjon arbeider mer og bedre med Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Du kan forvente å motta e-post, som skal gjøre deg bedre til å få Firefox til å fungere best mulig for deg. Vi lærer deg også å beskytte ditt personvern bedre, om sikkerhet, og hvordan du får den beste opplevelse på nettet.
-
-
-;You can unsubscribe anytime, for any reason.
-Du kan alltid velge ikke å motta flere e-poster.
-
-
-;We will not share, sell or use your email for any other purposes.
-Vi vil ikke dele, selge eller bruke e-postadressen din for noe annet formål.
-
-
-;Let’s do this!
-La oss gjøre det!
-
-
-;Sync up with Firefox on mobile:
-Synkronisér med Firefox på mobilen:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Gratis nettleser
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Last ned Mozilla Firefox, en gratis nettleser. Firefox er laget av en global, ideell organisasjon, som har som mål at individet skal ta kontroll over egne aktiviteter på nettet. Last ned Firefox for Windows, macOS, Linux, Android og iOS i dag!
-
-
-;Download the fastest Firefox ever
-Last ned den raskeste Firefox-nettleseren noen gang
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Raskere sidelasting, mindre minnebruk og fullastet av nye funksjoner, den nye Firefox er her.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Tar vare å personvernet ditt
 
 ;Truly Private Browsing with Tracking Protection
 Ekte privat nettlesing med sporingsbeskyttelse
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Velkommen til Firefox
-
-
-;Take Firefox with You
-Ta med deg Firefox
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Få dine bokmerker, historikk, passord, og andre innstillinger på alle enhetene dine.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Bruker du allerede Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Logg deg på kontoen din, og vi synkroniserer bokmerkene, passordene og andre flotte ting du har lagret i Firefox på andre enheter.
-
-
-;Learn more about Firefox Accounts
-Les mer om Firefox-konto
-
-
-;Skip this step
-Hopp over dette trinnet
-
-
-# Old firstrun page
-;Chart your own course
-Gå din egen vei
 
 

--- a/ne-NP/firefox/campaign.lang
+++ b/ne-NP/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-बधाई छ! तपाईँ Firefox को नयाँ संस्करण चलाउँदै हुनुहुन्छ।
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-नविनतम गति र गोपनियताका लागि अाफ्नो Firefox <a href="%(url)s">अद्यावधिक गर्नुहोस्</a>।
-
-
-;You’re using a pre-release version of Firefox.
-तपाईं Firefox को प्रि-रिलीज संस्करण प्रयोग गर्दै हुनुहुन्छ।
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox लाई ताजा पार्नुहोस्
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-कृपया Firefox स्थापना गर्न <a href="%(url)s">यी निर्देशनहरू</a> पालना गर्नुहोस्।
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox. {ok}
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Download Firefox
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/nl/firefox/campaign.lang
+++ b/nl/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/nl/firefox/campaign.lang
+++ b/nl/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Gefeliciteerd! U gebruikt de nieuwste versie van Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Werk uw Firefox bij</a> voor het nieuwste in snelheid en privacy.
-
-
-;You’re using a pre-release version of Firefox.
-U gebruikt een pre-releaseversie van Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-U gebruikt een onveilig, verouderd besturingssysteem dat <a href="%(url)s">niet meer door Firefox wordt ondersteund</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ De nieuwe <strong>Firefox</strong>
 
 ;Fast for good.
 Snel voor het goede.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Maak kennis met Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nieuw. Snel. Voor het goede.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Nu downloaden
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox opfrissen
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Volg <a href="%(url)s">deze instructies</a> om Firefox te installeren.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Geavanceerde installatieopties & andere platformen
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Geavanceerde installatieopties & andere platformen
-
-
-;Keep up with<br> all things Firefox.
-Blijf op de hoogte<br> van alles in Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>voor Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>voor macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>voor Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Downloaden voor andere platformen & talen
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Downloaden in een andere taal
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Uw download begint automatisch. Werkt het niet? <a id="%(id)s" href="%(fallback_url)s">Probeer nogmaals te downloaden</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Uw download begint automatisch. <a id="%(id)s" href="%(fallback_url)s">Klik hier</a> als dat niet zo is.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Lees hoe u Firefox nog slimmer, sneller en veiliger kunt maken.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Ontvang informatieve tips, trucs en productaankondigingen in uw mailbox.
-
-
-;Enter your email address
-Voer uw e-mailadres in
-
-
-;How will Mozilla use my email?
-Hoe gebruikt Mozilla mijn e-mailadres?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla waardeert niet alleen de privacy en beveiliging van uw e-mailadres – het is onderdeel van ons <a href="%(manifesto)s">Manifest</a>: “De veiligheid en privacy van personen op het internet zijn fundamenteel en moeten niet als optioneel worden beschouwd.” <a href="%(principles)s">Hier kunt u meer over onze Principes over gegevensprivacy lezen</a>.
-
-
-;What we want you to know:
-Wat we willen dat u weet:
-
-
-;You don’t need to give us your email to download and use Firefox.
-U hoeft ons niet uw e-mailadres te geven om Firefox te downloaden en te gebruiken.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We hebben om uw e-mailadres gevraagd omdat ons onderzoek aantoont dat mensen die een inleidende ervaring krijgen, meer en betere dingen doen met Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-U kunt e-mails verwachten die zijn opgesteld om u te helpen Firefox zo goed mogelijk te optimaliseren, meer over privacy en beveiliging te lezen, en te ontdekken hoe u het beste uit het web kunt halen.
-
-
-;You can unsubscribe anytime, for any reason.
-U kunt zich altijd uitschrijven, om welke reden dan ook.
-
-
-;We will not share, sell or use your email for any other purposes.
-We zullen uw e-mailadres niet voor andere doeleinden delen, verkopen of gebruiken.
-
-
-;Let’s do this!
-Daar gaan we!
-
-
-;Sync up with Firefox on mobile:
-Synchroniseer met Firefox op mobiel:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Gratis webbrowser
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, een gratis webbrowser. Firefox wordt gemaakt door een wereldwijde non-profitorganisatie die zich inzet om gebruikers online de controle te laten houden. Download Firefox nu voor Windows, macOS, Linux, Android en iOS!
-
-
-;Download the fastest Firefox ever
-Download de snelste Firefox ooit
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Sneller pagina’s laden, minder geheugengebruik en boordevol functies: de nieuwe Firefox is er.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Krachtig privé
 
 ;Truly Private Browsing with Tracking Protection
 Echt privé surfen met bescherming tegen volgen
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welkom bij Firefox
-
-
-;Take Firefox with You
-Neem Firefox met u mee
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Zet uw bladwijzers, geschiedenis, wachtwoorden en andere instellingen op al uw apparaten.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Gebruikt u al Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Meld u aan bij uw account en we synchroniseren de bladwijzers, wachtwoorden en andere leuke dingen die u in Firefox op andere apparaten hebt opgeslagen.
-
-
-;Learn more about Firefox Accounts
-Meer info over Firefox Accounts
-
-
-;Skip this step
-Deze stap overslaan
-
-
-# Old firstrun page
-;Chart your own course
-Bepaal uw eigen koers
 
 

--- a/nn-NO/firefox/campaign.lang
+++ b/nn-NO/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/nn-NO/firefox/campaign.lang
+++ b/nn-NO/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Gratulerer! Du brukar den siste versjonen av Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Oppdater</a> Firefox og få det siste innan fart og peronvern.
-
-
-;You’re using a pre-release version of Firefox.
-Du brukar ein «pre-release» versjon av Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Du brukar eit utrygt, utdatert operativsystem <a href="%(url)s">som ikkje lenger er støtta av Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Nye <strong>Firefox</strong>
 
 ;Fast for good.
 Raskast til no.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Møt Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Ny. Rask. For alltid.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Last ned no
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Frisk opp Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Følg <a href="%(url)s">denne rettleiinga</a> for å installera Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Avanserte installasjonsalternativ og andre plattformer
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Avanserte installasjonsalternativ og andre plattformer
-
-
-;Keep up with<br> all things Firefox.
-Hald deg oppdatert med<br> siste nytt om Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Last ned Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Last ned Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Last ned Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Last ned for andre plattformar og språk
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Last ned på eit anna språk
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Nedlastinga di bør starte automatisk. Fungerte det ikkje? <a id="%(id)s" href="%(fallback_url)s">Prøv å laste ned på nytt</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Nedlastinga di skal starte automatisk. Om ho ikkje gjer det, <a id="%(id)s" href="%(fallback_url)s">klikk her</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Lær deg korleis du gjer Firefox endå smartare, raskare og sikrare.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Få informative tips og triks samt produktnyheiter levert til innboksen din.
-
-
-;Enter your email address
-Skriv inn e-postadressa di
-
-
-;How will Mozilla use my email?
-Korleis vil Mozilla bruke e-posten min?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla verdset ikkje berre personvern og sikkerheit for e-postadressa di - det er ein del av <a href="%(manifesto)s">manifestet</a> vårt: «Sikkerheit og personvern for individet på nettet er fundamentalt, og må på ingen måte sjåast på som valfritt.» <a href="%(principles)s">Du kan lese meir om prinsippa våre om datapersonvern her</a>.
-
-
-;What we want you to know:
-Kva vi vil at du skal vite:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Du treng ikkje å gje oss e-postadressa di for å laste ned Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Vi bad om e-postadressa di fordi forskinga vår viser at personar som får ein introduksjon arbeider meir og betre med Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Du kan forvente å motta e-post, som skal gjere deg betre til å få Firefox til å fungere best mogleg for deg. Vi lærer deg også å beskytte personvernet ditt betre, om sikkerheit, og korleis du får den beste opplevinga på nettet.
-
-
-;You can unsubscribe anytime, for any reason.
-Du kan avbryte abonnentet når som helst.
-
-
-;We will not share, sell or use your email for any other purposes.
-Vi vil ikkje dele, selje eller bruke e-postadressa di for noko anna føremål.
-
-
-;Let’s do this!
-La oss gjere det!
-
-
-;Sync up with Firefox on mobile:
-Synkronisér med Firefox på mobilen:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Gratis nettlesar
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Last ned Mozilla Firefox, ein gratis nettlesar. Firefox er laga av ein global, ideell organisasjon som vil gje deg som individ brukarkontroll på nettet. Last ned Firefox for Windows, macOS, Linux, Android og iOS i dag!
-
-
-;Download the fastest Firefox ever
-Last ned den raskaste Firefox-nettlesaren nokon gong
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Raskare sidelasting, mindre minnebruk og full av nye funksjonar, nye Firefox er her.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Tek vare å personvernet ditt
 
 ;Truly Private Browsing with Tracking Protection
 Ekte privat nettlesing med sporningsvern
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Velkomen til Firefox
-
-
-;Take Firefox with You
-Ta med deg Firefox
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Få bokmerke, historikk, passord, og andre innstillingar på alle einingane dine.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Brukar du allereie Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Logg inn på kontoen din, og vi vil synkroniserere bokmerka, passorda og andre flotte ting du har lagra i Firefox på andre einingar.
-
-
-;Learn more about Firefox Accounts
-Les meir om Firefox-kontoen
-
-
-;Skip this step
-Hopp over dette steget
-
-
-# Old firstrun page
-;Chart your own course
-Gå din eigen veg
 
 

--- a/nv/firefox/campaign.lang
+++ b/nv/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Congrats! You’re using the latest version of Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refresh Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Free Web Browser
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Yá’át’ééh Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/oc/firefox/campaign.lang
+++ b/oc/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Felicitacions&nbsp;! Utilizatz la version la mai recenta de Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Reparar Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Navigador web gratuit
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/or/firefox/campaign.lang
+++ b/or/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Congrats! You’re using the latest version of Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refresh Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Free Web Browser
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Firefox ରେ ଆପଣଙ୍କୁ ସ୍ୱାଗତ କରୁଅଛୁ
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/pa-IN/firefox/campaign.lang
+++ b/pa-IN/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/pa-IN/firefox/campaign.lang
+++ b/pa-IN/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-ਵਧਾਈਆਂ ਜੀ! ਤੁਸੀਂ ਫਾਇਰਫਾਕਸ ਦਾ ਬਿਲਕੁਲ ਨਵਾਂ ਵਰਜ਼ਨ ਵਰਤ ਰਹੇ ਹੋ।
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-ਤੇਜ਼ੀ ਅਤੇ ਪਰਦੇਦਾਰੀ ਲਈ ਨਵੇਂ ਵਾਸਤੇ ਆਪਣੇ ਫਾਇਰਫਾਕਸ ਨੂੰ <a href="%(url)s">ਅੱਪਡੇਟ ਕਰੋ</a>।
-
-
-;You’re using a pre-release version of Firefox.
-ਤੁਸੀਂ ਫਾਇਰਫਾਕਸ ਦਾ ਪਹਿਲਾਂ-ਰੀਲਿਜ਼ ਕੀਤਾ ਵਰਜ਼ਨ ਵਰਤ ਰਹੇ ਹੋ।
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-ਤੁਸੀਂ ਇੱਕ ਅਸੁਰੱਖਿਅਤ, ਪੁਰਾਣਾ ਓਪਰੇਟਿੰਗ ਸਿਸਟਮ ਵਰਤ ਰਹੇ ਹੋ <a href="%(url)s"> ਹੁਣ ਫਾਇਰਫਾਕਸ </a> ਦੁਆਰਾ ਸਮਰਥਿਤ ਨਹੀਂ ਹੈ।
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@
 
 ;Fast for good.
 ਚੰਗੇ ਲਈ ਤੇਜ਼ ਹੈ।
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-ਫਾਇਰਫਾਕ ਕੁਆਂਟਮ ਨੂੰ ਮਿਲੋ
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-ਨਵਾਂ। ਤੇਜ਼। ਭਲੇ ਲਈ।
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-ਹੁਣੇ ਡਾਊਨਲੋਡ ਕਰੋ
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox ਤਾਜ਼ਾ ਕਰੋ
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-ਫਾਇਰਫਾਕਸ ਨੂੰ ਇੰਸਟਾਲ ਕਰਨ ਲਈ <a href="%(url)s">ਇਹਨਾਂ ਸੇਧਾਂ</a> ਦੀ ਪਾਲਣਾ ਕਰੋ।
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-ਤਕਨੀਕੀ ਇੰਸਟਾਲ ਕਰਨ ਦੀਆਂ ਚੋਣਾਂ ਤੇ ਹੋਰ ਮੰਚ
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-ਤਕਨੀਕੀ ਇੰਸਟਾਲ ਕਰਨ ਦੀਆਂ ਚੋਣਾਂ ਅਤੇ ਹੋਰ ਮੰਚ
-
-
-;Keep up with<br> all things Firefox.
-ਫਾਇਰਫਾਕਸ ਨਾਲ ਸਭ ਕੁਝ<br>ਨਾਲ ਤਿਆਰ ਰਹੋ।
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-<span>Windows ਲਈ</span> ਫਾਇਰਫਾਕਸ ਨੂੰ ਡਾਊਨਲੋਡ ਕਰੋ
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-<span>macOS ਲਈ</span> ਫਾਇਰਫਾਕਸ ਡਾਊਨਲੋਡ ਕਰੋ
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-<span>ਲੀਨਕਸ ਲਈ</span> ਫਾਇਰਫਾਕਸ ਨੂੰ ਡਾਊਨਲੋਡ ਕਰੋ
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-ਹੋਰ ਮੰਚਾਂ ਤੇ ਜ਼ੁਬਾਨਾਂ ਲਈ ਡਾਊਨਲੋਡ ਕਰੋ
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-ਹੋਰ ਜ਼ੁਬਾਨ 'ਚ ਡਾਊਨਲੋਡ ਕਰੋ
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-ਤੁਹਾਡਾ ਡਾਊਨਲੋਡ ਆਪਣੇ-ਆਪ ਸ਼ੁਰੂ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ। ਕੀ ਇਹ ਨਹੀਂ ਹੋਇਆ? <a id="%(id)s" href="%(fallback_url)s">ਡਾਊਨਲੋਡ ਕਰਨ ਦੀ ਫੇਰ ਕੋਸ਼ਿਸ਼ ਕਰੋ।</a>।
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-ਤੁਹਾਡਾ ਡਾਊਨਲੋਡ ਆਪਣੇ-ਆਪ ਸ਼ੁਰੂ ਹੋੋਣਾ ਚਾਹੀਦਾ ਹੈ। ਜੇ ਇਹ ਨਹੀਂ ਹੁੰਦਾ ਹੈ ਤਾਂ <a id="%(id)s" href="%(fallback_url)s">ਇੱਥੇ ਕਲਿੱਕ ਕਰੋ</a>।
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-ਫਾਇਰਫਾਕਸ ਨੂੰ ਚੁਸਤ, ਤੇਜ਼ ਅਤੇ ਵਧੇਰੇ ਸੁਰੱਖਿਅਤ ਬਣਾਉਣ ਬਾਰੇ ਸਿੱਖੋ।
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-ਆਪਣੇ ਇਨਬਾਕਸ ਨੂੰ ਜਾਣਕਾਰੀ ਦੇਣ ਵਾਲੇ ਸੁਝਾਅ, ਟ੍ਰਿਕਸ ਅਤੇ ਉਤਪਾਦਾਂ ਦੀਆਂ ਘੋਸ਼ਣਾਵਾਂ ਪ੍ਰਾਪਤ ਕਰੋ।
-
-
-;Enter your email address
-ਆਪਣਾ ਈ-ਮੇਲ ਸਿਰਨਾਵਾਂ ਦਿਓ
-
-
-;How will Mozilla use my email?
-ਮੋਜ਼ੀਲਾ ਮੇਰੇ ਈਮੇਲ ਦਾ ਇਸਤੇਮਾਲ ਕਿਵੇਂ ਕਰੇਗਾ?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-ਮੋਜ਼ੀਲਾ ਸਿਰਫ ਤੁਹਾਡੀ ਈਮੇਲ ਦੀ ਨਿੱਜਤਾ ਅਤੇ ਸੁਰੱਖਿਆ ਨੂੰ ਮਹੱਤਵ ਨਹੀਂ ਦਿੰਦਾ - ਇਹ ਸਾਡੇ <a href="%(manifesto)s"> ਮੈਨੀਫੈਸਟੋ </a> ਦਾ ਹਿੱਸਾ ਹੈ: "ਵਿਅਕਤੀਗਤ ਦੀ ਸੁਰੱਖਿਆ ਅਤੇ ਇੰਟਰਨੈਟ ਤੇ ਨਿੱਜਤਾ ਮੁੱਢਲੀ ਹਨ ਅਤੇ ਇਸਦਾ ਇਲਾਜ ਨਹੀਂ ਕੀਤਾ ਜਾਣਾ ਚਾਹੀਦਾ ਵਿਕਲਪਕ ਦੇ ਰੂਪ ਵਿੱਚ। "<a href="%(principles)s"> ਤੁਸੀਂ ਇੱਥੇ ਸਾਡੇ ਡੇਟਾ ਪ੍ਰਾਈਵੇਸੀ ਦੇ ਪ੍ਰਿੰਸੀਪਲ ਬਾਰੇ ਸਿੱਖ ਸਕਦੇ ਹੋ </a>।
-
-
-;What we want you to know:
-ਅਸੀਂ ਤੁਹਾਨੂੰ ਕੀ ਜਾਣਨਾ ਚਾਹੁੰਦੇ ਹਾਂ:
-
-
-;You don’t need to give us your email to download and use Firefox.
-ਤੁਹਾਨੂੰ ਫਾਇਰਫਾਕਸ ਡਾਊਨਲੋਡ ਕਰਨ ਅਤੇ ਵਰਤਣ ਲਈ ਸਾਨੂੰ ਆਪਣਾ ਈਮੇਲ ਦੇਣ ਦੀ ਜ਼ਰੂਰਤ ਨਹੀਂ ਹੈ।
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-ਅਸੀਂ ਤੁਹਾਡੇ ਈਮੇਲ ਮੰਗਿਆ ਹੈ ਕਿਉਂਕਿ ਸਾਡੀ ਖੋਜ ਤੋਂ ਪਤਾ ਲੱਗਦਾ ਹੈ ਕਿ ਜਿਨ੍ਹਾਂ ਲੋਕਾਂ ਨੂੰ ਸ਼ੁਰੂਆਤੀ ਤਜਰਬੇ ਮਿਲਦੇ ਹਨ ਉਹ ਫਾਇਰਫਾਕਸ ਦੇ ਨਾਲ ਹੋਰ ਅਤੇ ਵਧੀਆ ਕਰਦੇ ਹਨ।
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-ਤੁਸੀਂ ਆਪਣੇ ਲਈ ਸਭ ਤੋਂ ਵਧੀਆ ਕੰਮ ਕਰਨ ਲਈ ਫਾਇਰਫਾਕਸ ਨੂੰ ਅਨੁਕੂਲਿਤ ਕਰਨ, ਗੋਪਨੀਯਤਾ ਅਤੇ ਸੁਰੱਖਿਆ ਬਾਰੇ ਹੋਰ ਜਾਣੋ ਅਤੇ ਵੈੱਬ 'ਤੇ ਆਪਣੇ ਸਭ ਤੋਂ ਵਧੀਆ ਸਮਾਂ ਕਿਵੇਂ ਕੱਢਣਾ ਹੈ, ਇਸ ਬਾਰੇ ਜਾਣਕਾਰੀ ਹਾਸਲ ਕਰਨ ਲਈ ਈਮੇਲ ਕਰਨ ਦੀ ਆਸ ਕਰ ਸਕਦੇ ਹੋ।
-
-
-;You can unsubscribe anytime, for any reason.
-ਤੁਸੀਂ ਕਿਸੇ ਵੀ ਸਮੇਂ, ਕਿਸੇ ਵੀ ਕਾਰਨ ਲਈ ਅਨਸਬਸਕ੍ਰਾਈਬ ਕਰ ਸਕਦੇ ਹੋ।
-
-
-;We will not share, sell or use your email for any other purposes.
-ਅਸੀਂ ਕਿਸੇ ਹੋਰ ਉਦੇਸ਼ਾਂ ਲਈ ਤੁਹਾਡੇ ਈ-ਮੇਲ ਨੂੰ ਸਾਂਝਾ, ਵੇਚ ਜਾਂ ਨਹੀਂ ਵਰਤਾਂਗੇ।
-
-
-;Let’s do this!
-ਆਓ ਇਹ ਕਰੋ!
-
-
-;Sync up with Firefox on mobile:
-ਮੋਬਾਈਲ 'ਤੇ ਫਾਇਰਫਾਕਸ ਨਾਲ ਸਿੰਕ ਕਰੋ:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Firefox ਤਾਜ਼ਾ ਕਰੋ
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 ਮੌਜ਼ੀਲਾ ਫਾਇਰਫਾਕਸ, ਮੁਫ਼ਤ/ਮੁਕਤ ਵੈੱਬ ਬਰਾਊਜ਼ਰ, ਨੂੰ ਡਾਊਨਲੋਡ ਕਰੋ। ਫਾਇਰਫਾਕਸ ਨੂੰ ਆਨਲਾਈਨ ਲੋਕਾਂ ਨੂੰ ਕੰਟਰੋਲ ਦੇਣ ਵਾਸਤੇ ਸਮਰਪਿਤ ਸੰਸਾਰ ਭਰ ਵਿੱਚ ਮੌਜੂਦ ਗ਼ੈਰ-ਫਾਇਦਾ ਪ੍ਰਾਪਤ ਲੋਕਾਂ ਵਲੋਂ ਬਣਾਇਆ ਗਿਆ ਹੈ। ਵਿੰਡੋਜ਼, macOS, ਲੀਨਕਸ, ਐਂਡਰਾਈਡ ਅਤੇ iOS ਲਈ ਅੱਜੇ ਹੀ ਫਾਇਰਫਾਕਸ ਲਵੋ!
-
-
-;Download the fastest Firefox ever
-ਹੁਣ ਤੱਕ ਦੇ ਸਭ ਤੋਂ ਤੇਜ਼ ਫਾਇਰਫਾਕਸ ਡਾਊਨਲੋਡ ਕਰੋ
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-ਹੋਰ ਵੱਧ ਤੇਜ਼ ਸਫ਼ੇ ਲੋਡ ਕਰਨਾ, ਘੱਟ ਮੈਮੋਰੀ ਦੀ ਵਰਤੋਂ ਕਰਨਾ ਅਤੇ ਫੀਚਰਾਂ ਨਾਲ ਭਰਪੂਰ, ਨਵਾਂ ਫਾਇਰਫਾਕਸ ਆ ਗਿਆ ਹੈ।
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Firefox ਤਾਜ਼ਾ ਕਰੋ
 
 ;Truly Private Browsing with Tracking Protection
 ਟਰੈਕ ਹੋਣ ਤੋਂ ਸੁਰੱਖਿਆ ਦੇਣ ਨਾਲ ਸੱਚੀ-ਸੁੱਚੀ ਪ੍ਰਾਈਵੇਟ ਬਰਾਊਜ਼ਿੰਗ
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-ਫਾਇਰਫਾਕਸ ਵਲੋਂ ਜੀ ਆਇਆਂ ਨੂੰ
-
-
-;Take Firefox with You
-ਫਾਇਰਫਾਕਸ ਆਪਣੇ ਨਾਲ ਲੈ ਜਾਓ
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-ਆਪਣੇ ਬੁੱਕਮਾਰਕ, ਅਤੀਤ, ਪਾਸਵਰਡ ਅਤੇ ਹੋਰ ਸੈਟਿੰਗਾਂ ਨੂੰ ਆਪਣੇ ਸਾਰੇ ਡਿਵਾਈਸਾਂ ਉੱਤੇ ਲਵੋ।
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-ਪਹਿਲਾਂ ਹੀ ਫਾਇਰਫਾਕਸ ਵਰਤ ਰਹੇ ਹੋ?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-ਆਪਣੇ ਖਾਤੇ 'ਚ ਸਾਈਨ ਇਨ ਕਰੋ ਅਤੇ ਅਸੀਂ ਹੋਰ ਡਿਵਾਈਸਾਂ 'ਤੇ ਫਾਇਰਫਾਕਸ ਲਈ ਸੰਭਾਲੇ ਹੋਏ ਬੁੱਕਮਾਰਕਾਂ, ਪਾਸਵਰਡਾਂ ਤੇ ਹੋਰ ਵਧੀਆ ਚੀਜ਼ਾਂ ਨੂੰ ਸਿੰਕ ਕਰਾਂਗੇ।
-
-
-;Learn more about Firefox Accounts
-ਫਾਇਰਫਾਕਸ ਖਾਤਿਆਂ ਬਾਰੇ ਹੋਰ ਜਾਣੋ
-
-
-;Skip this step
-ਇਹ ਪਗ਼ ਛੱਡੋ
-
-
-# Old firstrun page
-;Chart your own course
-ਆਪਣੇ ਖੁਦ ਦੇ ਕੋਰਸ ਦਾ ਨਕਸ਼ਾ ਬਣਾਓ
 
 

--- a/pai/firefox/campaign.lang
+++ b/pai/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Congrats! You’re using the latest version of Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refresh Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Free Web Browser
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/pbb/firefox/campaign.lang
+++ b/pbb/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Congrats! You’re using the latest version of Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refresh Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Free Web Browser
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/pl/firefox/campaign.lang
+++ b/pl/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Gratulacje! Używasz najnowszej wersji Firefoksa.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Uaktualnij</a> swojego Firefoksa dla zwiększonej szybkości i prywatności.
-
-
-;You’re using a pre-release version of Firefox.
-Używasz rozwojowej wersji Firefoksa.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Używasz niebezpiecznego, przestarzałego systemu operacyjnego, który <a href="%(url)s">nie jest już obsługiwany przez Firefoksa</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Nowy <strong>Firefox</strong>
 
 ;Fast for good.
 Szybki, już na dobre.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Poznaj Firefoksa Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nowy. Szybki. Już na dobre.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Pobierz teraz
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Odśwież Firefoksa
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Instrukcje, jak <a href="%(url)s">zainstalować Firefoksa</a>.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Pozostałe opcje instalacji i dla innych systemów
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Pozostałe opcje instalacji i dla innych systemów
-
-
-;Keep up with<br> all things Firefox.
-Wszystko<br>o Firefoksie.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Pobierz Firefoksa <span>na Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Pobierz Firefoksa <span>na macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Pobierz Firefoksa <span>na Linuksa</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Pobierz w innych językach i na inne systemy
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Pobierz w innym języku
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Pobieranie powinno rozpocząć się samoczynnie. Jeśli nie, to <a id="%(id)s" href="%(fallback_url)s">spróbuj jeszcze raz</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Pobieranie powinno rozpocząć się samoczynnie. Jeśli nie, <a id="%(id)s" href="%(fallback_url)s">kliknij tutaj</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Dowiedz się, jak Firefox może być jeszcze inteligentniejszy, szybszy i bezpieczniejszy.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Porady, wskazówki i zapowiedzi programów w Twojej skrzynce odbiorczej.
-
-
-;Enter your email address
-Wpisz swój adres e-mail
-
-
-;How will Mozilla use my email?
-Jak Mozilla wykorzysta mój adres e-mail?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla nie tylko ceni prywatność i bezpieczeństwo Twojego adresu e-mail — to część naszego <a href="%(manifesto)s">manifestu</a>: „Bezpieczeństwo i prywatność jednostek w Internecie jest wartością fundamentalną i nie może być postrzegane jako opcjonalne.” <a href="%(principles)s">Więcej informacji o naszych pryncypiach prywatności danych</a>.
-
-
-;What we want you to know:
-Co musisz wiedzieć:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Nie musisz dawać nam swojego adresu e-mail, aby pobrać i używać Firefoksa.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Poprosiliśmy o Twój adres e-mail, ponieważ nasze badania wskazują, że osoby, które otrzymały wprowadzenie do Firefoksa korzystają z niego wydajniej i wygodniej.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Możesz spodziewać się wiadomości e-mail zaprojektowanych tak, aby pomóc Ci zoptymalizować Firefoksa według swoich potrzeb, dowiedzieć się więcej o prywatności i bezpieczeństwie oraz porad, jak najlepiej wykorzystać swój czas w Internecie.
-
-
-;You can unsubscribe anytime, for any reason.
-Możesz zrezygnować z subskrypcji w każdej chwili, z jakiegokolwiek powodu.
-
-
-;We will not share, sell or use your email for any other purposes.
-Nie udostępnimy, nie sprzedamy ani nie wykorzystamy Twojego adresu e-mail w jakichkolwiek innych celach.
-
-
-;Let’s do this!
-Zaczynamy!
-
-
-;Sync up with Firefox on mobile:
-Synchronizuj z Firefoksem na telefon:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Darmowa przeglądarka
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Pobierz Mozillę Firefox, darmową przeglądarkę. Firefox jest tworzony przez ogólnoświatową organizację non-profit, której celem jest oddanie użytkownikom kontroli nad siecią. Pobierz Firefoksa na Windows, macOS, Linuksa, Androida lub iOS.
-
-
-;Download the fastest Firefox ever
-Pobierz najszybszego Firefoksa
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Szybsze wczytywanie stron, mniejsze zużycie pamięci i mnóstwo funkcji w nowym Firefoksie.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Potężnie prywatny
 
 ;Truly Private Browsing with Tracking Protection
 Prawdziwie prywatna przeglądarka z ochroną przed śledzeniem
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Witaj w Firefoksie
-
-
-;Take Firefox with You
-Zabierz Firefoksa ze sobą
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Zakładki, historia, hasła i pozostałe ustawienia na wszystkich urządzeniach.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Korzystasz już z Firefoksa?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Zaloguj się do konta, a zsynchronizujemy zakładki, hasła i wszystkie inne dobroci zachowane przez Ciebie w Firefoksie na innych urządzeniach.
-
-
-;Learn more about Firefox Accounts
-Więcej informacji o koncie Firefoksa
-
-
-;Skip this step
-Pomiń ten krok
-
-
-# Old firstrun page
-;Chart your own course
-Wytycz własny kurs
 
 

--- a/pl/firefox/campaign.lang
+++ b/pl/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/pt-BR/firefox/campaign.lang
+++ b/pt-BR/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/pt-BR/firefox/campaign.lang
+++ b/pt-BR/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Parabéns! Você está usando a versão mais recente do Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Atualize</a> o seu Firefox para mais velocidade e privacidade.
-
-
-;You’re using a pre-release version of Firefox.
-Você está usando uma versão de pré-lançamento do Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Você está usando um sistema operacional desatualizado e inseguro que <a href="%(url)s">não é mais suportado pelo Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ O novo <strong>Firefox</strong>
 
 ;Fast for good.
 Rápido de verdade.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Conheça o Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Novo. Rápido. Para o bem.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Baixe agora
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Restaure seu Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Por favor, siga <a href="%(url)s">estas instruções</a> para instalar o Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Opções avançadas de instalação e outras plataformas
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Opções avançadas de instalação e outras plataformas
-
-
-;Keep up with<br> all things Firefox.
-Fique por dentro de tudo<br> sobre o Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Baixe o Firefox <span>para Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Baixe o Firefox <span>para macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Baixe o Firefox <span>para Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Baixe para outras plataformas e idiomas
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Baixar em outro idioma
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-O seu download deve iniciar automaticamente. Não funcionou? <a id="%(id)s" href="%(fallback_url)s">Baixar novamente</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-O seu download começará automaticamente. Se não, <a id="%(id)s" href="%(fallback_url)s">clique aqui</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Saiba como tornar o Firefox ainda mais inteligente, rápido e seguro.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Receba dicas informativas, truques e anúncios de produtos na sua caixa de entrada.
-
-
-;Enter your email address
-Digite seu endereço de email
-
-
-;How will Mozilla use my email?
-Como a Mozilla usará meu email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-A Mozilla não somente valoriza sua privacidade e segurança de e-mail ─ é parte do nosso <a href="%(manifesto)s">Manifesto</a>: “A segurança e privacidade das pessoas na internet são fundamentais e não podem ser tratadas como opcionais.” <a href="%(principles)s">Você pode saber mais aqui sobre nossos Princípios de Privacidade de Dados</a>.
-
-
-;What we want you to know:
-O que queremos que você saiba:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Você não precisa nos dar seu email para baixar e usar o Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Pedimos seu e-mail porque nossa pesquisa mostra que as pessoas que recebem uma mensagem introdutória usam o Firefox mais e melhor.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Você pode esperar e-mails preparados para ajudar você a otimizar o Firefox, a fim de melhor atender suas necessidades específicas, saber mais sobre privacidade e segurança, e descobrir como aproveitar ao máximo seu tempo na web.
-
-
-;You can unsubscribe anytime, for any reason.
-Você pode cancelar a inscrição a qualquer momento, por qualquer motivo.
-
-
-;We will not share, sell or use your email for any other purposes.
-Não iremos compartilhar, vender ou usar seu e-mail para quaisquer outros propósitos.
-
-
-;Let’s do this!
-Vamos lá!
-
-
-;Sync up with Firefox on mobile:
-Sincronize com o Firefox em dispositivos móveis:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Navegador web gratuito
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Baixe o Mozilla Firefox, um navegador Web gratuito. O Firefox é criado por uma comunidade global sem fins lucrativos dedicada a colocar indivíduos no controle on-line. Obtenha o Firefox para Windows, macOS, Linux, Android e iOS hoje!
-
-
-;Download the fastest Firefox ever
-Baixe o Firefox mais rápido da história
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Carregamento de páginas mais rápido, menos uso de memória e recheado de recursos, o novo Firefox está aqui.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Poderosamente privativo
 
 ;Truly Private Browsing with Tracking Protection
 A verdadeira navegação privativa com proteção contra rastreamento
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Bem-vindo ao Firefox
-
-
-;Take Firefox with You
-Leve o Firefox com você
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Tenha seus favoritos, histórico, senhas e outras configurações em todos os seus dispositivos.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Já está usando o Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Entre na sua conta e nós sincronizaremos seus favoritos, senhas e outras coisas legais que você salvou no Firefox em outros dispositivos.
-
-
-;Learn more about Firefox Accounts
-Saiba mais sobre a Conta Firefox
-
-
-;Skip this step
-Pular essa etapa
-
-
-# Old firstrun page
-;Chart your own course
-Trace seu próprio caminho
 
 

--- a/pt-PT/firefox/campaign.lang
+++ b/pt-PT/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/pt-PT/firefox/campaign.lang
+++ b/pt-PT/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Parabéns! Está a usar a versão mais recente do Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Atualize</a> o seu Firefox para o mais recente em velocidade e privacidade.
-
-
-;You’re using a pre-release version of Firefox.
-Está a utilizar uma versão de pré-lançamento do Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Está a utilizar um sistema operativo inseguro e desatualizado <a href="%(url)s">não mais suportado pelo Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ O novo <strong>Firefox</strong>
 
 ;Fast for good.
 Rápido de vez.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Conheça o Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Novo. Rápido. De vez.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Transferir agora
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Restaurar o Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Por favor, siga <a href="%(url)s">estas instruções</a> para instalar o Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Opções avançadas de instalação e outras plataformas
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Opções avançadas de instalação e outras plataformas
-
-
-;Keep up with<br> all things Firefox.
-Mantenha-se a par<br> sobre tudo Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Transfira o Firefox <span>para Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Transfira o Firefox <span>para macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Transfira o Firefox <span>para Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Transferir para outras plataformas e idiomas
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Transferir noutro idioma
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-A sua transferência deve começar automaticamente. Não funcionou? <a id="%(id)s" href="%(fallback_url)s">Tente transferir novamente</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-A sua transferência deve começar automaticamente. Se não, <a id="%(id)s" href="%(fallback_url)s">clique aqui</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Saiba como fazer o Firefox ainda mais inteligente, rápido e mais seguro.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Obtenha dicas informativas, truques e anúncios de produtos entregues na sua caixa de entrada.
-
-
-;Enter your email address
-Introduza o seu endereço de email
-
-
-;How will Mozilla use my email?
-Como é que a Mozilla irá utilizar o meu email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-A Mozilla não só valoriza a sua privacidade de email e segurança – é parte do nosso <a href="%(manifesto)s">Manifesto</a>: “A segurança e privacidade individual na internet são fundamentais e não podem ser tratadas como opcionais.” <a href="%(principles)s">Pode saber mais acerca dos nossos Princípios de privacidade de dados aqui</a>.
-
-
-;What we want you to know:
-O que nós queremos saber:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Não precisa de nos dar o seu email para transferir e utilizar o Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Nós perguntámos pelo seu email porque a nossa pesquisa mostra que as pessoas que recebem uma experiência introdutória fazem mais e melhor com o Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Pode esperar emails desenhados para lhe ajudar a otimizar o Firefox para trabalhar melhor para si, saber mais acerca de privacidade e segurança e descobrir como aproveitar o seu tempo ao máximo na web.
-
-
-;You can unsubscribe anytime, for any reason.
-Pode cancelar a subscrição a qualquer altura, por qualquer razão.
-
-
-;We will not share, sell or use your email for any other purposes.
-Não iremos partilhar, vender ou utilizar o seu email para quaisquer outros propósitos.
-
-
-;Let’s do this!
-Vamos lá
-
-
-;Sync up with Firefox on mobile:
-Sincronize com o Firefox em dispositivos móveis:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Navegador Web gratuito
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Transfira o Mozilla Firefox, um navegador Web gratuito. O Firefox é criado por uma empresa global sem fins lucrativos dedicada a colocar indivíduos em controlo online. Obtenha o Firefox para Windows, macOS, Linux, Android e iOS hoje!
-
-
-;Download the fastest Firefox ever
-Transfira o Firefox mais rápido de sempre
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Carregamento de páginas mais rápido, menos utilização de memória e repleto de funcionalidades, o novo Firefox está aqui.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Poderosamente privado
 
 ;Truly Private Browsing with Tracking Protection
 Navegação verdadeiramente privada com proteção contra monitorização
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Bem-vindo(a) ao Firefox
-
-
-;Take Firefox with You
-Leve o Firefox consigo
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Obtenha os seus marcadores, histórico, palavras-passe e outras definições em todos os seus dispositivos.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Já utiliza o Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Inicie sessão na sua conta e nós iremos sincronizar os marcadores, palavras-passe e outras coisas boas que guardou no Firefox noutros dispositivos.
-
-
-;Learn more about Firefox Accounts
-Saber mais acerca do Contas Firefox
-
-
-;Skip this step
-Saltar este passo
-
-
-# Old firstrun page
-;Chart your own course
-Trace o seu próprio percurso
 
 

--- a/qvi/firefox/campaign.lang
+++ b/qvi/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Congrats! You’re using the latest version of Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refresh Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Free Web Browser
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/rm/firefox/campaign.lang
+++ b/rm/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/rm/firefox/campaign.lang
+++ b/rm/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Gratulaziun! Ti utiliseschas la pli nova versiun da Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Actualisescha</a> tes Firefox per dapli sveltezza e sfera privata.
-
-
-;You’re using a pre-release version of Firefox.
-Ti utiliseschas ina versiun preliminara da Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Ti utiliseschas in sistem operativ betg actual e malsegir <a href="%(url)s">che na vegn betg pli sustegnì da Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Il nov <strong>Firefox</strong>
 
 ;Fast for good.
 Il navigatur rumantsch.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Firefox Quantum è qua
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nov. Spert. E propi bun.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Telechargiar ussa
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Redefinir Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Suonda <a href="%(url)s">questas infurmaziuns</a> per installar Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Opziuns d'installaziun avanzadas & autras plattafurmas
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Opziuns d'installaziun avanzadas & autras plattafurmas
-
-
-;Keep up with<br> all things Firefox.
-Ta tegna al current<br> davart Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Telechargiar Firefox <span>per Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Telechargiar Firefox <span>per macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Telechargiar Firefox <span>per Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Telechargiar per autras plattafurmas & linguas
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Telechargiar en in'autra lingua
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Tia telechargiada duess cumenzar automaticamain. Betg gartegià? <a id="%(id)s" href="%(fallback_url)s">Empruvar danovamain</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Tia telechargiada duess cumenzar automaticamain. Uschiglio <a id="%(id)s" href="%(fallback_url)s">clicca qua</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Ve a savair co far daventar Firefox anc pli intelligent, pli svelt e pli segir.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Retschaiva tips infurmativs, trics e novitads davart products direct en tia posta entrada.
-
-
-;Enter your email address
-Endatescha tia adressa d'e-mail
-
-
-;How will Mozilla use my email?
-Tge fa Mozilla cun mia adressa?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-La protecziun da datas e la segirezza èn fitg impurtantas per Mozilla – ed ellas èn ina part da noss <a href="%(manifesto)s">Manifest</a>: «La segirezza e la protecziun da datas da mintga persuna en l'internet è fundamentala e betg facultativa.» <a href="%(principles)s">Ulteriuras infurmaziuns davart noss princips da la protecziun da datas chattas ti qua</a>.
-
-
-;What we want you to know:
-Nus vulain che ti sappias il suandant:
-
-
-;You don’t need to give us your email to download and use Firefox.
-I n'è betg necessari d'ans dar tia adressa d'e-mail per telechargiar ed utilisar Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Nus avain dumandà tia adressa d'e-mail perquai che nossas retschertgas mussan che persunas che han vis ina introducziun vegnan da lavurar dapli e meglier cun Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Ti vegns a retschaiver e-mails che ta gidan ad optimar Firefox per tes basegns, ulteriuras infurmaziuns davart la protecziun da datas & la segirezza e co ti profiteschas il pli fitg dal temp passentà en l'internet.
-
-
-;You can unsubscribe anytime, for any reason.
-Ti pos annullar l'abunament da tut temp per tge motiv ch'i saja.
-
-
-;We will not share, sell or use your email for any other purposes.
-Nus na vegnin betg a cundivider, vender u utilisar tia adressa d'e-mail per x in auter motiv.
-
-
-;Let’s do this!
-En posiziun, pront, dai!
-
-
-;Sync up with Firefox on mobile:
-Sincronisescha cun tes telefonin:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Il navigatur gratuit
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Telechargia Mozilla Firefox, in navigatur da web gratuit e liber. Firefox è vegnì creà dad in'organisaziun senza finamira da profit che s'engascha per che ti hajas la controlla sur da tias activitads en l'internet. Telechargia uss Firefox per Windows, macOS, Linux, Android ed iOS!
-
-
-;Download the fastest Firefox ever
-Telechargiar la versiun la pli sperta da Firefox
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Paginas che chargian pli spert, in consum da memoria reducì e novas funcziuns: Il nov Firefox è qua.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Propi privat
 
 ;Truly Private Browsing with Tracking Protection
 In modus privat cun protecziun encunter il fastizar
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Bainvegni tar Firefox
-
-
-;Take Firefox with You
-Prenda Firefox cun tai
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Acceda cun tut tes apparats a tes segnapaginas, a la cronologia, als pleds-clav ed ad autras preferenzas.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Dovras ti gia Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-T'annunzia cun tes conto e nus sincronisain ils segnapaginas, pleds-clav e las autras chaussas che ti has memorisà en Firefox sin tschels apparats.
-
-
-;Learn more about Firefox Accounts
-Ulteriuras infurmaziuns davart contos da Firefox
-
-
-;Skip this step
-Sursiglir quest pass
-
-
-# Old firstrun page
-;Chart your own course
-Bainvegni en la libertad
 
 

--- a/ro/firefox/campaign.lang
+++ b/ro/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/ro/firefox/campaign.lang
+++ b/ro/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Felicitări! Folosești ultima versiune de Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Actualizează</a> Firefox pentru cele mai noi îmbunătățiri în materie de viteză și confidențialitate.
-
-
-;You’re using a pre-release version of Firefox.
-Folosești o versiune preliminară de Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Folosești un sistem de operare nesigur și perimat <a href="%(url)s">care nu mai este suportat de Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Noul <strong>Firefox</strong>
 
 ;Fast for good.
 Rapid, pe bune.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Descoperă Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nou. Rapid. Pe bune.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Descarcă acum
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Restaurează Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Te rugăm să urmezi aceste instrucțiuni <a href="%(url)s"></a> pentru instalarea Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Opțiuni avansate de instalare și alte platforme
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Opțiuni avansate de instalare și alte platforme
-
-
-;Keep up with<br> all things Firefox.
-Fii la curent<br> cu noutățile din Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Descarcă Firefox <span>pentru Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Descarcă Firefox <span>pentru macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Descarcă Firefox <span>pentru Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Descarcă pentru alte platforme și limbi
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Descarcă în altă limbă
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Descărcarea ar trebui să înceapă automat. Nu a mers? <a id="%(id)s" href="%(fallback_url)s">Încearcă din nou</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Descărcarea ta ar trebui să înceapă automat. În caz contrar, <a id="%(id)s" href="%(fallback_url)s">apasă aici</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Află cum să faci Firefox și mai inteligent, mai rapid și mai securizat.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Abonează-te la ponturi informative, trucuri și anunțuri de produse livrate în căsuța ta de poștă electronică.
-
-
-;Enter your email address
-Introdu adresa de e-mail
-
-
-;How will Mozilla use my email?
-Cum va folosi Mozilla adresa mea de e-mail?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla nu doar că pune preț pe confidențialitatea și securitatea emailului tău – este parte a <a href="%(manifesto)s">Manifestului </a> nostru: „Securitatea persoanelor și confidențialitatea pe internet sunt fundamentale și nu trebuie tratate ca opționale. <a href="%(principles)s">Poți afla mai multe despre principiile noastre privind confidențialitatea datelor de aici</a>.
-
-
-;What we want you to know:
-Ce dorim să știi:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Nu trebuie să ne dai adresa de e-mail ca să descarci și să folosești Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Ți-am cerut adresa de e-mail pentru că din cercetările noastre rezultă că cei care primesc o prezentare introductivă se descurcă mai mult și mai bine cu Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Te poți aștepta la mesaje pe e-mail concepute pentru a te ajuta să optimizezi Firefox ca să funcționeze cel mai bine pentru tine, să afli mai multe despre confidențialitate și securitate și despre cum să îți petreci cel mai bine timpul pe web.
-
-
-;You can unsubscribe anytime, for any reason.
-Te poți dezabona oricând, indiferent de motive.
-
-
-;We will not share, sell or use your email for any other purposes.
-Nu vom partaja, vinde sau folosi adresa ta de e-mail în niciun alt scop.
-
-
-;Let’s do this!
-Să începem!
-
-
-;Sync up with Firefox on mobile:
-Sincronizează Firefox pe mobil:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Browser web gratuit
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Descarcă Mozilla Firefox, un browser web gratuit. Firefox este creat de o organizație globală nonprofit cu misiunea de a da utilizatorilor controlul online. Instalează Firefox pentru Windows, macOS, Linux, Android și iOS astăzi!
-
-
-;Download the fastest Firefox ever
-Descarcă cel mai rapid Firefox care a existat vreodată
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Noul Firefox este aici: încărcare mai rapidă a paginilor, mai puțină memorie necesară și plin de funcționalități.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Confidențialitate puternică
 
 ;Truly Private Browsing with Tracking Protection
 Navigare cu adevărat privată folosind protecția împotriva urmăririi
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Bine ai venit la Firefox
-
-
-;Take Firefox with You
-Ia Firefox cu tine
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Ia cu tine marcajele, istoricul, parolele și alte setări pe toate dispozitivele.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Deja folosești Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Autentifică-te în cont și îți vom sincroniza pe alte dispozitive marcajele, parolele și alte lucruri importante pe care le-ai salvat în Firefox.
-
-
-;Learn more about Firefox Accounts
-Află mai multe despre conturile Firefox
-
-
-;Skip this step
-Omite acest pas
-
-
-# Old firstrun page
-;Chart your own course
-Creează-ți propriul drum
 
 

--- a/ru/firefox/campaign.lang
+++ b/ru/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/ru/firefox/campaign.lang
+++ b/ru/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Поздравляем! Вы используете последнюю версию Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Обновите</a> свой Firefox до последней версии, чтобы увеличить скорость работы и повысить приватность.
-
-
-;You’re using a pre-release version of Firefox.
-Вы используете предрелизную версию Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Вы используете небезопасную, устаревшую операционную систему, <a href="%(url)s">более не поддерживаемую Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@
 
 ;Fast for good.
 Быстрый и Ответственный.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Встречайте Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Новый. Быстрый. Ответственный.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Загрузить сейчас
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Очистить Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Пожалуйста, следуйте <a href="%(url)s">этим инструкциям</a>, чтобы установить Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Расширенные возможности установки и другие платформы
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Расширенные возможности установки и другие платформы
-
-
-;Keep up with<br> all things Firefox.
-Будьте в курсе всего,<br> что связано с Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Загрузить Firefox <span>для Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Загрузить Firefox <span>для macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Загрузить Firefox <span>для Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Загрузить для других платформ и языков
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Загрузить на другом языке
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Загрузка начнётся автоматически. Она не началась? <a id="%(id)s" href="%(fallback_url)s">Щёлкните здесь</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Загрузка начнётся автоматически. Если она не началась, <a id="%(id)s" href="%(fallback_url)s">щёлкните здесь</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Узнайте, как сделать Firefox ещё умнее, быстрее и защищённее.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Получайте полезные советы, информацию об интересных особенностях, а также объявления о новинках на свой ящик.
-
-
-;Enter your email address
-Введите свой адрес эл. почты
-
-
-;How will Mozilla use my email?
-Как Mozilla будет использовать мой адрес электронной почты?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla не только ценит приватность вашего адреса электронной почты и безопасность - это часть нашего <a href="%(manifesto)s">манифеста</a>: «Безопасность и приватность пользователей Интернета имеют основополагающее значение и не могут рассматриваться как второстепенные моменты.» <a href="%(principles)s">Вы можете узнать больше о наших принципах конфиденциальности данных здесь</a>.
-
-
-;What we want you to know:
-Мы хотим, чтобы вы знали:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Вам не нужно указывать свой адрес электронной почты, чтобы загрузить и пользоваться Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Мы просим вас сообщить ваш адрес электронной почты, так как наши исследования показывают, что люди, получившие вводный курс в Firefox, делают с ним больше и работают лучше.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Вы будете получать письма, написанные с целью помочь вам оптимизировать Firefox под ваши нужды, узнать больше о конфиденциальности и безопасности, и узнать, как лучше всего использовать ваше время в сети.
-
-
-;You can unsubscribe anytime, for any reason.
-Вы можете отписаться в любое время, по любой причине.
-
-
-;We will not share, sell or use your email for any other purposes.
-Мы не будет делиться, продавать или использовать ваш адрес эл. почты для каких-либо других целей.
-
-
-;Let’s do this!
-Давайте это сделаем!
-
-
-;Sync up with Firefox on mobile:
-Синхронизируйтесь с Firefox на мобильном:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Mozilla не только ценит приватность вашего адр�
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Загрузите бесплатный веб-браузер Mozilla Firefox. Firefox создан глобальной некоммерческой организацией, которая хочет дать людям возможность контролировать свою жизнь в Интернете. Загрузите Firefox для Windows, macOS, Linux, Android и iOS прямо сейчас!
-
-
-;Download the fastest Firefox ever
-Загрузите самый быстрый в истории Firefox
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Более быстрая загрузка страниц, меньшее использование памяти и множество функций, новый Firefox уже здесь.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Mozilla не только ценит приватность вашего адр�
 
 ;Truly Private Browsing with Tracking Protection
 Настоящий приватный просмотр с защитой от отслеживания
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Добро пожаловать в Firefox
-
-
-;Take Firefox with You
-Возьмите Firefox с собой
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Получите доступ к вашим закладкам, истории, паролям и другим параметрам на всех ваших устройствах.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Уже используете Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Войдите в свой аккаунт и мы синхронизируем все ваши закладки, пароли и другие нужные вещи, которые вы сохранили в Firefox на других устройствах.
-
-
-;Learn more about Firefox Accounts
-Узнайте больше об Аккаунтах Firefox
-
-
-;Skip this step
-Пропустить этот шаг
-
-
-# Old firstrun page
-;Chart your own course
-Сами определите свой курс
 
 

--- a/si/firefox/campaign.lang
+++ b/si/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-සුබ පැතුම්! ඔබ Firefox නවතම නිකුතුව භාවිත කරයි.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-නවතම වේගය සහ පුද්ගලිකත්වය සඳහා ඔබගේ Firefox <a href="%(url)s">යාවත්කාල කරන්න</a>.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox නැවුම් කරන්න
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Firefox ස්ථාපනය සඳහා කරුණාකර <a href="%(url)s">මෙම උපදෙස්</a> පිළිපදින්න.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Download Firefox
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/sk/firefox/campaign.lang
+++ b/sk/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/sk/firefox/campaign.lang
+++ b/sk/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Gratulujeme! Používate najnovšiu verziu Firefoxu.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Aktualizujte</a> svoj Firefox. Získate vyššiu rýchlosť a lepšiu ochranu súkromia.
-
-
-;You’re using a pre-release version of Firefox.
-Používate nefinálnu verziu Firefoxu.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Používate nezabezpečený, zastaraný operačný systém, ktorý <a href="%(url)s">Firefox nepodporuje</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Nový <strong>Firefox</strong>
 
 ;Fast for good.
 Neuveriteľne rýchly.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Spoznajte Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nový. Rýchly. Skvelý.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Prevziať
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Obnoviť Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Pri inštalácií Firefoxu postupujte, prosím, podľa <a href="%(url)s">týchto inštrukcií</a>.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Pokročilé možnosti inštalácie a ďalšie platformy
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Pokročilé možnosti inštalácie a ďalšie platformy
-
-
-;Keep up with<br> all things Firefox.
-Zostaňte v spojení<br> s Firefoxom.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Prevezmite si Firefox <span>pre Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Prevezmite si Firefox <span>pre macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Prevezmite si Firefox <span>pre Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Prevziať verziu pre inú platformu a jazyk
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Prevziať v inom jazyku
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Preberanie by malo začať automaticky. Nezačalo? <a id="%(id)s" href="%(fallback_url)s">Skúste to znova</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Preberanie by malo začať automaticky. Ak preberanie nezačalo, <a id="%(id)s" href="%(fallback_url)s">kliknite sem</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Zistite, ako Firefox ešte vylepšiť.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Nechajte si do svojej schránky zasielať tipy a triky.
-
-
-;Enter your email address
-Zadajte svoju e-mailovú adresu
-
-
-;How will Mozilla use my email?
-Ako Mozilla naloží s mojou e-mailovou adresou?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla si neváži len súkromie a bezpečnosť vašej e-mailovej adresy - je to súčasť nášho <a href="%(manifesto)s">manifestu</a>: „Bezpečnosť a súkromie týchto jedincov na internete sú dôležité a nemôžu byť brané na ľahkú váhu.“ <a href="%(principles)s">Viac sa o našich zásadách dozviete tu</a>.
-
-
-;What we want you to know:
-Čo chceme aby ste vedeli:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Prevzatie a používanie Firefoxu nie je podmienené vašou e-mailovou adresou.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-O vašu e-mailovú adresu sme požiadali, pretože naše výskumy ukázali, že ľudia, ktorí dostanú úvodné informácie sú s Firefoxom spokojnejší.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Môžete očakávať e-maily, ktoré vám pomôžu optimalizovať si svoj Firefox. Nájdete v nich taktiež informácie o súkromí a zabezpečení.
-
-
-;You can unsubscribe anytime, for any reason.
-Z odoberania sa môžete kedykoľvek odhlásiť.
-
-
-;We will not share, sell or use your email for any other purposes.
-Vašu e-mailovú adresu nebudeme zdieľať, predávať ani používať na akékoľvek iné účely.
-
-
-;Let’s do this!
-Poďme na to!
-
-
-;Sync up with Firefox on mobile:
-Synchronizácia s mobilným Firefoxom:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Voľne dostupný webový prehliadač
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Prevezmite si Mozillu Firefox, voľne dostupný webový prehliadač. Firefox je vyvíjaný neziskovou organizáciou, ktorej cieľom je dať ľudom kontrolu nad internetom. Prevezmite si Firefox pre Windows, macOS, Linux, Android a iOS!
-
-
-;Download the fastest Firefox ever
-Prevezmite si ten najrýchlejší Firefox vôbec
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Rýchlejšie načítavanie stránok, menšia spotreba pamäte a množstvo funkcií. Nový Firefox je tu.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Zameraný na súkromie
 
 ;Truly Private Browsing with Tracking Protection
 Skutočne súkromné prehliadanie s ochranou pred sledovaním
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Víta vás Firefox
-
-
-;Take Firefox with You
-Vezmite si Firefox so sebou
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Majte svoje záložky, históriu, heslá a ostatné nastavenia na všetkých vašich zariadeniach.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Používate už Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Prihláste sa do svojho účtu a my zosynchronizujeme vaše záložky, heslá a ďalšie skvelé veci, ktoré ste si uložili do Firefoxu na iných zariadeniach.
-
-
-;Learn more about Firefox Accounts
-Ďalšie informácie o účtoch Firefox
-
-
-;Skip this step
-Preskočiť tento krok
-
-
-# Old firstrun page
-;Chart your own course
-Vyberte si svoj vlastný cieľ
 
 

--- a/sl/firefox/campaign.lang
+++ b/sl/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/sl/firefox/campaign.lang
+++ b/sl/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Čestitke, uporabljate najnovejšo različico Firefoxa.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Posodobite</a> svoj brskalnik Firefox, da bo še hitrejši in zasebnejši.
-
-
-;You’re using a pre-release version of Firefox.
-Uporabljate razvojno različico Firefoxa.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Uporabljate zastarel operacijski sistem, ki ni več varen in ga <a href="%(url)s">Firefox več ne podpira</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Novi <strong>Firefox</strong>
 
 ;Fast for good.
 Hiter za vedno.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Spoznajte Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Nov. Hiter. Za vedno.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Prenesi zdaj
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Osveži Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Za namestitev Firefoxa sledite <a href="%(url)s">navodilom</a>.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Napredne možnosti namestitve & druge platforme
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Napredne možnosti namestitve & druge platforme
-
-
-;Keep up with<br> all things Firefox.
-Ostanite na tekočem<br> s Firefoxom.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Prenesite Firefox <span>za Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Prenesite Firefox <span>za macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Prenesite Firefox <span>za Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Prenesi za druge platforme in jezike
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Prenesite v drugem jeziku
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Prenos bi se moral začeti samodejno. Ne deluje? <a id="%(id)s" href="%(fallback_url)s">Poskusite znova začeti prenos</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Prenos bi se moral začeti samodejno. Če se ne, <a id="%(id)s" href="%(fallback_url)s">kliknite tukaj</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Naučite se napraviti Firefox še pametnejši, hitrejši in varnejši.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Prejemajte uporabne nasvete, zvijače in novice o izdelkih v e-poštni predal.
-
-
-;Enter your email address
-Vnesite svoj e-poštni naslov
-
-
-;How will Mozilla use my email?
-Kako bo Mozilla uporabila moj e-poštni naslov?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Ne le, da Mozilla spoštuje zasebnost in varnost vaše e-pošte – to je del našega <a href="%(manifesto)s">manifesta</a>: “Varnost in zasebnost posameznika na internetu sta bistveni, zato se ju ne sme obravnavati kot nekaj neobveznega.” <a href="%(principles)s">Več o naših načelih zasebnosti podatkov lahko preberete tukaj</a>.
-
-
-;What we want you to know:
-Kaj želimo, da veste:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Za prenos in uporabo Firefoxa ni potrebno, da nam daste svoj e-poštni naslov.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Za vaš e-poštni naslov smo vprašali, ker naša raziskava kaže, da tisti, ki so deležni uvoda v Firefox, z njim zmorejo več in bolje.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Pričakujete lahko sporočila, ki vam bodo pomagala napraviti Firefox po lastnem okusu, vas obveščala o zasebnosti in varnosti ter vam pomagala iz spleta potegniti kar največ.
-
-
-;You can unsubscribe anytime, for any reason.
-Odjavite se lahko kadarkoli in iz kateregakoli razloga.
-
-
-;We will not share, sell or use your email for any other purposes.
-Vašega e-poštnega naslova ne bomo delili z drugimi, ga prodajali ali uporabljali v katerikoli drug namen.
-
-
-;Let’s do this!
-Pa dajmo!
-
-
-;Sync up with Firefox on mobile:
-Sinhronizacija s Firefoxom za mobilne naprave:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Brezplačen brskalnik
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Prenesite brezplačni brskalnik Mozilla Firefox. Ustvarila ga je globalna neprofitna organizacija, ki želi, da imajo posamezniki priložnost nadzora v spletu. Prenesite si Firefox za Windows, macOS, Linux, Android ali iOS!
-
-
-;Download the fastest Firefox ever
-Prenesite najhitrejši Firefox vseh časov
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Hitrejše nalaganje strani, manjša poraba pomnilnika in kopica novih zmožnosti – novi Firefox je tu.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Popolnoma zaseben
 
 ;Truly Private Browsing with Tracking Protection
 Resnično zasebno brskanje z zaščito pred sledenjem
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Dobrodošli v Firefoxu
-
-
-;Take Firefox with You
-Vzemite Firefox s seboj
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Imejte dostop do svojih zaznamkov, zgodovine, gesel in drugih podatkov z vseh svojih naprav.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Že uporabljate Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Prijavite se v svoj račun in sinhronizirali bomo zaznamke, gesla in druge stvari, ki ste jih shranili v Firefoxu na ostalih napravah.
-
-
-;Learn more about Firefox Accounts
-Več o Firefox Računih
-
-
-;Skip this step
-Preskoči ta korak
-
-
-# Old firstrun page
-;Chart your own course
-Začrtajte si potek
 
 

--- a/son/firefox/campaign.lang
+++ b/son/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Hoyhoy! War goo ma goy nda Firefox dumi kokorantaa.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox taagandi
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Duu alhabar<br> Firefox mise kul ga.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Interneti ceecikaw forba
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Kubayni Firefox ra
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/sq/firefox/campaign.lang
+++ b/sq/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/sq/firefox/campaign.lang
+++ b/sq/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Përgëzime! Po përdorni versionin më të ri të Firefox-it.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Përditësoni</a> Firefox-in tuaj me zhvillimet më të reja në shpejtësi dhe privatësi.
-
-
-;You’re using a pre-release version of Firefox.
-Po përdorni një version paraqarkullim të Firefox-it.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Keni në përdorim një sistem operativ të pasigurt, të vjetruar, <a href="%(url)s">që nuk mbulohet më nga Firefox-i</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Keni në përdorim një sistem operativ të pasigurt, të vjetruar, <a href="%(u
 
 ;Fast for good.
 I shpejtë përgjithnjë.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Njihuni me Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-I ri. I shpejtë. Përgjithnjë.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Shkarkojeni Tani
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Rifreskoni Firefox-in
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Që të instaloni Firefox-in, ju lutemi, ndiqni <a href="%(url)s">këto udhëzime</a>.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Mundësi të Thelluara Instalimi & Platforma të Tjera
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Mundësi të thelluara instalimi & platforma të tjera
-
-
-;Keep up with<br> all things Firefox.
-Ndiqni<br> gjithçka mbi Firefox-in.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Shkarkoni Firefox-in <span>për Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Shkarkoni Firefox-in <span>për macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Shkarkoni Firefox-in <span>për Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Shkarkime për platforma & gjuhë të tjera
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Shkarkojeni në një gjuhë tjetër
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Shkarkimi juaj do të duhej të fillonte vetvetiu. S’ndodhi? <a id="%(id)s" href="%(fallback_url)s">Provoni sërish ta shkarkoni</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Shkarkimi juaj do të duhej të fillonte vetvetiu. Nëse s’fillon, <a id="%(id)s" href="%(fallback_url)s">klikoni këtu</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Mësoni si ta bëni Firefox-in edhe më të mençur, më të shpejtë dhe më të sigurt.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Merrni ndihmëza informative, marifete dhe njoftime mbi produktesh drejt e te email-i juaj.
-
-
-;Enter your email address
-Jepni adresën tuaj email
-
-
-;How will Mozilla use my email?
-Përse do ta përdorë Mozilla email-in tim?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla jo thjesht vlerëson privatësinë dhe sigurinë e email-it tuaj – këto janë pjesë të <a href="%(manifesto)s">Manifestit tonë</a>: “Siguria dhe privatësia e individit në internet janë themelore dhe nuk duhen trajtuar si opsionale.” <a href="%(principles)s">Këtu mund të mësoni rreth Parimeve tona mbi Privatësinë e të Dhënave</a>.
-
-
-;What we want you to know:
-Ç’duam të dini:
-
-
-;You don’t need to give us your email to download and use Firefox.
-S’ju duhet të na jepni email-in tuaj për të shkarkuar dhe përdorur Firefox-in.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Ua kërkuam email-in ngaqë kërkimet tona tregojnë se personat që marrin pak ndihmë sa për fillim, arrijnë me Firefox-in më shumë gjëra dhe më mirë.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Mund të prisni prej nesh email-e të konceptuar për t’ju ndihmuar të optimizoni Firefox-in për të punuar në mënyrën më të mirë për ju, të mësoni më tepër rreth privatësisë & sigurisë dhe të shihni se si përfitoni maksimumin nga interneti.
-
-
-;You can unsubscribe anytime, for any reason.
-Mund të shpajtoheni kurdo, për çfarëdo arsyeje.
-
-
-;We will not share, sell or use your email for any other purposes.
-Email-n tuaj nuk do t’ua japim të tjerëve, shesim apo përdorim për çfarëdo qëllimi tjetër.
-
-
-;Let’s do this!
-Le ta bëjmë!
-
-
-;Sync up with Firefox on mobile:
-Njëkohësojeni me Firefox-in në celular:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Shfletues Web i Lirë
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Shkarkoni Mozilla Firefox-in, një shfletues Web i lirë. Firefox-i është krijuar nga një organizëm jofitimprurës, mbarëbotëror, i përkushtuar vënies së individit në kontroll të jetës së tij <em>online</em>. Merreni që sot Firefox-in për Windows, macOS, Linux, Android dhe iOS!
-
-
-;Download the fastest Firefox ever
-Shkarkoni Firefox-in më të shpejtë deri më sot
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Ngarkim më i shpejtë faqesh, përdorim më i pakët i kujtesës dhe plot me veçori, Firefox-i i ri erdhi.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Fuqimisht privat
 
 ;Truly Private Browsing with Tracking Protection
 Shfletim Përnjëmend Privat me Mbrojtje Nga Gjurmimi
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Mirë se vini në Firefox
-
-
-;Take Firefox with You
-Merreni Firefox-in me Vete
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Merrni në krejt pajisjet tuaja faqerojtësit, historikun, fjalëkalimet dhe të tjera rregullime tuajat.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-E përdorni tashmë Firefox-in?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Hyni te llogaria juaj dhe do të njëkohësojmë faqerojtësit, fjalëkalimet dhe të tjera gjëra të dobishme që keni ruajtur te Firefox-i në pajisje të tjera.
-
-
-;Learn more about Firefox Accounts
-Mësoni më tepër rreth Llogarive Firefox
-
-
-;Skip this step
-Anashkalojeni këtë hap
-
-
-# Old firstrun page
-;Chart your own course
-Hartojeni vetë kursin tuaj
 
 

--- a/sr/firefox/campaign.lang
+++ b/sr/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/sr/firefox/campaign.lang
+++ b/sr/firefox/campaign.lang
@@ -1,25 +1,4 @@
-## active ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Честитамо! Користите последњу верзију Firefox-а.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Ажурирајте</a> свој Firefox за најновије у брзини и приватности.
-
-
-;You’re using a pre-release version of Firefox.
-Користите бета верзију Firefox-а.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -28,133 +7,6 @@ You’re using an insecure, outdated operating system <a href="%(url)s">no longe
 
 ;Fast for good.
 Брз са разлогом.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Упознајте Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Нов. Брз. За стално.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Преузмите сада
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Освежи Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Пратите <a href="%(url)s">ове кораке</a> за инсталацију Firefox-а.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Напредне инсталационе опције и друге платформе
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Додатне инсталационе опције и друге платформе
-
-
-;Keep up with<br> all things Firefox.
-Будите обавештени о<br> свим Firefox стварима.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Преузмите Firefox <span>за Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Преузмите Firefox <span>за macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Преузмите Firefox <span>за Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Преузмите за друге платформе и језике
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Преузмите на другом језику
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Преузимање би требало аутоматски да почне. Не ради? <a id="%(id)s" href="%(fallback_url)s">Покушајте поново</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Ваше преузимање би требало аутоматски да почне. Ако не почне, <a id="%(id)s" href="%(fallback_url)s">кликните овде</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Урадимо то!
-
-
-;Sync up with Firefox on mobile:
-Синхронизујте се са Firefox-ом на мобилном:
 
 
 # HTML page title prefix
@@ -170,14 +22,6 @@ We will not share, sell or use your email for any other purposes.
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Преузмите Mozilla Firefox, бесплатни веб прегледач. Firefox је створен са циљем да људима широм света омогући интернет контролу. Преузмите Firefox за Windows, macOS, Android и iOS већ данас!
-
-
-;Download the fastest Firefox ever
-Преузмите најбржи Firefox икада
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Брже учитавање страница, мања употреба меморије, нови Firefox је стигао.
 
 
 ;2x Faster
@@ -202,41 +46,5 @@ We will not share, sell or use your email for any other purposes.
 
 ;Truly Private Browsing with Tracking Protection
 Прави прегледач за приватност са заштитом од праћења
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Добродошли у Firefox
-
-
-;Take Firefox with You
-Понесите Firefox са собом
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Пренесите ваше забелешке, историјат, лозинке и друге поставке на све ваше уређаје.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Већ користите Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Пријавите се са вашим налогом и синхронизоваћемо белешке, лозинке и све остале сјајне ствари које сте сачували унутар Firefox-а на осталим уређајима.
-
-
-;Learn more about Firefox Accounts
-Сазнајте више о Firefox налозима
-
-
-;Skip this step
-Прескочи овај корак
-
-
-# Old firstrun page
-;Chart your own course
-Зацртајте сопствени курс
 
 

--- a/sv-SE/firefox/campaign.lang
+++ b/sv-SE/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/sv-SE/firefox/campaign.lang
+++ b/sv-SE/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Gratulerar! Du använder den senaste versionen av Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Uppdatera</a> Firefox för det senaste inom hastighet och integritet.
-
-
-;You’re using a pre-release version of Firefox.
-Du använder en förhandsversion av Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Du använder ett osäkert, föråldrat operativsystem <a href="%(url)s">som inte längre stöds av Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Nya <strong>Firefox</strong>
 
 ;Fast for good.
 Snabbast hittills.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Möt Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Ny. Snabb. Häftig.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Hämta nu
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Återställ Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Följ <a href="%(url)s">dessa instruktioner</a> för att installera Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Avancerade installationsalternativ och andra plattformar
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Avancerade installationsalternativ och andra plattformar
-
-
-;Keep up with<br> all things Firefox.
-Håll dig uppdaterad med<br> de senaste nyheterna i Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Ladda ner Firefox <span>för Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Ladda ner Firefox <span>för macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Ladda ner Firefox <span>för Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Ladda ner för andra plattformar och språk
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Hämta på ett annat språk
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Din nedladdning bör starta automatiskt. Fungerade det inte? <a id="%(id)s" href="%(fallback_url)s">Försök att ladda ner igen</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Din nedladdning bör starta automatiskt. Om det inte gör det, <a id="%(id)s" href="%(fallback_url)s">klicka här</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Lär dig hur du gör Firefox ännu smartare, snabbare och säkrare.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Få informativa tips och tricks samt produktnyheter levererade till din inkorg.
-
-
-;Enter your email address
-Ange din e-postadress
-
-
-;How will Mozilla use my email?
-Hur kommer Mozilla använda min e-postadress?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla värderar inte bara din sekretess och säkerhet för din e-postadress – det ingår i vår <a href="%(manifesto)s">manifest</a>: "Personers säkerhet och integritet på internet är grundläggande och kan inte betraktas som valfritt." <a href="%(principles)s">Du kan lära dig om våra principer om datasekretess här</a>.
-
-
-;What we want you to know:
-Vad vi vill att du ska veta:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Du behöver inte ge oss din e-postadress för att ladda ner och använda Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Vi bad om din e-postadress eftersom vår forskning visar att personer som får en introduktion arbetar mer och bättre med Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Du kan förvänta dig e-postmeddelanden som är utformade för att hjälpa dig att optimera Firefox för att fungera bäst för dig, lära dig mer om integritet och säkerhet och ta reda på hur du får det bästa av din tid på webben.
-
-
-;You can unsubscribe anytime, for any reason.
-Du kan avbryta prenumerationen när som helst.
-
-
-;We will not share, sell or use your email for any other purposes.
-Vi delar inte, säljer eller använder ditt e-postadress för något annat ändamål.
-
-
-;Let’s do this!
-Låt oss göra det!
-
-
-;Sync up with Firefox on mobile:
-Synkronisering med Firefox för mobila enheter:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Gratis webbläsare
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Ladda ner Mozilla Firefox, en gratis webbläsare. Firefox är skapad av en global ideell grupp som vill ge individer kontroll på nätet. Hämta Firefox för Windows, macOS, Linux, Android och iOS idag!
-
-
-;Download the fastest Firefox ever
-Ladda ner den snabbaste Firefox någonsin
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Snabbare sidladdning, mindre minnesanvändning och fulländad med funktioner, den nya Firefox är här.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Skyddar din integritet
 
 ;Truly Private Browsing with Tracking Protection
 Äkta privat surfning med spårningsskydd
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Välkommen till Firefox
-
-
-;Take Firefox with You
-Ta med dig Firefox
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Få dina bokmärken, historik, lösenord och andra inställningar på alla dina enheter.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Använder du redan Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Logga in på ditt konto och vi kommer att synkronisera bokmärken, lösenord och andra bra saker du har sparat till Firefox på andra enheter.
-
-
-;Learn more about Firefox Accounts
-Lär dig mer om Firefox-konton
-
-
-;Skip this step
-Hoppa över det här steget
-
-
-# Old firstrun page
-;Chart your own course
-Gå din egna väg
 
 

--- a/sw/firefox/campaign.lang
+++ b/sw/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Congrats! You’re using the latest version of Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refresh Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Free Web Browser
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/ta/firefox/campaign.lang
+++ b/ta/firefox/campaign.lang
@@ -1,25 +1,4 @@
-## active ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-வாழ்த்துக்கள்! நீங்கள் பயர்பாக்ஸின் புதிய பதிப்பை பயன்படுத்துகிறீர்கள்.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-சமீபத்திய வேகம் மற்றும் தனியுரிமைக்காக உங்கள் Firefoxஐப் <a href="%(url)s">புதுப்பிக்கவும்</a>.
-
-
-;You’re using a pre-release version of Firefox.
-நீங்கள் பயர்பாஃசின் தற்போதைய வெளியீட்டுக்கு முந்தைய பதிப்பினைப் பயன்படுத்துகிறீர்கள்.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -28,133 +7,6 @@ You’re using an insecure, outdated operating system <a href="%(url)s">no longe
 
 ;Fast for good.
 அதி வேகம் மிக நன்று.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-பயர்பாக்சு குவாண்டம் சந்தியுங்கள்
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-புதிது. அதி வேகம். மிக நன்று.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-இப்பொழுதே பதிவிறக்கு
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-பயர்பாக்க்ப் புதுப்பியுங்கள்
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-பயர்பாக்சை நிறுவுவதற்கு தயவுசெய்து <a href="%(url)s">இந்த வழிமுறைகளைப்</a> பின்பற்றவும்.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-மேம்பட்ட நிறுவல் தேர்வுகள் & பிற தளங்கள்
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-மேம்பட்ட நிறுவல் தேர்வுகள் & பிற தளங்கள்
-
-
-;Keep up with<br> all things Firefox.
-பயர்பாக்சின் அனைத்து நிகழ்வுகளிலும்<br> இணைந்திருங்கள்.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-<span>விண்டோசு இயங்குதளத்திற்கான</span> பயர்பாக்சை பதிவிறக்கவும்
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-<span> மேக் இயங்குதளத்திற்கான</span> பயர்பாக்சைப் பதிவிறக்கவும்
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-<span>இலினக்சு இயங்குதளத்திற்கான</span> பயர்பாக்சைப் பதிவிறக்கவும்
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-பிற இயக்குதளங்கள் & மொழிகளுக்கு பதிவிறக்குங்கள்
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-மற்றொரு மொழியில் பதிவிறக்குங்கள்
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-உங்கள் பதிவிறக்கம் தானாகவே தொடங்க வேண்டும். வேலை செய்யவில்லையா? <a id="%(id)s" href="%(fallback_url)s">மீண்டும் பதிவிறக்க முயற்சியுங்கள்</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-உங்கள் பதிவிறக்கம் தானாகவே தொடங்க வேண்டும். இல்லையெனில், <a id="%(id)s" href="%(fallback_url)s">இங்கே சொடுக்குங்கள்</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-இதைச் செய்வோம்!
-
-
-;Sync up with Firefox on mobile:
-கைபேசியில் பயர்பாக்சுடன் ஒத்திசையுங்கள்:
 
 
 # HTML page title prefix
@@ -170,14 +22,6 @@ We will not share, sell or use your email for any other purposes.
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 இலவசமான இணைய உலாவி, மொசில்லா பயர்பாக்சை பதிவிறக்கு. பயர்பாக்சு தனிநபர் கட்டுப்பாடுகளை இணையத்தில் வைத்திருக்க அர்பணிக்கப்பட்ட ஒரு சர்வதேச இலாப நோக்கமற்ற நிறுவனத்தால் உருவாக்கப்பட்டது. விண்டோஸ், macOS, இலினக்சு, ஆண்ட்ராய்டு மற்றும் iOS இயங்குதளங்களுக்கான பயர்பாக்சை இன்றே பெறுங்கள்!
-
-
-;Download the fastest Firefox ever
-எப்போதும் வேகமான பயர்பாக்சைப் பதிவிறக்கவும்
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-வேகமான பக்க ஏற்றம், குறைந்த நினைவகப் பயன்பாடு போன்ற அம்சங்கள் நிறைந்த, புதிய பயர்பாக்சு இதோ.
 
 
 ;2x Faster
@@ -202,41 +46,5 @@ We will not share, sell or use your email for any other purposes.
 
 ;Truly Private Browsing with Tracking Protection
 உண்மையான தடமறியல் பாதுகாப்புடன் கூடிய அந்தரங்க உலாவல்
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-பயர்பாக்சுக்கு வருக
-
-
-;Take Firefox with You
-பயர்பாக்சை உங்களுடன் எடுத்துச் செல்லுங்கள்
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-உங்கள் எல்லா கருவிகளிலும் உங்களின் புத்தகக்குறிகள், வரலாறு, கடவுச்சொற்கள் மற்றும் பிற அமைப்புகளைப் பெறுங்கள்.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-ஏற்கனவே பயர்பாக்சு பயன்படுத்துகிறீர்களா?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-உங்கள் கணக்கில் புகுபதியவும் நாங்கள் பிற கருவிகளின் பயர்பாக்சில் நீங்கள் சேமித்த புத்தக்குறிகள், கடவுச்சொற்கள் மற்ற பிற சிறந்த விசயங்களை ஒத்திசைப்போம்.
-
-
-;Learn more about Firefox Accounts
-பயர்பாக்சு பற்றி மேலும் தெரிந்துகொள்ளவும்
-
-
-;Skip this step
-இந்த படியைத் தாவவும்
-
-
-# Old firstrun page
-;Chart your own course
-உங்கள் பாதையை நீங்களே வரையவும்
 
 

--- a/ta/firefox/campaign.lang
+++ b/ta/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/te/firefox/campaign.lang
+++ b/te/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-అభినందనలు! మీరు సరికొత్త Firefox సంచికనే వాడుతున్నారు.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-వేగం మరియు గోప్యత విషయంలో కొత్తగా ఉండటానికి మీ Firefox ను<a href="%(url)s">నవీకరించండి</a>.
-
-
-;You’re using a pre-release version of Firefox.
-మీరు మును-విడుదల Firefox వెర్షను వాడుతున్నారు.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 కొత్త <strong>Firefox</strong>
 
 
 ;Fast for good.
 వేగం, మంచికి.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Firefox Quantumను కలవండి
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-కొత్తది. వేగవంతం. మంచికి.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-ఇప్పుడే దింపుకోండి
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox రిఫ్రెష్ చేయండి
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Firefox ను ఇన్స్టాల్ చేయడానికి దయచేసి <a href="%(url)s">ఈ సూచనలు</a> అనుసరించండి.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-అధునాతన స్థాపన ఎంపికలు మరియు ఇతర వేదికలు
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-అధునాతన స్థాపన ఎంపికలు మరియు ఇతర వేదికలు
-
-
-;Keep up with<br> all things Firefox.
-అన్ని Firefox విషయాలూ<br> ఎప్పటికప్పుడే తెలుసుకోండి.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-<span>Windows కొరకు</span> Firefoxను దింపుకోండి
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-<span>macOS కొరకు</span> Firefoxను దింపుకోండి
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-<span>Linux కొరకు</span> Firefoxను దింపుకోండి
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-ఇతర ప్లాట్‌ఫారాలకు & భాషలలో దించుకోండి
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-మరొక భాషలో దింపుకోండి
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-మీ దింపుకోలు ఆటోమెటిగ్గా మొదలవాలి. కాలేదా? <a id="%(id)s" href="%(fallback_url)s">మళ్ళీ దింపుకోడానికి ప్రయత్నించండి</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-మీ దింపుకోలు ఆటోమెటిగ్గా మొదలవాలి. ఒకవేళ కాకపోతే, <a id="%(id)s" href="%(fallback_url)s">ఇక్కడ నొక్కండి</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-మీ ఈమెయిలు చిరునామా ఇవ్వండి
-
-
-;How will Mozilla use my email?
-నా ఈమెయిలును మొజిల్లా ఎలా ఉపయోగిస్తుంది?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-మీరు ఏమి తెలుసుకోవాలని అనుకుంటున్నాం:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-చేద్దాం పదండి!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Firefoxను దింపుకోండి
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Mozilla Firefox, ఒక ఉచిత జాల విహారిణి డౌన్లోడు చేయండి. Firefox అనేది ఒక ప్రపంచ లాభాపేక్షలేని ఆన్లైన్ నియంత్రణ కోసం వ్యక్తులకు రూపొందించినారు. Windows, MacOS, Linux, Android మరియు iOS కోసం Firefox నేడు పొందవచ్చు!
-
-
-;Download the fastest Firefox ever
-సరికొత్త Firefoxను దించుకోండి
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Chrome కంటే 30% తక్కువ మెమొరీ వాడుకు
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Firefoxకి స్వాగతం
-
-
-;Take Firefox with You
-Firefoxని మీతో తీసుకెళ్ళండి
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-ఇప్పటికే Firefox ఉపయోగిస్తున్నారా?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Firefox ఖాతాల గురించి మరింత తెలుసుకోండి
-
-
-;Skip this step
-ఈ దశను దాటవేయి
-
-
-# Old firstrun page
-;Chart your own course
-మీ స్వంత కోర్సుతో చార్టుచేయండి
 
 

--- a/th/firefox/campaign.lang
+++ b/th/firefox/campaign.lang
@@ -1,24 +1,4 @@
-## active ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-ยินดีด้วย! คุณกำลังใช้ Firefox รุ่นล่าสุด
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">อัปเดต</a> Firefox ของคุณเพื่อให้ได้ความเร็วและความเป็นส่วนตัวล่าสุด
-
-
-;You’re using a pre-release version of Firefox.
-คุณกำลังใช้ Firefox รุ่นก่อนเปิดตัว
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -27,133 +7,6 @@ You’re using an insecure, outdated operating system <a href="%(url)s">no longe
 
 ;Fast for good.
 เร็วขึ้นดีขึ้น
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-พบกับ Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-ใหม่ เร็ว ดีขึ้น
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-ดาวน์โหลดเดี๋ยวนี้
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-ล้าง Firefox ใหม่
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-โปรดทำตาม<a href="%(url)s">คำแนะนำนี้</a>เพื่อติดตั้ง Firefox
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-ตัวเลือกการติดตั้งขั้นสูงและแพลตฟอร์มอื่น ๆ
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-ตัวเลือกการติดตั้งขั้นสูงและแพลตฟอร์มอื่น ๆ
-
-
-;Keep up with<br> all things Firefox.
-ตามทัน<br>เรื่องราวทุกอย่างของ Firefox
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-ดาวน์โหลด Firefox <span>สำหรับ Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-ดาวน์โหลด Firefox <span>สำหรับ macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-ดาวน์โหลด Firefox <span>สำหรับ Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Firefox สำหรับแพลตฟอร์มและภาษาอื่น
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-ดาวน์โหลดในภาษาอื่น
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-จะเริ่มดาวน์โหลดอัตโนมัติ ถ้าหากดาวน์โหลดไม่ได้ <a id="%(id)s" href="%(fallback_url)s">ลองดาวน์โหลดใหม่อีกครั้ง</a>
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-จะเริ่มดาวน์โหลดอัตโนมัติ หากยังไม่เริ่ม<a id="%(id)s" href="%(fallback_url)s">คลิกที่นี่</a>
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-เริ่มกันเลย
-
-
-;Sync up with Firefox on mobile:
-ซิงค์กับ Firefox บนอุปกรณ์เคลื่อนที่:
 
 
 # HTML page title prefix
@@ -169,14 +22,6 @@ We will not share, sell or use your email for any other purposes.
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 ดาวน์โหลด Mozilla Firefox เว็บเบราว์เซอร์ฟรี Firefox ถูกสร้างโดยองค์กรไม่แสวงผลกำไรในระดับโลกซึ่งอุทิศตัวเพื่อผลักดันการควบคุมในโลกออนไลน์ให้แต่ละคน รับ Firefox บน Windows, macOS, Linux, Android และ iOS วันนี้!
-
-
-;Download the fastest Firefox ever
-ดาวน์โหลด Firefox ตัวที่เร็วที่สุดตั้งแต่เคยมีมา
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-โหลดหน้าเว็บไวขึ้น ใช้หน่วยความจำน้อยลง และเต็มไปด้วยคุณสมบัติ Firefox ใหม่อยู่ที่นี่แล้ว
 
 
 ;2x Faster
@@ -201,41 +46,5 @@ Firefox ที่ดีที่สุดเท่าที่เคยมีม
 
 ;Truly Private Browsing with Tracking Protection
 การท่องเว็บแบบส่วนตัวที่แท้จริงพร้อมการป้องกันการติดตาม
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-ยินดีต้อนรับสู่ Firefox
-
-
-;Take Firefox with You
-นำ Firefox ไปกับคุณ
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-ใช้ Firefox อยู่แล้วหรือ ?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-ลงชื่อเข้าใช้บัญชีของคุณและเราจะชิงค์ที่คั่นหน้า รหัสผ่านและสิ่งดี ๆ อื่น ๆ ที่คุณบันทึกไว้ใน Firefox บนอุปกรณ์อื่น ๆ
-
-
-;Learn more about Firefox Accounts
-เรียนรู้เพิ่มเติมเกี่ยวกับบัญชี Firefox
-
-
-;Skip this step
-ข้ามขั้นตอนนี้
-
-
-# Old firstrun page
-;Chart your own course
-กำหนดวิถึชีวิตของคุณเอง
 
 

--- a/th/firefox/campaign.lang
+++ b/th/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/tl/firefox/campaign.lang
+++ b/tl/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Mabuhay! Ang Firefox mo ay ang pinakabagong bersyon
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Mabilis para sa kabutihan.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Kilalanin ang Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Bago. Mabilis. Para sa kabutihan.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-I-download Ngayon
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-I-refresh ang Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-I-download ang Firefox <span>para sa Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-I-download ang Firefox  <span>para sa macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-I-download ang Firefox  <span>para sa Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-I-download sa ibang wika
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Ano ang iyong email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Gawin natin ngayon!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Libreng Web Browser
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Mabuhay, ito ang Firefox
-
-
-;Take Firefox with You
-Dalhin ang Firefox saan man
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Gumagamit ka na ba ng Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Laktawan
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/tr/firefox/campaign.lang
+++ b/tr/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/tr/firefox/campaign.lang
+++ b/tr/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Tebrikler! Firefox’un son sürümünü kullanıyorsun.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-En yeni hız ve gizlilik özellikleri için Firefox’unu <a href="%(url)s">güncelle</a>.
-
-
-;You’re using a pre-release version of Firefox.
-Firefox’un yayımlanmamış bir sürümünü kullanıyorsun.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-<a href="%(url)s">Artık Firefox tarafından desteklenmeyen</a>, güvenli olmayan ve eski bir işletim sistemi kullanıyorsunuz.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Yeni <strong>Firefox</strong>
 
 ;Fast for good.
 İyi insanların tarayıcısı.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Firefox Quantum’la tanış
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Yeni. Hızlı. Çok güzel oldu.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Hemen indir
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox’u yenile
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Firefox’u yüklemek için lütfen <a href="%(url)s">bu yönergeleri</a> izle.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Gelişmiş yükleme seçenekleri ve diğer platformlar
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Gelişmiş yükleme seçenekleri ve diğer platformlar
-
-
-;Keep up with<br> all things Firefox.
-Firefox ile ilgili her<br> şeyden haberin olsun.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-<span>Windows için </span> Firefox’u indir
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-<span>macOS için </span> Firefox’u indir
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-<span>Linux için </span> Firefox’u indir
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Diğer platformlar ve diller için indir
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Başka bir dilde indir
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-İndirme işlemi birazdan kendiliğinden başlayacak. Başlamazsa <a id="%(id)s" href="%(fallback_url)s">yeniden indirmeyi dene</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-İndirme işlemi birazdan başlayacak. Başlamazsa <a id="%(id)s" href="%(fallback_url)s">buraya tıklayın</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Firefox’u daha akıllı, daha hızlı ve daha güvenli yapmayı öğren.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Bilgilendirici ipuçları, püf noktaları ve ürün duyuruları e-posta adresine gelsin.
-
-
-;Enter your email address
-E-posta adresinizi yazın
-
-
-;How will Mozilla use my email?
-Mozilla e-posta adresimi nasıl kullanacak?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-E-posta gizliliğiniz ve güvenliğiniz bizim için önemli. Hatta bu, <a href="%(manifesto)s">manifestomuzun</a> bir parçası: “Bireylerin internet üzerindeki güvenlikleri ve gizlilikleri esastır. Bunlar isteğe bağlıymış gibi muamele yapılamaz.” <a href="%(principles)s">Veri gizliliği ilkelerimiz hakkında daha bilgiyi burada bulabilirsiniz</a>.
-
-
-;What we want you to know:
-Şunu unutmayın:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Firefox’u indirmek ve kullanmak için e-posta adresinizi vermeniz gerekmez.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-E-posta adresinizi neden mi soruyoruz? Çünkü araştırmalar, tanıtıcı bir e-postayla işe başlayan kullanıcıların Firefox’u daha verimli kullandığını gösteriyor.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Size Firefox’u kendinize en uygun hale getirmenizi sağlayacak bilgiler, gizlilik ve güvenlik hakkında bilgiler, internette zamanınızı nasıl daha iyi geçirebileceğinize dair bilgiler içeren e-postalar göndereceğiz.
-
-
-;You can unsubscribe anytime, for any reason.
-İstediğiniz zaman aboneliğinizi iptal edebilirsiniz.
-
-
-;We will not share, sell or use your email for any other purposes.
-E-posta adresinizi paylaşmayacağız, satmayacağız ve başka bir amaçla kullanmayacağız.
-
-
-;Let’s do this!
-Başlıyoruz!
-
-
-;Sync up with Firefox on mobile:
-Firefox’u mobil cihazına da yükleyip verilerini eşitleyebilirsin:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Firefox’u indir
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Ücretsiz web tarayıcısı Mozilla Firefox’u indirin. Firefox, internette kontrolü elinizde tutmanızı isteyen, kâr amacı gütmeyen bir organizasyon tarafından yaratıldı. Firefox’u Windows, macOS, Linux, Android ve iOS’te kullanabilirsiniz.
-
-
-;Download the fastest Firefox ever
-Bugüne kadarki en hızlı Firefox'u indirin
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Daha hızlı açılan sayfalar, daha az bellek kullanımı ve bir sürü özelliğiyle yeni Firefox burada.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Sapasağlam gizlilik
 
 ;Truly Private Browsing with Tracking Protection
 İzlenme koruması ile gerçekten gizli gezinti
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Firefox’a hoş geldiniz
-
-
-;Take Firefox with You
-Firefox’u yanında taşı
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Yer imlerini, geçmişini, parolalarını ve diğer ayarlarını tüm cihazlarında kullanabilirsin.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Zaten Firefox mu kullanıyordun?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Hesabına giriş yaparsan diğer cihazlarında Firefox’a kaydettiğin yer imlerini, parolalarını ve diğer verilerini eşitleyebiliriz.
-
-
-;Learn more about Firefox Accounts
-Firefox Hesapları hakkında bilgi alın
-
-
-;Skip this step
-Bu adımı atla
-
-
-# Old firstrun page
-;Chart your own course
-Kendi yolunu çiz
 
 

--- a/trs/firefox/campaign.lang
+++ b/trs/firefox/campaign.lang
@@ -1,23 +1,4 @@
-## active ##
-## firefox_new_platform_link_text ##
-## firefox_quantum_new_headline ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-¡Nahuin nia' ruat! nga 'iaj sunt nga versión nakà guenda Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Nagi'iaj nakà</a> Firefox da' gi'iaj sun hiò man.
-
-
-;You’re using a pre-release version of Firefox.
-Hiàj raj huè versión na nga Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -26,133 +7,6 @@ Firefox <strong>Nakàa</strong>
 
 ;Fast for good.
 Hìo ga yitïnj man.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Gini'i doj dàj 'iaj sun Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Hua nakaj. Hua hìo. Huê dan ga yitïnj man.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Nadunïnj hiaj
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Nagui'iaj nako' Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Ganiko'<a href="%(url)s">nej nuguan' na</a> da' gi'iaj sunt nga Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Chrēj huāj ñan doj guendâ nādunïnjt nī a’ngô nej plataforma
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Chrēj huāj ñan doj guendâ nādunïnjt nī a’ngô nej plataforma
-
-
-;Keep up with<br> all things Firefox.
-Garasun nga <br> nuin si hua rayi'i Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Naduninj Firefox <span>guenda Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Naduninj Firefox <span>guenda macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Naduninj Firefox <span>guenda Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Nadunïnj guendâ a'ngô plataforma ngà nuguan'an
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Nadunïnj ngà a'ngô nuguan'an
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Sa nadunïnjt ni da'ui man gayi'ìj nanïnj man'an. Si se dan huin, <a id="%(id)s" href="%(fallback_url)s">guru'man ra'a hiuj nan</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-¡Ginù huîn'!
-
-
-;Sync up with Firefox on mobile:
-Nagi'iaj guñan Firefox nga aga' li nikajt:
 
 
 # HTML page title prefix
@@ -168,14 +22,6 @@ Nitaj si ru'ue' riña web na
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Naduninj Mozilla Firefox, web 'na chrê. Firefox 'iaj sun ni'ninj nga daran' nej digui' ruhua gache nun riña aga' na. ¡Hua Firefox guenda Windows, MacOS, Linux, Android ni iOS!
-
-
-;Download the fastest Firefox ever
-Nadunïnj Firefox 'iaj sun hìo
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Hìo doj na'nïn, ûta hua sa nika ni doj memoria araj sunj, huêj huin Firefox nakà ngà huaa.
 
 
 ;2x Faster
@@ -200,41 +46,5 @@ Araj sunt 30 % memoria dòj nga da' Chrome
 
 ;Truly Private Browsing with Tracking Protection
 Riña aché nu huì' hiô' nikaj sa dugumî ñù'
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Guruhuât gunumânt riña Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Ngà ayi’ìt arâj sunt Firefox aj
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Gayi’ì sesión ngà si kuendât nī nagi’iaj nuguàn’an ñûnj nej marcador, da’nga’ huìi nī a’ngô nej nuguan’ nachra sà’t riña a’ngô da’āj nej si agâ’t.
-
-
-;Learn more about Firefox Accounts
-Doj nuguan’ huā rayi’î nej si kuendâ Firefox
-
-
-;Skip this step
-Gūej yichrá chrēj nan
-
-
-# Old firstrun page
-;Chart your own course
-Naguī chrēj ruhuât gan’ānjt
 
 

--- a/trs/firefox/campaign.lang
+++ b/trs/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/uk/firefox/campaign.lang
+++ b/uk/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Вітаємо! Ви використовуєте найновішу версію Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Оновіть</a> свій Firefox для найкращої швидкодії та приватності.
-
-
-;You’re using a pre-release version of Firefox.
-Ви використовуєте версію Firefox, що знаходиться в розробці.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Ви використовуєте незахищену, застарілу операційну систему, <a href="%(url)s">яка більше не підтримується Firefox</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@
 
 ;Fast for good.
 Швидкість заради добрих справ.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Знайомтеся: Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Новий. Швидкий. Позитивний.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Завантажити зараз
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Відновити Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Дотримуйтесь <a href="%(url)s">цих вказівок</a> для встановлення Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Розширені опції встановлення й інші платформи
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Розширені опції встановлення й інші платформи
-
-
-;Keep up with<br> all things Firefox.
-Будьте в курсі усього,<br> що пов'язано з Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Завантажити Firefox <span>для Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Завантажити Firefox <span>для macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Завантажити Firefox <span>для Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Завантажити для інших платформ та мов
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Завантажити іншою мовою
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Завантаження повинно початися автоматично. Якщо ж цього не сталося<a id="%(id)s" href="%(fallback_url)s">, спробуйте ще раз</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Завантаження повинно початися автоматично. Якщо ж цього не сталося<a id="%(id)s" href="%(fallback_url)s">, натисніть сюди</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Дізнайтесь, як зробити Firefox ще розумнішим, швидшим і більш захищеним.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Отримуйте корисні поради, інформацію про цікаві особливості, а також оголошення про новинки на свою скриньку.
-
-
-;Enter your email address
-Введіть адресу своєї електронної пошти
-
-
-;How will Mozilla use my email?
-Як Mozilla використовуватиме мою електронну пошту?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla цінує не лише приватність та безпеку вашої електронної пошти – це частина нашого <a href="%(manifesto)s">Маніфесту</a>: “Безпека та приватність користувачів інтернету мають фундаментальне значення і не можуть розглядатися як другорядні.” <a href="%(principles)s">Ви можете ознайомитися з нашими принципами приватності даних тут</a>.
-
-
-;What we want you to know:
-Ми хочемо, щоб ви знали:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Вам не потрібно повідомляти свою адресу електронної пошти для завантаження і користування Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Ми запитуємо адресу вашої електронної пошти, тому що наше дослідження показує, що користувачі, які отримують ознайомлювальну інформацію, використовують більше можливостей Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Ви будете отримувати листи, з яких дізнаєтесь, як налаштувати Firefox для найзручнішого використання, прочитаєте докладніше про політику приватності та безпеки, а також знайдете відповідь на питання, як найкраще проводити свій час в мережі.
-
-
-;You can unsubscribe anytime, for any reason.
-Ви можете відписатись у будь-який час, незалежно від причини.
-
-
-;We will not share, sell or use your email for any other purposes.
-Ми не оприлюднюємо, не продаємо і не використовуємо вашу адресу електронної пошти для будь-яких інших цілей.
-
-
-;Let’s do this!
-Вперед!
-
-
-;Sync up with Firefox on mobile:
-Синхронізуйтесь з Firefox на мобільному:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Mozilla цінує не лише приватність та безпеку ва
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Завантажте вільний веб-браузер Mozilla Firefox. Він створений всесвітньою некомерційною організацією, яка віддана місії надання кожному можливості контролювати своє перебування в Інтернеті. Отримайте Firefox для Windows, macOS, Linux, Android та iOS сьогодні!
-
-
-;Download the fastest Firefox ever
-Завантажте найшвидшу з існуючих версій Firefox
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Швидкіше завантаження сторінок, менше використання пам'яті, безліч нових можливостей: це новий Firefox.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Mozilla цінує не лише приватність та безпеку ва
 
 ;Truly Private Browsing with Tracking Protection
 Дійсно приватний перегляд із захистом від стеження
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Ласкаво просимо у Firefox
-
-
-;Take Firefox with You
-Візьміть Firefox з собою!
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Ваші закладки, історія, паролі та інші налаштування завжди з вами - на всіх ваших пристроях.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Вже використовуєте Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Увійдіть до свого облікового запису і ми синхронізуємо всі ваші закладки, паролі та інші потрібні речі, які ви зберегли у Firefox на інших пристроях.
-
-
-;Learn more about Firefox Accounts
-Дізнайтеся більше про обліковий запис Firefox
-
-
-;Skip this step
-Пропустити цей крок
-
-
-# Old firstrun page
-;Chart your own course
-Самі визначте свій напрямок
 
 

--- a/uk/firefox/campaign.lang
+++ b/uk/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/ur/firefox/campaign.lang
+++ b/ur/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-مبارک ہو! آپ Firefox کا تازہ ترین ورژن استعمال کر رہے ہیں۔
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-آپ کے Firefox کو رفتار اور رازداری کے لئے <a href="%(url)s">تازہ کاری کریں</a>
-
-
-;You’re using a pre-release version of Firefox.
-آپ Firefox کا پہلے سے ریلز ورژن استعمال کر رہے ہے۔
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 نیا <strong>Firefox</strong>
 
 
 ;Fast for good.
 اچھے کے لئے تیز۔
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-ملیئے Firefox Quantum سے
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-ابھی ڈاؤن لوڈ کریں
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-فائرفاکس کو تازہ کریں
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Firefox تنصب کرنے کے لئے براہ مہربانی <a href="%(url)s">ان ہدایتوں</a> پر عمل کریں۔
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-اعلی درجے کے انسٹال اختیارات اور دیگر پلیٹ فارمز
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Firefox کے <br>ساتھ تمام چیزوں کے ساتھ تازہ رہے۔
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-ڈاؤن لوڈ Firefox <span>براۓ ونڈوز</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-ڈاؤن لوڈ Firefox <span>براۓ macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-ڈاؤن لوڈ Firefox <span>براۓ Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-دیگر پلیٹ فارم اور زبانوں کے لئے ڈائون لوڈ کریں
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-ایک اور زبان میں ڈائونلوڈ کریں
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-اپنا ای میل پتہ داخل کریں
-
-
-;How will Mozilla use my email?
-Mozilla میرا ای میل کیسے استعمال کرے گا؟
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-ہم آپ کو کیا جاننا چاہتے ہیں:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-چلو ایسا کرتے ہیں!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Firefox ڈاؤن لوڈ کریں
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Firefox میں خوش آمدید
-
-
-;Take Firefox with You
-Firefox کو اپنے ساتھ لیجائیں
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-پہلے سے Firefox استعمال کر رہے ہیں؟
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/uz/firefox/campaign.lang
+++ b/uz/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Tabriklaymiz! Siz hozirda "Firefox"ning eng so‘nggi versiyasidan foydalanyapsiz.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Firefox’ni yangilash
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Bepul internet brauzeri
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/vi/firefox/campaign.lang
+++ b/vi/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/vi/firefox/campaign.lang
+++ b/vi/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-Chúc mừng! Bạn đang sử dụng phiên bản Firefox mới nhất.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Cập nhật</a> Firefox để có tốc độ nhanh nhất và sự riêng tư nhất.
-
-
-;You’re using a pre-release version of Firefox.
-Bạn đang sử dụng một phiên bản tiền phát hành của Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-Bạn đang sử dụng một hệ điều hành lỗi thời, không an toàn và <a href="%(url)s">không còn được Firefox hỗ trợ nữa</a>.
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@ Bạn đang sử dụng một hệ điều hành lỗi thời, không an toàn v
 
 ;Fast for good.
 Nhanh và tốt hơn.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Gặp gỡ Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-Mới. Nhanh. Tốt hơn.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Tải xuống ngay
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Làm mới Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Xin làm theo <a href="%(url)s">những hướng dẫn sau</a> để cài đặt Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Tùy chọn cài đặt nâng cao & các nền tảng khác
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Tùy chọn cài đặt nâng cao & các nền tảng khác
-
-
-;Keep up with<br> all things Firefox.
-Theo kịp mọi thứ<br> với Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Tải xuống Firefox <span>cho Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Tải xuống Firefox <span>cho macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Tải xuống Firefox <span>cho Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Tải xuống cho các nền tảng và ngôn ngữ khác
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Tải xuống với ngôn ngữ khác
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Việc tải xuống sẽ diễn ra tự động. Nếu không, hãy <a id="%(id)s" href="%(fallback_url)s">nhấp vào đây</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Việc tải xuống sẽ diễn ra tự động. Nếu không, hãy <a id="%(id)s" href="%(fallback_url)s">nhấp vào đây</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Tìm hiểu cách làm cho Firefox thông minh hơn, nhanh hơn và an toàn hơn.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Nhận các mẹo thông tin, thủ thuật và thông báo sản phẩm được gửi đến hộp thư đến của bạn.
-
-
-;Enter your email address
-Nhập địa chỉ email của bạn
-
-
-;How will Mozilla use my email?
-Mozilla sẽ sử dụng email của tôi như thế nào?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla không chỉ coi trọng quyền riêng tư và bảo mật email của bạn – đó là một phần của<a href="%(manifesto)s">tuyên ngôn</a>: “Bảo mật và quyền riêng tư của cá nhân trên internet là cơ bản và không được xử lý dưới dạng tùy chọn.” <a href="%(principles)s">Bạn có thể tìm hiểu về Nguyên tắc bảo mật dữ liệu của chúng tôi tại đây</a>.
-
-
-;What we want you to know:
-Những gì chúng tôi muốn bạn biết:
-
-
-;You don’t need to give us your email to download and use Firefox.
-Bạn không cần phải cung cấp cho chúng tôi email của bạn để tải xuống và sử dụng Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-Chúng tôi đã yêu cầu email của bạn vì nghiên cứu của chúng tôi cho thấy rằng những người nhận được trải nghiệm giới thiệu sẽ làm nhiều hơn và tốt hơn với Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-Bạn có thể chờ đợi các email được thiết kế để giúp bạn tối ưu hóa Firefox để hoạt động tốt nhất cho bạn, tìm hiểu thêm về quyền riêng tư & bảo mật và tìm hiểu cách tận dụng thời gian tốt nhất trên web.
-
-
-;You can unsubscribe anytime, for any reason.
-Bạn có thể hủy đăng ký bất cứ lúc nào, vì bất kỳ lý do nào.
-
-
-;We will not share, sell or use your email for any other purposes.
-Chúng tôi sẽ không chia sẻ, bán hoặc sử dụng email của bạn cho bất kỳ mục đích nào khác.
-
-
-;Let’s do this!
-Làm thôi!
-
-
-;Sync up with Firefox on mobile:
-Đồng bộ với Firefox trên di động:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Trình duyệt web miễn phí
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Tải xuống Mozilla Firefox, một trình duyệt web miễn phí. Firefox được tạo ra bởi một tổ chức phi lợi nhuận toàn cầu giúp mỗi cá nhân có quyền kiểm soát trực tuyến. Tải xuống Firefox cho Windows, macOS, Linux, Android và iOS hôm nay!
-
-
-;Download the fastest Firefox ever
-Tải ngay Firefox nhanh hơn bao giờ hết
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Tải trang nhanh hơn, sử dụng ít bộ nhớ hơn và có nhiều tính năng, Firefox mới có ở đây.
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Riêng tư mạnh mẽ
 
 ;Truly Private Browsing with Tracking Protection
 Duyệt web riêng tư thực sự với Trình chống theo dõi
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Chào mừng đến với Firefox
-
-
-;Take Firefox with You
-Mang Firefox theo bên bạn
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Đồng bộ các dấu trang, lịch sử, mật khẩu và các cài đặt khác lên tất cả các thiết bị của bạn.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Đã từng sử dụng Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Đăng nhập vào tài khoản của bạn và chúng tôi sẽ đồng bộ trang đánh dấu, mật khẩu và những thứ tuyệt vời khác bạn đã lưu vào Firefox trên các thiết bị khác nhau.
-
-
-;Learn more about Firefox Accounts
-Tìm hiểu thêm về các tài khoản Firefox
-
-
-;Skip this step
-Bỏ qua bước này
-
-
-# Old firstrun page
-;Chart your own course
-Lập biểu đồ khóa học của riêng bạn
 
 

--- a/wo/firefox/campaign.lang
+++ b/wo/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Congrats! You’re using the latest version of Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refresh Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Free Web Browser
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/xh/firefox/campaign.lang
+++ b/xh/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Halala! Usebenzisa uhlelo lwamvanje lweFirefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Hlaziya</a>iFirefox ukuze ufumane isantya nobungasese bakutshanje.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Hlaziya u-Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Nceda ulandele<a href="%(url)s">le miyalelo</a> ukuze ufakele iFirefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Hambisana ne<br> zonke izinto zeFirefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Ibhrawuza yewebhu yasimahla
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Wamkelekile kwiFirefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/zam/firefox/campaign.lang
+++ b/zam/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Congrats! You’re using the latest version of Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-B-lày nál
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Lí kúb Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-B-là Firefox <span>lent Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-B-là Firefox <span>lent macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-B-là Firefox <span>lent GNU-Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-B-là=y tá thîb dízh
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Gú len? Internet
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Bestá dîed lù lenɁ Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 

--- a/zh-CN/firefox/campaign.lang
+++ b/zh-CN/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/zh-CN/firefox/campaign.lang
+++ b/zh-CN/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-太好了！您正在使用最新版本的 Firefox。
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">更新</a>您的 Firefox 至最新版本获得最佳的速度和隐私保障。
-
-
-;You’re using a pre-release version of Firefox.
-您正在使用 Firefox 的预发布版本。
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-您正在使用一个不安全、已过时的操作系统。<a href="%(url)s">Firefox 已停止支持 </a>。
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@
 
 ;Fast for good.
 快，只为更好。
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-遇见 Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-更新、更快、更好
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-立即下载
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-翻新 Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-请按照<a href="%(url)s">这些步骤</a>安装 Firefox。
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-高级安装选项和其他平台
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-高级安装选项和其他平台
-
-
-;Keep up with<br> all things Firefox.
-了解 Firefox<br>有哪些新变化。
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-下载 Firefox <span>Windows 版</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-下载 Firefox <span>macOS 版</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-下载 Firefox <span>Linux 版</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-适合其他平台和语言版本下载
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-下载其他语言版本
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-您的下载即将自动开始。并没有开始？<a id="%(id)s" href="%(fallback_url)s">重试下载</a>。
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-您的下载将自动开始。如果没有，<a id="%(id)s" href="%(fallback_url)s">点击这里</a>。
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-了解如何让 Firefox 变得更智能、更快、更安全。
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-为您的收件箱订阅提示信息、技巧以及产品公告。
-
-
-;Enter your email address
-请输入您的电子邮件地址
-
-
-;How will Mozilla use my email?
-Mozilla 将如何使用我的邮件地址？
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla 不仅重视您的电子邮件隐私与安全性，更是已经铭记于我们的<a href="%(manifesto)s">宣言</a>当中：“用户在互联网上的安全和隐私保护是基本要求，不可忽视。”您可以<a href="%(principles)s">了解我们的数据隐私原则</a>。
-
-
-;What we want you to know:
-我们想告诉您：
-
-
-;You don’t need to give us your email to download and use Firefox.
-下载和使用 Firefox 不需要您提供电子邮件地址。
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-我们向您询问电子邮件地址是因为，我们的研究表明，获得体验介绍的用户使用 Firefox 时会更加得心应手。
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-您会收到帮助您优化 Firefox 以最适合您的电子邮件，还可了解更多有关隐私与安全的信息，以及如何充分利用时间来畅享网络。
-
-
-;You can unsubscribe anytime, for any reason.
-您可以出于任何原因，随时取消订阅。
-
-
-;We will not share, sell or use your email for any other purposes.
-我们不会为任何其他目的而分享、出售或使用您的电子邮件地址。
-
-
-;Let’s do this!
-我们出发吧！
-
-
-;Sync up with Firefox on mobile:
-与手机版 Firefox 同步：
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Mozilla 不仅重视您的电子邮件隐私与安全性，更是已经铭记于
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 下载免费的网络浏览器 Mozilla Firefox。Firefox 由致力于让每个人都能自行控制网络生活的全球性非营利社区打造。立即下载用于 Windows、macOS、Linux、Android 以及 iOS 的 Firefox 吧！
-
-
-;Download the fastest Firefox ever
-下载有史以来最快的 Firefox
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-加载更快、内存占用更低、包含更多功能。全新的 Firefox 闪耀登场！
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Mozilla 不仅重视您的电子邮件隐私与安全性，更是已经铭记于
 
 ;Truly Private Browsing with Tracking Protection
 具有跟踪保护功能的隐私浏览
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-欢迎使用 Firefox
-
-
-;Take Firefox with You
-随身携带 Firefox
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-在您的所有设备上获取您的书签、历史记录、密码以及其他设置。
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Firefox 的老朋友？
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-登录您的账户后，我们会为您把书签、密码等等您在其他设备上存在 Firefox 里的好东西同步过来。
-
-
-;Learn more about Firefox Accounts
-详细了解 Firefox 账户
-
-
-;Skip this step
-跳过此步骤
-
-
-# Old firstrun page
-;Chart your own course
-走出自己的路
 
 

--- a/zh-TW/firefox/campaign.lang
+++ b/zh-TW/firefox/campaign.lang
@@ -1,26 +1,4 @@
-## active ##
-## download_thanks_newsletter_092018 ##
-## firefox_new_platform_link_text ##
-## firefox_new_try_again_link_020818 ##
-## firefox_quantum_new_headline ##
-## firstrun_email_only_form ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
-
-
-;Congrats! You’re using the latest version of Firefox.
-恭喜您！您使用的是最新版的 Firefox。
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">更新</a> 您的 Firefox 取得最新的效能改善與隱私保護功能。
-
-
-;You’re using a pre-release version of Firefox.
-您使用的是尚未正式發行的 Firefox。
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-您正在使用的是 <a href="%(url)s">Firefox 已停止支援</a>，也不安全的過時作業系統。
 
 
 ;The new <strong>Firefox</strong>
@@ -29,133 +7,6 @@
 
 ;Fast for good.
 更快、更多好事。
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-認識 Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-全新、速度更快、作好事。
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-立刻下載
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-重新整理 Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-請依照 <a href="%(url)s">下列步驟</a> 安裝 Firefox。
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-進階安裝選項及其他平台
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-進階安裝選項及其他平台
-
-
-;Keep up with<br> all things Firefox.
-了解 Firefox<br>有哪些不同。
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-下載 Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-下載 Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-下載 Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-下載其他平台與語言版本
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-下載其他語言版本
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-將自動開始下載，若沒有的話請<a id="%(id)s" href="%(fallback_url)s">點擊此處再試一次</a>。
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-將自動開始下載，若沒有的話請<a id="%(id)s" href="%(fallback_url)s">點擊此處</a>。
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-了解如何讓 Firefox 變得更聰明、更快、更安全。
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-訂閱電子報，讓使用小祕訣、產品公告直達您的收件匣。
-
-
-;Enter your email address
-輸入您的電子郵件地址
-
-
-;How will Mozilla use my email?
-Mozilla 會如何使用我的信箱資料？
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla 不僅重視您的 E-Mail 隱私與安全性，更是已經銘記於我們的<a href="%(manifesto)s">宣言</a>當中:「使用者的網路安全及隱私為基本要求，不能妥協。」<a href="%(principles)s">您可在此瞭解我們的隱私資料處理原則</a>。
-
-
-;What we want you to know:
-我們想告訴您:
-
-
-;You don’t need to give us your email to download and use Firefox.
-不需要提供您的 E-Mail 信箱，也能下載使用 Firefox。
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-我們會向您請求 E-Mail 信箱，是因為根據研究發現，若人們可以收到關於 Firefox 的簡介，可以用得更好。
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-您會收到設計來幫助您有 Firefox 最佳使用體驗的郵件，並可更加了解隱私權、安全性，以及能如何在網路上更加善用時間。
-
-
-;You can unsubscribe anytime, for any reason.
-您可以因為任何原因，隨時退訂。
-
-
-;We will not share, sell or use your email for any other purposes.
-我們不會因電子報以外的理由，透露、賣掉或使用您的 E-Mail 信箱。
-
-
-;Let’s do this!
-一起出發吧！
-
-
-;Sync up with Firefox on mobile:
-在行動裝置上也同步使用 Firefox:
 
 
 # HTML page title prefix
@@ -171,14 +22,6 @@ Mozilla 不僅重視您的 E-Mail 隱私與安全性，更是已經銘記於我�
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 下載免費的網頁瀏覽器 Mozilla Firefox。Firefox 是由致力於讓每個人都能自行控制線上生活的全球性非營利社群所打造的。立刻下載 Firefox for Windows、macOS、Linux、Android 或 iOS！
-
-
-;Download the fastest Firefox ever
-下載有史以來最快的 Firefox
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-全新的 Firefox 來了！頁面載入更快、記憶體用量更少，還有更多不同功能。
 
 
 ;2x Faster
@@ -203,41 +46,5 @@ Mozilla 不僅重視您的 E-Mail 隱私與安全性，更是已經銘記於我�
 
 ;Truly Private Browsing with Tracking Protection
 包含追蹤保護功能的隱私瀏覽
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-歡迎使用 Firefox
-
-
-;Take Firefox with You
-Firefox 隨身帶著走
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-在您的任何裝置上取得書籤、瀏覽紀錄、密碼及其他設定。
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-已經在使用 Firefox 了嗎？
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-登入帳號後，我們就會同步書籤、密碼，以及您在其他裝置上的 Firefox 存下來的好東西。
-
-
-;Learn more about Firefox Accounts
-了解 Firefox Accounts 的更多資訊
-
-
-;Skip this step
-跳過這步
-
-
-# Old firstrun page
-;Chart your own course
-以您的方式使用
 
 

--- a/zh-TW/firefox/campaign.lang
+++ b/zh-TW/firefox/campaign.lang
@@ -1,3 +1,4 @@
+## active ##
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 

--- a/zu/firefox/campaign.lang
+++ b/zu/firefox/campaign.lang
@@ -1,155 +1,12 @@
 ## NOTE: Demo page at https://www-dev.allizom.org/firefox/campaign/
 
 
-;Congrats! You’re using the latest version of Firefox.
-Congrats! You’re using the latest version of Firefox.
-
-
-;<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.
-
-
-;You’re using a pre-release version of Firefox.
-You’re using a pre-release version of Firefox.
-
-
-;You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
-
-
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
 ;Fast for good.
 Fast for good.
-
-
-# String is obsolete. Do note remove.
-;Meet Firefox Quantum
-Meet Firefox Quantum
-
-
-# String is obsolete. Do note remove.
-;New. Fast. For good.
-New. Fast. For good.
-
-
-# Link points to /firefox/new/?scene=2
-;Download Now
-Download Now
-
-
-# Link points to https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings
-;Refresh Firefox
-Refresh Firefox
-
-
-# Link points to https://support.mozilla.org/kb/install-firefox-linux
-;Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-Please follow <a href="%(url)s">these instructions</a> to install Firefox.
-
-
-# Title displayed in the modal window for advanced options.
-# The different case is to let localizers use a different translation (or case) from the link, if needed
-;Advanced Install Options & Other Platforms
-Advanced Install Options & Other Platforms
-
-
-# Link to display the advanced install panel
-;Advanced install options & other platforms
-Advanced install options & other platforms
-
-
-;Keep up with<br> all things Firefox.
-Keep up with<br> all things Firefox.
-
-
-# Link Span is for visual formatting and line break.
-;Download Firefox <span>for Windows</span>
-Download Firefox <span>for Windows</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for macOS</span>
-Download Firefox <span>for macOS</span>
-
-
-# Span is for visual formatting and line break.
-;Download Firefox <span>for Linux</span>
-Download Firefox <span>for Linux</span>
-
-
-# Link points to /firefox/all/
-;Download for other platforms & languages
-Download for other platforms & languages
-
-
-# The string is obsolete. Do not remove.
-# Link points to /firefox/all/
-;Download in another language
-Download in another language
-
-
-;Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-Your download should begin automatically. Didn’t work? <a id="%(id)s" href="%(fallback_url)s">Try downloading again</a>.
-
-
-# Obsolete string, DO NOT REMOVE
-;Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-Your download should begin automatically. If it doesn’t, <a id="%(id)s" href="%(fallback_url)s">click here</a>.
-
-
-;Learn how to make Firefox even smarter, faster and more secure.
-Learn how to make Firefox even smarter, faster and more secure.
-
-
-;Get informative tips, tricks and product announcements delivered to your inbox.
-Get informative tips, tricks and product announcements delivered to your inbox.
-
-
-;Enter your email address
-Enter your email address
-
-
-;How will Mozilla use my email?
-How will Mozilla use my email?
-
-
-;Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="%(manifesto)s">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="%(principles)s">You can learn about our Data Privacy Principles here</a>.
-
-
-;What we want you to know:
-What we want you to know:
-
-
-;You don’t need to give us your email to download and use Firefox.
-You don’t need to give us your email to download and use Firefox.
-
-
-;We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.
-
-
-;You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.
-
-
-;You can unsubscribe anytime, for any reason.
-You can unsubscribe anytime, for any reason.
-
-
-;We will not share, sell or use your email for any other purposes.
-We will not share, sell or use your email for any other purposes.
-
-
-;Let’s do this!
-Let’s do this!
-
-
-;Sync up with Firefox on mobile:
-Sync up with Firefox on mobile:
 
 
 # HTML page title prefix
@@ -165,14 +22,6 @@ Free Web Browser
 # HTML page description
 ;Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
 Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!
-
-
-;Download the fastest Firefox ever
-Download the fastest Firefox ever
-
-
-;Faster page loading, less memory usage and packed with features, the new Firefox is here.
-Faster page loading, less memory usage and packed with features, the new Firefox is here.
 
 
 ;2x Faster
@@ -197,41 +46,5 @@ Powerfully private
 
 ;Truly Private Browsing with Tracking Protection
 Truly Private Browsing with Tracking Protection
-
-
-# These strings are used in /firstrun, e.g. https://www-dev.allizom.org/firefox/56.0/firstrun/
-;Welcome to Firefox
-Welcome to Firefox
-
-
-;Take Firefox with You
-Take Firefox with You
-
-
-;Get your bookmarks, history, passwords and other settings on all your devices.
-Get your bookmarks, history, passwords and other settings on all your devices.
-
-
-# Obsolete string, DO NOT REMOVE
-;Already using Firefox?
-Already using Firefox?
-
-
-# Obsolete string, DO NOT REMOVE
-;Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.
-
-
-;Learn more about Firefox Accounts
-Learn more about Firefox Accounts
-
-
-;Skip this step
-Skip this step
-
-
-# Old firstrun page
-;Chart your own course
-Chart your own course
 
 


### PR DESCRIPTION
Removes unneeded strings from `firefox/campaign.lang`, leaving only the strings required for this page: https://bedrock-demo-agibson.oregon-b.moz.works/en-US/firefox/campaign/

