### PR TITLE
Update strings for accounts page

### DIFF
--- a/ach/firefox/accounts-2018.lang
+++ b/ach/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/af/firefox/accounts-2018.lang
+++ b/af/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/am/firefox/accounts-2018.lang
+++ b/am/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/an/firefox/accounts-2018.lang
+++ b/an/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/ar/firefox/accounts-2018.lang
+++ b/ar/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 زامِن بأمان كلّ من كلمات السر والعلامات والألسنة عبر الأجهزة لديك. سجّل حساب فَيَرفُكس لك – بولوج واحد تمتلك القدرة والخصوصية في كل مكان.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 بولوج واحد تمتلك القدرة والخصوصية في كل مكان.
 
@@ -46,6 +57,11 @@
 نزِّل تطبيق Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 لا مزيد من تسجيل الخروج بالتطبيقات والمواقع، Lockbox يؤمن كل كلمات السر المحفوظة بفَيَرفُكس، ويعطيك وصول سريع عبر كل أجهزة iOS.
 
@@ -86,11 +102,6 @@
 امسح رمز QR لتزيل تطبيق بوكِت على جهازك المحمول.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-امسح رمز QR لتزيل تطبيق Lockbox على جهاز آبل.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 امسح رمز QR لتزيل تطبيق Lockbox على جهازك المحمول.
 
@@ -133,5 +144,21 @@
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 إعداد خدمة «تزامن» <br>على جهاز أندرويد
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/as/firefox/accounts-2018.lang
+++ b/as/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/ast/firefox/accounts-2018.lang
+++ b/ast/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/az/firefox/accounts-2018.lang
+++ b/az/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Lockbox Tətbiqini endirin
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Pocket Tətbiqini mobil cihazınıza endirmək üçün QR Kodu oxudun.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Lockbox Tətbiqini Apple cihazınıza endirmək üçün QR Kodu oxudun.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Lockbox Tətbiqini mobil cihazınıza endirmək üçün QR Kodu oxudun.
 
@@ -131,5 +142,21 @@ iOS üçün Sinxronlaşdırmanı qurun
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Sinxronlaşdırmanı<br>Android cihazınızda qurun
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/azz/firefox/accounts-2018.lang
+++ b/azz/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/be/firefox/accounts-2018.lang
+++ b/be/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Бяспечна сінхранізуйце свае паролі, закладкі і карткі паміж усімі сваімі прыладамі. Атрымайце ўліковы запіс Firefox зараз – Адзіны ўваход – Моц і прыватнасць усюды.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Адзіны ўваход у сістэму. Моц і прыватнасць усюды.
 
@@ -46,6 +57,11 @@
 Атрымайце праграму Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Канец згубам доступу да праграм і вэб-сайтаў. Lockbox трымае ў бяспецы ўсе паролі, якія вы захавалі ў Firefox, і дае вам просты доступ на ўсіх вашых iOS-прыладах.
 
@@ -86,11 +102,6 @@
 Скануйце QR-код для сцягвання праграмы Pocket на вашу мабільную прыладу.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Скануйце QR-код для сцягвання праграмы Lockbox на вашу прыладу Apple.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Скануйце QR-код для сцягвання праграмы Lockbox на вашу мабільную прыладу.
 
@@ -133,5 +144,21 @@
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Наладзіць Sync на вашай <br>Android прыладзе
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/bg/firefox/accounts-2018.lang
+++ b/bg/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/bn-BD/firefox/accounts-2018.lang
+++ b/bn-BD/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Firefox Account ব্যবহার করুন – আপনা তথ্য
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 সব ডিভাইসে আপনার পাসওয়ার্ড, বুকমার্ক, এবং ট্যাব নিরাপদে সিঙ্ক করুন। এখনই Firefox একাউন্ট তৈরী করুন – একটিমাত্র লগ-ইন – শক্তি আর গোপনীয়তা সব জায়গায়।
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 এক লগ-ইন। সর্বত্র শক্তি এবং গোপনীয়তা।
 
@@ -46,6 +57,11 @@ Lockbox এ আপনার পাসওয়ার্ড মনে রাখ�
 Lockbox ব্যবহার করুন
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 আর নয় ওয়েবসাইট কিংবা অ্যাপ থেকে লক আউট হয়ে যাওয়া। Firefox এ সংরক্ষণ করে রাখা আপনার সকল পাসওয়ার্ড সুরক্ষিত করবে লকবক্স আর আপনার সকল iOS ডিভাইসে দেবে সহজ প্রবেশাধিকার।
 
@@ -86,11 +102,6 @@ Notes এর মাধ্যমে আপনার ধারনা ও অনু
 আপনার মোবাইল ডিভাইসে Pocket App টি ডাউনলোড করতে QR Code স্ক্যান করুন।
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-আপনার অ্যাপল ডিভাইসে লকবক্স অ্যাপ ডাউনলোড করতে QR কোডটি স্ক্যান করুন।
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 আপনার মোবাইল ডিভাইসে Lockbox App টি ডাউনলোড করতে QR Code স্ক্যান করুন।
 
@@ -133,5 +144,21 @@ iOS এর জন্য সিঙ্ক সেট আপ করুন
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 আপনার Android ডিভাইসে <br>সিঙ্ক সেট আপ করুন
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/bn-IN/firefox/accounts-2018.lang
+++ b/bn-IN/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/br/firefox/accounts-2018.lang
+++ b/br/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/bs/firefox/accounts-2018.lang
+++ b/bs/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Napravite Firefox račun – Čuvajte svoje podatke kao privatne, sigurne i sinh
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Sigurno sinhronizujte svoje lozinke, oznake i tabove na svim svojim uređajima. Napravite Firefox račun – Jedna prijava – Snaga i privatnost svuda.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Jedna prijava. Moć i privatnost svuda.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/ca/firefox/accounts-2018.lang
+++ b/ca/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/cak/firefox/accounts-2018.lang
+++ b/cak/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Tik'ul jun Rub'i' Rutaqoya'l Firefox – Kejike' chuqa' kexime' ri ichinan taq a
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Jikïl ke'axima' konojel ri ewan taq atzij, taq yaketal chuqa' taq ruwi' pa ronojel okisab'äl. Tak'ulu' jun Rub'i' Ataqoya'l richin Firefox – Xa jun rutikirib'axik molojri'ïl – Uchuq'ab'il chuqa' ichinanem pa ronojel k'ojlib'äl.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Jun rutikirisaxik molojri'ïl. Uchuq'ab'il chuqa' ichinanem pa ronojel k'ojlib'äl.
 
@@ -46,6 +57,11 @@ Ke'anataj ri ewan taq atzij pa Lockbox
 Tik'ul ri Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Mani chik q'atoj taq chokoy chuqa' ajk'amaya'l taq ruxaq. Lockbox yeruchajij ronojel ri ewan taq tzij e'ayakon pa Firefox chuqa'  anin nuya' q'ij chawe yatok pa ri taq awokisab'al richin iOSl
 
@@ -86,11 +102,6 @@ Ri taq ana'ojib'al chuqa' taq atzij e jikïl chuqa' ewan kisik'ixik pa Notes –
 Tatz'ajwachib'ej ri QR b'itz'ib' richin naqasaj ri Ruchokoy Pocket pan awoyonib'al.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Tatz'ajwachib'ej ri QR b'itz'ib' richin naqasaj ri Lockbox App pan awoyonib'al.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Tatz'ajwachib'ej ri QR b'itz'ib' richin naqasaj ri Ruchokoy Lockbox pan awoyonib'al.
 
@@ -133,5 +144,21 @@ Tinuk'ub'ëx ri Ximojriïl richin iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Tinuk'ub'ëx Sync pa <br>Android okisab'äl
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/crh/firefox/accounts-2018.lang
+++ b/crh/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/cs/firefox/accounts-2018.lang
+++ b/cs/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Získejte účet Firefoxu – uchovejte svá data v bezpečí a synchronizovaná
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Bezpečně synchronizujte svá hesla, záložky a panely na všechna vaše zařízení. Získejte účet Firefoxu dnes – jedno přihlášení – možnosti a soukromí všude.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Jedno přihlášení. Možnosti a soukromí všude.
 
@@ -46,6 +57,11 @@ Uložte si svá hesla do Lockboxu
 Získejte aplikaci Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Už nikdy nebudete vzpomínat na heslo od svých účtů. Lockbox zabezpečí všechna vaše hesla uložená ve Firefoxu a dá vám k ním snadný přístup na všech zařízeních s iOS.
 
@@ -86,11 +102,6 @@ Vaše nápady zůstanou v Notes uložené bezpečně šifrovaně. A pokud se př
 Naskenujte QR kód a stáhněte si Pocket do svého zařízení.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Naskenujte QR kód a stáhněte si Lockbox do svého zařízení od Applu.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Naskenujte QR kód a stáhněte si Lockbox do svého zařízení.
 
@@ -133,5 +144,21 @@ Nastavte si Sync pro iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Nastavte si Sync <br>pro své zařízení s Androidem
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/cy/firefox/accounts-2018.lang
+++ b/cy/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Defnyddiwch Gyfrif Firefox - Cadwch eich data'n breifat, yn ddiogel ac wedi ei g
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Cydweddwch eich cyfrineiriau, eich nodau tudalen a'ch tabiau yn ddiogel ar draws eich holl ddyfeisiau. Defnyddiwch Gyfrif Firefox nawr - Un mewngofnod - Pŵer a phreifatrwydd ymhobman.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Un mewngofnod. Pŵer a phreifatrwydd ym mhobman.
 
@@ -46,6 +57,11 @@ Cofio eich cyfrineiriau yn Lockbox
 Estyn yr Ap Lockerbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Dim mwy o gael eich cloi allan o apiau a gwefannau. Mae Lockbox yn diogelu'r cyfrineiriau rydych chi wedi'u cadw yn Firefox ac yn rhoi mynediad hawdd i chi ar draws eich holl ddyfeisiau iOS.
 
@@ -86,11 +102,6 @@ Mae eich syniadau a'u hysbrydoliaeth yn ddiogel ac wedi'u hamgryptio gyda Notes 
 Sganiwch y cod QR i lwythoi'r ap Pocket i lawr ar eich dyfais symudol.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Sganiwch y Code QR i lwytho i lawr yr Ap Lockerbox ar eich dyfais Apple.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Sganiwch y cod QR i lwythoi'r ap Lockboxi lawr ar eich dyfais symudol.
 
@@ -133,5 +144,21 @@ Gosod Sync ar gyfer iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Gosod Sync ar eich <br>dyfais Android
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/da/firefox/accounts-2018.lang
+++ b/da/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Få en Firefox-konto – Hold dine data private, sikre og synkroniserede
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Synkroniser dine adgangskoder, bogmærker og faneblade sikkert på alle dine enheder. Få en Firefox-konto nu – Et login – Tag kontrollen og beskyt dit privatliv overalt.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Tag kontrollen og beskyt dit privatliv overalt.
 
@@ -46,6 +57,11 @@ Gem dine adgangskoder i Lockbox
 Hent Lockbox-appen
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Slut med at blive låst ude af apps og websteder. Lockbox sikrer alle de adgangskoder, du har gemt i Firefox, og giver dig nem adgang fra alle dine iOS-enheder.
 
@@ -86,11 +102,6 @@ Dine idéer og inspiration er sikret og krypteret med Notes – og de synkronise
 Scan QR-koden for at hente Pocket-appen på din mobile enhed.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan QR-koden for at hente Lockbox-appen på din Apple-enhed.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan QR-koden for at hente Lockbox-appen på din mobile enhed.
 
@@ -133,5 +144,21 @@ Opsæt Sync til iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Opsæt Sync på din <br>Android-enhed
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/de/firefox/accounts-2018.lang
+++ b/de/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Dein Firefox-Konto synchronisiert deine Daten sicher auf allen Geräten
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Synchronisiere Passwörter, Lesezeichen und Tabs sicher auf allen deinen Geräten. Hol dir dein Firefox-Konto: Ein Login. So viele Features.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Ein Konto. So viele Features.
 
@@ -46,6 +57,11 @@ Sichere Passwörter in Lockbox
 Hol dir die Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Passwörter merken, kannst du vergessen. Lockbox sichert deine gespeicherten Passwörter für dich, sodass du über alle deine iOS-Geräte darauf zugreifen kannst.
 
@@ -86,11 +102,6 @@ Deine Ideen bleiben mit Notes sicher und verschlüsselt. Synchronisiere sie einf
 Scanne den QR-Code, um die Pocket App auf dein Mobilgerät herunterzuladen.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scanne den QR-Code, um die Lockbox App auf dein Apple-Gerät herunterzuladen.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scanne den QR-Code, um die Lockbox App auf dein Mobilgerät herunterzuladen.
 
@@ -133,5 +144,21 @@ Sync für iOS einrichten
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Sync für dein <br>Android-Gerät einrichten
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/dsb/firefox/accounts-2018.lang
+++ b/dsb/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Wobstarajśo se konto Firefox - Źaržćo swóje daty priwatne, wěste a synchro
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Synchronizěrujśo swóje gronidła, cytańske znamjenja a rejtarki wěsće pśez wšykne swóje rědy. Wobstarajśo se nowe konto Firefox - Jadno pśizjawjenje - wugbaśe a priwatnosć wšuźi.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Jadno pśizjawjenje. Wugbaśe a priwatnosć wšuźi.
 
@@ -46,6 +57,11 @@ Składujśo swóje gronidła w Lockbox
 Nałoženje Lockbox wobstaraś
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Njebuźćo nigda wěcej z nałoženjow a websedłow wuzamknjony. Lockbock zawěsćujo wšykne waše gronidła, kótarež sćo składł w Firefox a dajo wam lažki pśistup pśez wšykne waše rědy iOS.
 
@@ -86,11 +102,6 @@ Waše ideje a waša inspiracija stej wěste a z Notes skoděrowane - a gaž sćo
 Skannujśo QR-kod, aby nałoženje Pocket na waš mobilny rěd ześěgnuł.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Skannujśo QR-kod, aby nałoženje Lockbox do swójogo rěda Apple ześěgnuł.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Skannujśo QR-kod, aby nałoženje Lockbox na waš mobilny rěd ześěgnuł.
 
@@ -133,5 +144,21 @@ Zarědujśo Sync za iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Zarědujśo Sync na wašom <br>rěźe za Android
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/el/firefox/accounts-2018.lang
+++ b/el/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Μία σύνδεση. Ισχύς και απόρρητο παντού.
 
@@ -44,6 +55,11 @@ Send an open tab on one device to all your others with a single tap. Much easier
 Λήψη της εφαρμογής Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Σαρώστε τον κωδικό QR για λήψη της εφαρμογής Pocket στην κινητή σας συσκευή.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Σαρώστε τον κωδικό QR για λήψη της εφαρμογής Lockbox στην Apple συσκευή σας.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Σαρώστε τον κωδικό QR για λήψη της εφαρμογής Lockbox στην κινητή σας συσκευή.
 
@@ -131,5 +142,21 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Ρύθμιση του Sync στη <br>συσκευή Android σας
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/en-CA/firefox/accounts-2018.lang
+++ b/en-CA/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Get a Firefox Account – Keep your data private, safe and synced {ok}
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere. {ok}
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere. {ok}
 
@@ -46,6 +57,11 @@ Remember your passwords in Lockbox {ok}
 Get the Lockbox App {ok}
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices. {ok}
 
@@ -86,11 +102,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device. {ok}
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device. {ok}
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device. {ok}
 
@@ -133,5 +144,21 @@ Set up Sync for iOS {ok}
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device {ok}
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/en-GB/firefox/accounts-2018.lang
+++ b/en-GB/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Get a Firefox Account – Keep your data private, safe and synchronised
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely synchronise your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere. {ok}
 
@@ -46,6 +57,11 @@ Remember your passwords in Lockbox {ok}
 Get the Lockbox App {ok}
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and web sites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -86,11 +102,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device. {ok}
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device. {ok}
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device. {ok}
 
@@ -133,5 +144,21 @@ Set up Sync for iOS {ok}
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device {ok}
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/en-US/firefox/accounts-2018.lang
+++ b/en-US/firefox/accounts-2018.lang
@@ -9,6 +9,13 @@
 Get a Firefox Account – Keep your data private, safe and synced
 
 
+## TAG: firefox_send_20190420
+# Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 # Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.

--- a/en-US/firefox/accounts-2018.lang
+++ b/en-US/firefox/accounts-2018.lang
@@ -1,6 +1,7 @@
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
-## URL: https://www-demo3.allizom.org/%LOCALE%/firefox/accounts/
+## firefox_send_20190420 ##
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
+## URL: https://www-dev.allizom.org/%LOCALE%/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -13,6 +14,12 @@ Get a Firefox Account – Keep your data private, safe and synced
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+## TAG: firefox_send_20190420
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -46,6 +53,12 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+## TAG: firefox_send_20190420
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -86,12 +99,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-## TAG: accounts_2018_qrcodes
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -135,3 +142,24 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+## TAG: firefox_send_20190420
+;Share files safely – and privately
+Share files safely – and privately
+
+
+## TAG: firefox_send_20190420
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+## TAG: firefox_send_20190420
+;Try Firefox Send
+Try Firefox Send
+
+
+## TAG: firefox_send_20190420
+;Only in Firefox.
+Only in Firefox.
+

--- a/en-ZA/firefox/accounts-2018.lang
+++ b/en-ZA/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/eo/firefox/accounts-2018.lang
+++ b/eo/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/es-AR/firefox/accounts-2018.lang
+++ b/es-AR/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Obtené una cuenta de Firefox: mantené tus datos privados, seguros y sincroniza
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Sincronizá tus contraseñas, marcadores y pestañas de manera segura en todos tus dispositivos. Obtené una cuenta de Firefox ahora - Un único inicio de sesión - Poder y privacidad en todas partes.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Un único inicio de sesión. Poder y privacidad en todas partes.
 
@@ -46,6 +57,11 @@ Recordá tus contraseñas en Lockbox
 Conseguí la aplicación Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No más bloqueo de aplicaciones y sitios web. Lockbox protege todas las contraseñas que guardaste en Firefox y te brinda acceso fácil a todos tus dispositivos iOS.
 
@@ -86,11 +102,6 @@ Tus ideas e inspiración están seguras y cifradas con Notes, y cuando iniciás 
 Escaneá el código QR para descargar la aplicación Pocket en tu dispositivo móvil.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Escaneá el código QR para descargar la aplicación Lockbox en tu dispositivo Apple.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Escaneá el código QR para descargar la aplicación Lockbox en tu dispositivo móvil.
 
@@ -133,5 +144,21 @@ Configurá Sync para iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Configurá Sync en tu <br>dispositivo Android
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/es-CL/firefox/accounts-2018.lang
+++ b/es-CL/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Obtén una cuenta de Firefox – Mantén tus datos privados, seguros y sincroniz
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Sincroniza de forma segura tus contraseñas, marcadores y pestañas en todos tus dispositivos. Obtén una cuenta de Firefox ahora – Una conexión – Poder y privacidad en todas partes.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Una conexión. Poder y privacidad en todas partes.
 
@@ -46,6 +57,11 @@ Recuerda tus contraseñas en Lockbox.
 Obtén la aplicación de Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No más bloqueo de aplicaciones y sitios web. Lockbox protege todas las contraseñas que guardaste en Firefox y te brinda acceso fácil en todos tus dispositivos iOS.
 
@@ -86,11 +102,6 @@ Tus ideas e inspiraciones están seguros y cifrados con Notes – y cuando te co
 Escanea el código QR para bajar la app de Pocket en tu dispositivo móvil.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Escanea el código QR para bajar la aplicación de Lockbox en tu dispositivo Apple.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Escanea el código QR para bajar la app de Lockbox en tu dispositivo móvil.
 
@@ -133,5 +144,21 @@ Configurar Sync para iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Configurar Sync en tu <br>dispositivo Android
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/es-ES/firefox/accounts-2018.lang
+++ b/es-ES/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Consigue una cuenta de Firefox – Mantén tus datos privados, seguros y sincron
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Sincroniza de manera segura tus contraseñas, marcadores y pestañas en todos tus dispositivos. Consigue una cuenta de Firefox ahora – Un único inicio de sesión – Poder y privacidad en todas partes.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Un único inicio de sesión. Poder y privacidad en todas partes.
 
@@ -46,6 +57,11 @@ Recuerda tus contraseñas en Lockbox
 Obtener la aplicación Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No más bloqueo de aplicaciones y sitios web. Lockbox protege todas las contraseñas que guardaste en Firefox y te brinda fácil acceso en todos tus dispositivos iOS.
 
@@ -86,11 +102,6 @@ Tus ideas e inspiración están seguras y cifradas con Notes – y cuando inicie
 Escanea el código QR para descargar la app de Pocket en tu dispositivo móvil.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Escanea el código QR para descargar la aplicación Lockbox en tu dispositivo Apple.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Escanea el código QR para descargar la app de Lockbox en tu dispositivo móvil.
 
@@ -133,5 +144,21 @@ Configurar Sync para iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Configurar Sync en tu <br>dispositivo Android
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/es-MX/firefox/accounts-2018.lang
+++ b/es-MX/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Obtén una cuenta de Firefox – Mantén tus datos privados, seguros y sincroniz
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Sincroniza con toda seguridad tus contraseñas, marcadores y pestañas en todos tus dispositivos. Obtén una cuenta de Firefox ahora – Un solo inicio de sesión – Poder y privacidad en todo lugar.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Un inicio de sesión. Poder y privacidad en todos lados.
 
@@ -46,6 +57,11 @@ Recordar tus contraseñas en Lockbox
 Obtener la aplicación de Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No más bloqueo de aplicaciones y sitios web. Lockbox protege todas las contraseñas que guardaste en Firefox y te brinda acceso fácil a todos tus dispositivos iOS.
 
@@ -86,11 +102,6 @@ Tus ideas e inspiración están seguras y encriptadas con Notes – y cuando ing
 Escanear el código QR para descargar la app de Pocket en tu dispositivo móvil.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Escanea el código QR para descargar al App Lockbox en tu dispositivo Apple.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Escanea el código QR para descargar al aplicación Lockbox en tu dispositivo móvil.
 
@@ -133,5 +144,21 @@ Configurar Sync para iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Configurar Sync en tu <br>dispositivo Android
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/et/firefox/accounts-2018.lang
+++ b/et/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Firefoxi konto hankimine andmete privaatseks, turvaliseks ja sünkroonituna hoid
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Turvaline paroolide, järjehoidjate ja kaartide sünkroonimine seadmete vahel. Firefoxi konto – ühe sisselogimisega võim ja privaatsus igal pool.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Üks sisselogimine. Võim ja privaatsus igal pool.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/eu/firefox/accounts-2018.lang
+++ b/eu/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Eskuratu Firefox kontu bat – mantendu zure datuak pribatuan, babespean eta sin
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Sinkronizatu modu seguruan pasahitzak, laster-markak eta fitxak zure gailu guztien artean. Eskuratu Firefox kontua orain –Saio-hasiera bat – Boterea eta pribatutasuna edonon.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Saio-hasiera bat. Boterea eta pribatutasuna edonon.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Eskuratu Lockbox App-a
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Konfiguratu Sync iOSerako
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Konfiguratu Sync zure <br>Android gailuan
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/fa/firefox/accounts-2018.lang
+++ b/fa/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 گذرواژه‌ها، نشانک‌ها و زبانه‌های خود را به صورت امن روی تمام دستگاه‌هایتان همگام‌سازی کنید. هم‌اکنون یک حساب کاربری فایرفاکس ایجاد کنید – یک ورود به سیستم – قدرت و حریم خصوصی در همه جا.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 تنها یک ورود. قدرت و حریم خصوصی در همه جا.
 
@@ -44,6 +55,11 @@ Send an open tab on one device to all your others with a single tap. Much easier
 دریافت برنامه Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 کد QR را برای دریافت برنامه Pocket در دستگاه خود اسکن کنید.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-کد QR را برای دریافت برنامه Lockbox در دستگاه اپل خود اسکن کنید.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 کد QR را برای دریافت برنامه Lockbox در دستگاه همراه خود اسکن کنید.
 
@@ -131,5 +142,21 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 برپاساختن همگام‌سازی بر روی <br>دستگاه اندروید
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/ff/firefox/accounts-2018.lang
+++ b/ff/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/fi/firefox/accounts-2018.lang
+++ b/fi/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Luo Firefox-tili – Pidä tietosi yksityisenä, turvallisena ja synkronoituna
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Synkronoi salasanasi, kirjanmerkkisi ja välilehtesi kaikilla laitteillasi. Luo Firefox-tili nyt – Yksi kirjautuminen – Voimaa ja yksityisyyttä kaikkialla.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Yksi kirjautuminen. Voimaa ja yksityisyyttä kaikkialla.
 
@@ -46,6 +57,11 @@ Muista salasanasi Lockboxilla
 Hanki Lockbox-sovellus
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Älä enää jää lukkojen taa sovelluksista tai verkkosivustoista. Lockbox suojaa kaikki Firefoxiin tallennetut salasanat ja antaa sinulle niihin helpon pääsyn kaikilla iOS-laitteillasi.
 
@@ -86,11 +102,6 @@ Ideasi ja inspiraatiosi ovat turvassa ja salattuina Notesin avulla - ja kun olet
 Lataa Pocket-sovellus mobiililaitteellesi skannaamalla QR-koodi.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Lataa Lockbox-sovellus Apple-laitteellesi skannaamalla QR-koodi.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Lataa Lockbox-sovellus mobiililaitteellesi skannaamalla QR-koodi.
 
@@ -133,5 +144,21 @@ Määritä Sync iOS:lle
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Määritä Sync <br>Android-laitteellasi
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/fr/firefox/accounts-2018.lang
+++ b/fr/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Créez votre compte Firefox – Vos données restent synchronisées, sécurisée
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Synchronisez vos appareils en toute sécurité : mots de passe, marque-pages, onglets, etc. Créez votre compte Firefox dès aujourd’hui ! Une seule connexion vous garantit puissance et confidentialité à tous les niveaux.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Une seule connexion vous donne accès à tous ces avantages.
 
@@ -46,6 +57,11 @@ Retrouvez vos mots de passe avec Lockbox
 Installer l’application Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Vous n’aurez plus jamais de problème pour accéder aux applications et aux sites web. Lockbox sécurise les mots de passe que vous enregistrez dans Firefox et vous permet d’y accéder très facilement à partir de vos différents appareils iOS.
 
@@ -86,11 +102,6 @@ Avec Notes, vos idées et votre inspiration sont sécurisées et chiffrées, et 
 Scannez le QR code pour télécharger l’application Pocket sur votre appareil mobile.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scannez le QR code pour télécharger l’application Lockbox sur votre appareil Apple.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scannez le QR code pour télécharger l’application Lockbox sur votre appareil mobile.
 
@@ -133,5 +144,21 @@ Configurer Sync sur iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Configurer Sync sur <br>un appareil Android
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/fy-NL/firefox/accounts-2018.lang
+++ b/fy-NL/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Krij in Firefox-account – Bewarje jo gegevens prive, feilich en syngroan
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Syngronisearje jo wachtwurden, blêdwizers en ljepblêden feilich tusken al jo apparaten. Meitsje no in Firefox-account oan – Ien oanmelding – Oeral krêft en privacy.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Ien oanmelding. Krêft en privacy oeral.
 
@@ -46,6 +57,11 @@ Bewarje jo wachtwurden yn Lockbox
 Download de Lockbox-app
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Net mear útsluten wurde fan apps en websites. Lockbox befeiliget alle wachtwurden dy't jo yn Firefox bewarre hawwe en jout ienfâldige tagong op al jo iOS-apparaten.
 
@@ -86,11 +102,6 @@ Jo ideeën en ynspiraasje binne feilich en fersifere mei Notes – en wannear't 
 Scan de QR-koade om de Pocket-app op jo mobile apparaat te downloaden.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan de QR-koade om de Lockbox-app op jo Apple-apparaat te downloaden.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan de QR-koade om de Lockbox-app op jo mobile apparaat te downloaden.
 
@@ -133,5 +144,21 @@ Sync ynstelle foar iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Sync ynstelle op jo <br>Android-apparaat
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/ga-IE/firefox/accounts-2018.lang
+++ b/ga-IE/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/gd/firefox/accounts-2018.lang
+++ b/gd/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Faigh an aplacaid Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Suidhich an t-sioncronachadh airson iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Suidhich an t-sioncronachadh<br>air an inneal Android agad
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/gl/firefox/accounts-2018.lang
+++ b/gl/firefox/accounts-2018.lang
@@ -1,5 +1,5 @@
 ## active ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -8,10 +8,21 @@ Obteña unha conta Firefox – Manteña os seus datos privados, seguros e sincro
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Sincronice os seus contrasinais, marcadores e lapelas en todos os seus dispositivos de forma segura. Obteña xa unha conta Firefox – unha identificación – poder e privacidade en calquera lugar.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Unha identificación. Poder e privacidade en calquera lugar.
 
@@ -45,6 +56,11 @@ Lembrar os seus contrasinais en Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Acabáronse os aplicativos e os sitios web bloqueados. Lockbox asegura todos os contrasinais que gardou no Firefox e dálle acceso fácil a todos os seus dispositivos iOS.
 
@@ -85,11 +101,6 @@ As súas ideas e fontes de inspiración están seguras e cifradas con Notes. Can
 Examine o código QR para descargar o aplicativo Pocket no seu dispositivo.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Examine o código QR para descargar o aplicativo Lockbox no seu dispositivo.
 
@@ -132,5 +143,21 @@ Configure Sync para iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Configure Sync <br>no seu dispositivo Android
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/gn/firefox/accounts-2018.lang
+++ b/gn/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Eguerekóke Firefox mba’ete: emoĩ ne mba’ekuaarã ñemigua, tekorosã ha ñ
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Embojuehe ne ñe’ẽñemi, techaukaha ha tendayke hekorosã hag̃uáicha opaite ne mba’e’ikápe. Eguerekova’erã Firefox mba’ete ko’ág̃a – Emoñepyrũ tembiapo peteĩjeýnte – Pokatu ha tekorosã opaite hendápe.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Tembiapo moñepyrũ. Pokatu ha tekorosã opaite hendápe.
 
@@ -46,6 +57,11 @@ Nemandu’áke ne ñe’ẽñemi Lockbox pegua
 Eguereko Lockbox rembipuru’i
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Anive ejoko tembipuru’i ha ñanduti renda. Lockbox omo’ãta opaite umi ñe’ẽñemi eñngatuva’kue Firefox-pe ha eikekuaáta opaite ne mba’e’oka iOS peguápe.
 
@@ -86,11 +102,6 @@ Ne remiandu hekorosã ha ipapapy Notes ndive – ha emoñepyrũvo tembiapo ne mb
 Emoha'ãnga QR ayvu emboguejy hag̃ua Pocket rembipuru’i ne mba’e’oka oku’évape.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Emoha'ãnga QR ayvu emboguejy hag̃ua Lockbox rembipuru’i ne mba’e’oka Apple peguápe.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Emoha'ãnga QR ayvu emboguejy hag̃ua Lockbox rembipuru’i ne mba’e’oka oku’évape.
 
@@ -133,5 +144,21 @@ Emboheko Sync iOS peg̃uarã
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Emboheko Sync ne <br>Android mba’e’okápe
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/gu-IN/firefox/accounts-2018.lang
+++ b/gu-IN/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Firefox એકાઉન્ટ મેળવો - તમારો ખાનગી 
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 તમારા પાસવર્ડ્સ, બુકમાર્ક્સ અને ટૅબ્સ સુરક્ષિત રીતે તમારા બધાં ઉપકરણો પર સમન્વયિત કરો. હવે Firefox એકાઉન્ટ મેળવો - એક લૉગ ઇન - શક્તિ અને ગોપનીયતા સર્વત્ર.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 એક લૉગ ઇન. શક્તિ અને ગોપનીયતા સર્વત્ર.
 
@@ -46,6 +57,11 @@ Lockboxમાં તમારા પાસવર્ડ્સ યાદ રાખ
 Lockbox એપ્લિકેશન મેળવો
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 હવે એપ્લિકેશન્સ અને વેબસાઇટ્સથી લૉક થઈ જવાશે નહીં. Lockbox તમે Firefoxમાં સાચવેલા બધા પાસવર્ડોને સુરક્ષિત કરે છે અને તમને તમારા બધા iOS ઉપકરણો પર સરળ ઍક્સેસ આપે છે.
 
@@ -86,11 +102,6 @@ Notes એપ્લિકેશન મેળવો
 તમારા મોબાઇલ ઉપકરણ પર pocket એપ્લિકેશનને ડાઉનલોડ કરવા માટે QR કોડ સ્કેન કરો.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-તમારા Apple ઉપકરણ પર Lockbox એપ્લિકેશન ડાઉનલોડ કરવા માટે QR કોડને સ્કેન કરો.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 તમારા મોબાઇલ ઉપકરણ પર Lockbox એપ્લિકેશનને ડાઉનલોડ કરવા માટે QR કોડ સ્કેન કરો.
 
@@ -133,5 +144,21 @@ iOS માટે સમન્વયન સેટ કરો
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 તમારા <br>Android ઉપકરણ પર સમન્વયન સેટ કરો
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/he/firefox/accounts-2018.lang
+++ b/he/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 קבלו את אפליקציית Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 לא ננעלים מחוץ לאפליקציות ואתרים. Lockbox מאבטח את כל הסיסמאות ששמרת ב־Firefox ונותן לך גישה נוחה בכל המכשירים שלך.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ You deserve peace of mind everywhere.
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 הגדרת Sync במכשיר<br>ה־Android שלך
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/hi-IN/firefox/accounts-2018.lang
+++ b/hi-IN/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 अपने सभी उपकरणों पर पासवर्ड, बुकमार्क और टैबों को सुरक्षित रूप से सिंक करें। अभी एक Firefox खाता प्राप्त करें – एक लॉग-इन – पॉवर और गोपनियता हर जगह।
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 एक लॉग-इन। पॉवर और गोपनीयता हर जगह।
 
@@ -46,6 +57,11 @@ Lockbox में अपने पासवर्ड को याद रखे�
 Lockbox ऐप प्राप्त करें
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 ऐप्स एवं वेबसाइटों से अब और लॉक नहीं। Lockbox आपके द्वारा Firefox में सहेजे सभी पासवर्ड को सुरक्षित रखता है तथा आपके सभी iOS उपकरणों तक आसानी से पहुँच प्रदान करता है।
 
@@ -86,11 +102,6 @@ Notes ऐप प्राप्त करें
 अपने मोबाइल उपकरण पर Pocket ऐप डाउनलोड करने हेतु QR कोड स्कैन करें।
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-अपने Apple उपकरण पर Lockbox ऐप डाउनलोड करने हेतु दिए QR कोड को स्कैन करें।
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 अपने मोबाइल उपकरण पर Lockbox ऐप डाउनलोड करने हेतु QR कोड स्कैन करें।
 
@@ -133,5 +144,21 @@ iOS के लिए सिंक व्यवस्थित करें
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 अपने <br>Android उपकरण पर सिंक व्यवस्थित करें
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/hr/firefox/accounts-2018.lang
+++ b/hr/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Otvorite Firefox račun – čuvajte svoje podatke privatnima, sigurnima i sinkr
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Sigurno sinkronizirajte svoje lozinke, zabilješke i kartice diljem vaših uređaja. Otvorite Firefox račun sada – jedna prijava – moć i privatnost svugdje.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/hsb/firefox/accounts-2018.lang
+++ b/hsb/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Wobstarajće sej konto Firefox - Dźeržće swoje daty priwatne, wěste a synchr
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Synchronizujće swoje hesła, zapołožki a rajtarki wěsće přez wšě swoje graty. Wobstarajće sej nowe konto Firefox - Jedne přizjewjenje - wukon a priwatnosć wšudźe.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Jedne přizjewjenje. Wukon a priwatnosć wšudźe.
 
@@ -46,6 +57,11 @@ Składujće swoje hesła w Lockbox
 Nałoženje Lockbox wobstarać
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Njebudźće ženje wjace z nałoženjow a websydłow wuzamknjeny. Lockbock zawěsća wšě waše hesła, kotrež sće w Firefox składował a dawa wam lochki přistup přez wšě waše graty iOS.
 
@@ -86,11 +102,6 @@ Waše ideje a waša inspiracija su wěste a z Notes zaklučowane - a hdyž sće 
 Skenujće QR-kod, zo byšće nałoženje Pocket na waš mobilny grat sćahnył.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Skenujće QR-kod, zo byšće nałoženje Lockbox do swojeho grata Apple sćahnył.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Skenujće QR-kod, zo byšće nałoženje Lockbox na waš mobilny grat sćahnył.
 
@@ -133,5 +144,21 @@ Připrawće Sync za iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Připrawće Sync na wašim <br>graće za Android
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/hto/firefox/accounts-2018.lang
+++ b/hto/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/hu/firefox/accounts-2018.lang
+++ b/hu/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Szerezzen egy Firefox fiókot – Tartsa az adatait bizalmasan, biztonságban é
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Szinkronizálja biztonságosan a jelszavait, könyvjelzőit és lapjait az összes eszközén. Szerezzen egy Firefox fiókot most – Egy bejelentkezés – Teljesítmény és adatvédelem mindenhol.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Egy bejelentkezés. Teljesítmény és adatvédelem mindenhol.
 
@@ -46,6 +57,11 @@ Jegyeztesse meg a jelszavait a Lockboxban
 Szerezze be a Lockbox alkalmazást
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Ne zárja ki magát többé az alkalmazásokból vagy weboldalakból. A Lockbox biztonságosan tárolja összes Firefoxban mentett jelszavát, és könnyű hozzáférést biztosít az összes iOS-es eszközén.
 
@@ -86,11 +102,6 @@ Az ötletei és inspirációi biztonságban és titkosítva vannak a Notes-szal,
 Olvassa le a QR-kódot a Pocket alkalmazás az eszközére történő letöltéséhez.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Olvassa le a QR-kódot a Lockbox alkalmazás az Apple eszközére történő letöltéséhez.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Olvassa le a QR-kódot a Lockbox alkalmazás az eszközére történő letöltéséhez.
 
@@ -133,5 +144,21 @@ A Sync beálltása iOS-en
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 A Sync beállítása <br>androidos eszközén
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/hy-AM/firefox/accounts-2018.lang
+++ b/hy-AM/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/ia/firefox/accounts-2018.lang
+++ b/ia/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Aperi un conto de Firefox – Mantene tu datos private, secur e synchronisate
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Synchronisa con securitate tu contrasignos, marcapaginas e schedas trans tote tu apparatos. Crea un conto de Firefox ora – Un solo accesso – Potentia e confidentialitate ubique.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Un solo accesso. Potentia e confidentialitate ubique.
 
@@ -46,6 +57,11 @@ Rememora tu contrasignos in Lockbox
 Installa le application Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Jammais plus perder le accesso de applicationes e sitos web. Lockbox salveguarda tote le contrasignos que tu ha salvate in Firefox e te da facile accesso trans tote tu apparatos iOS.
 
@@ -86,11 +102,6 @@ Tu ideas e inspiration es salveguardate e cifrate con Notes – e quando tu ha a
 Scande le codice QR pro discargar le Application Pocket sur tu apparato mobile.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scande le codice QR pro discargar le Application Lockbox sur tu apparato Apple.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scande le codice QR pro discargar le Application Lockbox sur tu apparato mobile.
 
@@ -133,5 +144,21 @@ Configura Sync in iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Configura Sync sur tu <br>apparato Android
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/id/firefox/accounts-2018.lang
+++ b/id/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Dapatkan Firefox Account – Jaga data Anda tetap privat, aman dan tersinkronisa
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Sinkronisasi kata sandi, markah, dan tab dengan aman antar seluruh perangkat Anda. Dapatkan Firefox Account sekarang – Satu log-masuk – Kekuatan dan privasi di mana saja.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Satu log-masuk. Kekuatan dan privasi di mana saja.
 
@@ -46,6 +57,11 @@ Ingat kata sandi Anda di Lockbox
 Dapatkan Aplikasi Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Tak perlu lagi terkunci di luar aplikasi atau situs web. Lockbox mengamankan semua kata sandi Anda telah simpan di Firefox dan memberikan kemudahan akses di semua perangkat iOS Anda.
 
@@ -86,11 +102,6 @@ Ide dan inspirasi Anda aman dan terenkripsi dengan Notes - dan saat Anda masuk k
 Pindai Kode QR untuk mengunduh Pocket di peranti seluler Anda.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Pindai Kode QR untuk mengunduh aplikasi Lockbox di perangkat Apple Anda.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Pindai Kode QR untuk mengunduh Lockbock di peranti seluler Anda.
 
@@ -133,5 +144,21 @@ Atur Sync untuk iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Atur Sync di <br>perangkat Android Anda
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/is/firefox/accounts-2018.lang
+++ b/is/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/it/firefox/accounts-2018.lang
+++ b/it/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Crea un account Firefox: tieni i tuoi dati privati, al sicuro e sincronizzati
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Sincronizza in modo sicuro le tue password, i segnalibri e le schede su tutti i tuoi dispositivi. Crea subito un account Firefox; con un unico accesso hai personalizzazione e privacy ovunque.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Potenza e privacy ovunque con un unico accesso.
 
@@ -46,6 +57,11 @@ Memorizza le tue password in Lockbox
 Scarica l’app Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Non è più necessario bloccare app e siti web. Lockbox protegge tutte le password salvate su Firefox e ti permette di accederci da tutti i tuoi dispositivi iOS.
 
@@ -86,11 +102,6 @@ Le tue idee e le tue fonti di ispirazione sono al sicuro e cifrate con Notes. Qu
 Scansiona il codice QR e scarica Pocket sul tuo dispositivo.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scansiona il codice QR per scaricare Lockbox sul tuo dispositivo Apple.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scansiona il codice QR e scarica Lockbox sul tuo dispositivo.
 
@@ -133,5 +144,21 @@ Configura la sincronizzazione su iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Configura la sincronizzazione <br>su android
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/ja/firefox/accounts-2018.lang
+++ b/ja/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Firefox アプリをダウンロード
 Lockbox アプリを入手
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 もう、パスワードを忘れてアプリやウェブサイトから締め出されることはありません。Lockbox は、Firefox に保存したすべてのパスワードを安全に保管し、お持ちの iOS 端末から簡単にアクセスできます。
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ iOS 版 Sync のセットアップ
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Android 端末向け<br>Sync のセットアップ
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/ka/firefox/accounts-2018.lang
+++ b/ka/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 უსაფრთხოდ დაასინქრონეთ პაროლები, სანიშნები და ჩანართები ყველა თქვენს მოწყობილობაზე. შექმენით Firefox-ანგარიში ახლავე – ერთი შესვლა – მძლავრი შესაძლებლობები და პირადულობა ყველგან.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 ერთი შესვლა. მძლავრი შესაძლებლობები და პირადულობა ყველგან.
 
@@ -46,6 +57,11 @@
 გადმოწერეთ Lockbox-აპლიკაცია
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 ანგარიშების აღარავითარი ჩაკეტვები პროგრამებსა თუ საიტებზე. Lockbox დაიცავს ყველა თქვენს პაროლს, რომელიც Firefox-ში გაქვთ შენახული და მოგცემთ მარტივად წვდომის საშუალებას თქვენი iOS-მოწყობილობებიდან.
 
@@ -86,11 +102,6 @@
 QR-კოდის წაკითხვა, Pocket-პროგრამის მოწყობილობაზე ჩამოსატვირთად.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-გამოიყენეთ QR-კოდის წამკითხველი, Lockbox-აპლიკაციის თქვენს Apple-მოწყობილობაზე ჩამოსატვირთად.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 QR-კოდის წაკითხვა, Lockbox-პროგრამის მოწყობილობაზე ჩამოსატვირთად.
 
@@ -133,5 +144,21 @@ QR-კოდის წაკითხვა, Firefox-პროგრამის
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 გამართეთ Sync თქვენს <br>Android-მოწყობილობაზე
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/kab/firefox/accounts-2018.lang
+++ b/kab/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Awi amiḍan Firefox – Eǧǧ isefka-ik d usligen, d iɣelsanen, mtawin.
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Yiwet n tuqqna ad ak-mudd anekcum ɣer yal amḍiq.
 
@@ -44,6 +55,11 @@ Cfu ɣef wawalen-ik uffiren deg Lockbox
 Awi-d asnas Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Ṭṭef-d tangalt QR akken ad tessidreḍ asnas Pocket ɣef uziraz-ik.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Ṭṭef-d tangalt QR akken ad tessidreḍ asnas Lockbox ɣef uziraz-ik Apple.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Ṭṭef-d tangalt QR akken ad tessidreḍ asnas Lockbox ɣef uziraz-ik.
 
@@ -131,5 +142,21 @@ Sbadu Sync i iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Sebded Sync ɣef <br>yibenk-ik Android
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/kk/firefox/accounts-2018.lang
+++ b/kk/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ iOS үшін синхрондауды баптау
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Android құрылғыңыз үшін <br>Синхрондауды баптау
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/km/firefox/accounts-2018.lang
+++ b/km/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/kn/firefox/accounts-2018.lang
+++ b/kn/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/ko/firefox/accounts-2018.lang
+++ b/ko/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 한 번의 로그인으로 권한과 사생활 보호를 모든 곳에서
 
@@ -44,6 +55,11 @@ Lockbox에 비밀번호 저장하기
 Lockbox 앱 다운로드
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 QR 코드를 스캔해서 모바일 기기에 Pocket 앱을 다운로드하세요.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-QR 코드를 스캔해서 Apple 기기에 Lockbox 앱을 다운로드하세요.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 QR 코드를 스캔해서 모바일 기기에 Lockbox 앱을 다운로드하세요.
 
@@ -131,5 +142,21 @@ iOS용 동기화 설정하기
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 안드로이드 기기를 위한 <br>동기화 설정
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/lij/firefox/accounts-2018.lang
+++ b/lij/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Fatte 'n conto Firefox: mantegni i teu dæti privæ, segui e scincronizæ
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Scincronizza in mòddo seguo e paròlle segrete, segnalibbri e feuggi fra i teu dispoxitivi. Fatte 'n Account Firefox - Ina sola intrâ - Potensa e privacy dapertutto.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Co-ina sola intrâ. Potensa e privacy dapertutto.
 
@@ -44,6 +55,11 @@ Aregòrda e teu paròlle segrete con Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scançionn-a o còdice QR pe scaregâ l'app Pocket into teu dispoxitivo mòbile.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scançionn-a o còdice QR pe scaregâ l'app Lockbox into teu dispoxitivo mòbile.
 
@@ -131,5 +142,21 @@ Inpósta Sync pe iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Inpósta Sync in sciô teu <br>dispoxitivo Android
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/lo/firefox/accounts-2018.lang
+++ b/lo/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Send an open tab on one device to all your others with a single tap. Much easier
 ຕິດຕັ້ງແອັບ Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/lt/firefox/accounts-2018.lang
+++ b/lt/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Susikurkite „Firefox“ paskyrą – saugiai ir privačiai sinchronizuokite du
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Saugiai sinchronizuokite savo slaptažodžius, adresyną ir korteles tarp visų įrenginių. Susikurkite „Firefox“ paskyrą dabar. Viena paskyra – galimybės ir privatumas visur.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Viena paskyra – galimybės ir privatumas visur.
 
@@ -46,6 +57,11 @@ Vienu bakstelėjimu persiųskite viename įrenginyje atvertą kortelę į visus 
 Parsisiųskite „Lockbox“ programėlę
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Nebevarkite ieškodami programėlių ir svetainių slaptažodžių. „Lockbox“ apsaugos visus jūsų „Firefox“ naršyklėje įrašytus slaptažodžius ir suteiks prie jų patogią prieigą „iOS“ įrenginiuose.
 
@@ -86,11 +102,6 @@ Parsisiųskite „Notes“ programėlę
 Nuskenuokite QR kodą „Pocket“ programėlei parsisiųsti į savo mobilųjį įrenginį.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Nuskenuokite QR kodą „Lockbox“ programėlei parsisiųsti į savo „Apple“ įrenginį.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Nuskenuokite QR kodą „Lockbox“ programėlei parsisiųsti į savo mobilųjį įrenginį.
 
@@ -133,5 +144,21 @@ Sukonfigūruokite sinchronizavimą <br>savo „iOS“ įrenginyje
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Sukonfigūruokite sinchronizavimą <br>savo „Android“ įrenginyje
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/ltg/firefox/accounts-2018.lang
+++ b/ltg/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/lv/firefox/accounts-2018.lang
+++ b/lv/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Uzstādīt Sync iOS ierīcēm
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/mai/firefox/accounts-2018.lang
+++ b/mai/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/mk/firefox/accounts-2018.lang
+++ b/mk/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/ml/firefox/accounts-2018.lang
+++ b/ml/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/mr/firefox/accounts-2018.lang
+++ b/mr/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Firefox खाते मिळवा - आपला डेटा खाजगी
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 आपले पासवर्ड, वाचनखूण आणि टॅब सर्व उपकरणांवर सुरक्षित सिंक करा. आत्ताच Firefox खाते मिळावा – एकच लॉगिन – बळ व गोपनीयता सर्वत्र.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 एक लॉग-इन. सर्वत्र बळ आणि गोपनीयता.
 
@@ -44,6 +55,11 @@ Lockbox मध्ये आपले पासवर्ड लक्षात �
 Lockbox अॅप मिळवा
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ iOS साठी सींक प्रस्थापित करा
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 आपल्या Android उपकरणावर <br>सींक प्रस्थापित करा
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/ms/firefox/accounts-2018.lang
+++ b/ms/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/my/firefox/accounts-2018.lang
+++ b/my/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 တစ်ခါပဲဝင်ပါ။ နေရာတိုင်းမှာ စွမ်းအားနဲ့ ကိုယ်ရေးလုံခြုံမှု ရှိစေမှာ။
 
@@ -44,6 +55,11 @@ Lockbox ကို အသုံးပြုပြီး စကားဝှက်�
 Lockbox အက်ပ်ကို ရယူပါ
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ iOS အတွက် နေရာမရွေးတစ်ပြိုင်နက
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 သင့် Android ကိရိယာတွင်<br>အလိုအလျောက်တစ်ပြိုင်နက်သုံးနိုင်အောင်ပြုလုပ်ရန်
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/nb-NO/firefox/accounts-2018.lang
+++ b/nb-NO/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/ne-NP/firefox/accounts-2018.lang
+++ b/ne-NP/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/nl/firefox/accounts-2018.lang
+++ b/nl/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Maak een Firefox-account aan – Houd uw gegevens privé, veilig en synchroon
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Synchroniseer uw wachtwoorden, bladwijzers en tabbladen veilig tussen al uw apparaten. Maak nu een Firefox-account aan – Eén aanmelding – Overal kracht en privacy.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Eén aanmelding. Overal kracht en privacy.
 
@@ -46,6 +57,11 @@ Onthoud uw wachtwoorden in Lockbox
 De Lockbox-app downloaden
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Raak nooit meer buitengesloten van apps en websites. Lockbox beveiligt alle wachtwoorden die u in Firefox hebt opgeslagen en geeft eenvoudige toegang op al uw iOS-apparaten.
 
@@ -86,11 +102,6 @@ Uw ideeën en inspiratie zijn veilig en versleuteld met Notes – en wanneer u b
 Scan de QR-code om de Pocket-app op uw mobiele apparaat te downloaden.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan de QR-code om de Lockbox-app op uw Apple-apparaat te downloaden.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan de QR-code om de Lockbox-app op uw mobiele apparaat te downloaden.
 
@@ -133,5 +144,21 @@ Sync voor iOS instellen
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Sync op uw <br>Android-apparaat instellen
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/nn-NO/firefox/accounts-2018.lang
+++ b/nn-NO/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Få deg ein Firefox-konto – Hald dataa dine private, trygge og synkroniserte
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Synkroniser sikkert passord, bokmerke og filer mellom alle einingane dine. Få ein Firefox-konto no – Ei innlogging – Ta kontroll og vern om privatlivet ditt, overalt.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Ei inlogging. Kraft og personvern overalt.
 
@@ -46,6 +57,11 @@ Hugs passorda dine med Lockbox
 Last ned Lockbox-appen
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Det er slutt på å bli låst ute frå appar og nettstadar. Lockbox sikrar alle passorda du har lagra på Firefox, og gjev deg enkel tilgang på alle iOS-einingane dine.
 
@@ -86,11 +102,6 @@ Dine idear og din inspirasjon er sikra og krypterte med Notes – og når du er 
 Skann QR-koden for å laste ned Pocket-appen til mobileininga di.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Skann QR-koden for å laste ned appen Lockbox til Apple-eininga di.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Skann QR-koden for å laste ned Lockbox-appen til mobileininga di.
 
@@ -133,5 +144,21 @@ Konfigurer Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Konfigurer Sync på <br>Android-eininga di
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/nv/firefox/accounts-2018.lang
+++ b/nv/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/oc/firefox/accounts-2018.lang
+++ b/oc/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/or/firefox/accounts-2018.lang
+++ b/or/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/pa-IN/firefox/accounts-2018.lang
+++ b/pa-IN/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 ਆਪਣੇ ਸਾਰੇ ਡਿਵਾਇਸਾਂ ਅਤੇ ਆਪਣੇ ਪਾਸਵਰਡ, ਬੁੱਕਮਾਰਕਾਂ ਅਤੇ ਟੈਬਾਂ ਨੂੰ ਸੁਰੱਖਿਅਤ ਰੂਪ ਨਾਲ ਸਿੰਕ ਕਰੋ। ਹੁਣ ਫਾਇਰਫਾਕਸ ਖਾਤਾ ਲਵੋ - ਇੱਕ ਲਾਗ ਇਨ - ਹਰ ਜਗ੍ਹਾ ਦੀ ਪਾਵਰ ਅਤੇ ਪਰਦੇਦਾਰੀ।
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 ਇੱਕ ਲਾਗ-ਇਨ। ਹਰ ਜਗ੍ਹਾ ਦੀ ਸ਼ਕਤੀ ਅਤੇ ਪਰਦੇਦਾਰੀ।
 
@@ -46,6 +57,11 @@
 ਲਾਕਬਾਕਸ ਐਪ ਲਵੋ
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 ਕੋਈ ਹੋਰ ਐਪਾਂ ਅਤੇ ਵੈਬਸਾਈਟਾਂ ਤੋਂ ਲਾਕ ਨਹੀਂ ਹੋ ਰਿਹਾ ਹੈ। ਲਾਕਬਾਕਸ ਫਾਇਰਫਾਕਸ ਵਿਚ ਤੁਹਾਡੇ ਵਲੋਂ ਸੰਭਾਲੇ ਸਾਰੇ ਪਾਸਵਰਡ ਸੁਰੱਖਿਅਤ ਕਰਦਾ ਹੈ ਅਤੇ ਤੁਹਾਡੇ ਸਾਰੇ iOS ਡਿਵਾਈਸਾਂ ਵਿੱਚ ਤੁਹਾਨੂੰ ਆਸਾਨ ਪਹੁੰਚ ਦਿੰਦਾ ਹੈ।
 
@@ -86,11 +102,6 @@
 ਆਪਣੇ ਮੋਬਾਈਲ ਡਿਵਾਈਸ ਤੇ ਪਾਕੇਟ ਐਪ ਨੂੰ ਡਾਉਨਲੋਡ ਕਰਨ ਲਈ QR ਕੋਡ ਨੂੰ ਸਕੈਨ ਕਰੋ।
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-ਆਪਣੇ ਐਪ ਡਿਵਾਈਸ ਉੱਤੇ ਲਾਕਬਾਕਸਐਫ ਡਾਊਨਲੋਡ ਕਰਨ ਲਈ QR ਕੋਡ ਸਕੈਨ ਕਰੋ।
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 ਆਪਣੇ ਮੋਬਾਈਲ ਡਿਵਾਈਸ ਤੇ ਲਾਕਬਾਕਸ ਐਪ ਨੂੰ ਡਾਊਨਲੋਡ ਕਰਨ ਲਈ QR ਕੋਡ ਨੂੰ ਸਕੈਨ ਕਰੋ।
 
@@ -133,5 +144,21 @@ iOS ਲਈ ਸਿੰਕ ਨੂੰ ਸੈੱਟ ਅੱਪ ਕਰੋ
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 ਆਪਣੇ ਐਂਡਰਾਈਡ ਡਿਵਾਈਸ <br>ਲਈ ਸਿੰਕ ਸੈੱਟ ਅੱਪ ਕਰੋ
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/pai/firefox/accounts-2018.lang
+++ b/pai/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/pbb/firefox/accounts-2018.lang
+++ b/pbb/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/pl/firefox/accounts-2018.lang
+++ b/pl/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Załóż konto Firefoksa — Twoje dane będą prywatne, bezpieczne i zsynchron
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Bezpiecznie synchronizuj hasła, zakładki i karty na wszystkich urządzeniach. Załóż konto Firefoksa już teraz — jedno logowanie — prywatność w każdym miejscu.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Jedno logowanie. Prywatność w każdym miejscu.
 
@@ -46,6 +57,11 @@ Zachowaj swoje hasła w aplikacji Lockbox
 Pobierz aplikację Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Koniec z gubieniem haseł do stron i aplikacji. Lockbox zabezpiecza wszystkie hasła zachowane w Firefoksie i zapewnia do nich łatwy dostęp na wszystkich urządzeniach z systemem iOS.
 
@@ -86,11 +102,6 @@ Twoje pomysły i natchnienia są bezpieczne i zaszyfrowane za pomocą aplikacj
 Zeskanuj kod QR, aby pobrać aplikację Pocket na swój telefon.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Zeskanuj kod QR, aby pobrać aplikację Lockbox na swój telefon Apple.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Zeskanuj kod QR, aby pobrać aplikację Lockbox na swój telefon.
 
@@ -133,5 +144,21 @@ Synchronizuj na iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Synchronizuj <br>na Androidzie
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/pt-BR/firefox/accounts-2018.lang
+++ b/pt-BR/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Crie uma Conta Firefox – Mantenha seus dados privativos, seguros e sincronizad
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Sincronize com segurança suas senhas, favoritos e abas em todos os seus dispositivos. Crie agora uma Conta Firefox – Um único acesso – Poder e privacidade em todo lugar.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Um único acesso. Poder e privacidade em todo lugar.
 
@@ -46,6 +57,11 @@ Memorize suas senhas no Lockbox
 Instale o aplicativo Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Chega de ficar sem acesso a aplicativos e sites. O Lockbox protege todas as senhas que você salvou no Firefox e lhe fornece acesso fácil em todos os seus dispositivos iOS.
 
@@ -86,11 +102,6 @@ Suas ideias e inspirações estão seguras e criptografadas com o Notes – quan
 Capture o código QR para baixar o aplicativo Pocket em seu dispositivo móvel.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Capture o código QR para baixar o aplicativo Lockbox em seu dispositivo Apple.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Capture o código QR para baixar o aplicativo Lockbox em seu dispositivo móvel.
 
@@ -133,5 +144,21 @@ Configure o Sync no iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Configure o Sync em seu <br>dispositivo Android
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/pt-PT/firefox/accounts-2018.lang
+++ b/pt-PT/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Obtenha uma Conta Firefox - Mantenha os seus dados privados, seguros e sincroniz
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Sincronize as suas palavras-passe, marcadores e separadores em todos os seus dispositivos com segurança. Obtenha agora uma Conta Firefox - Uma conta - poder e privacidade em todo o lado.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Uma conta. Poder e privacidade em todo o lado.
 
@@ -46,6 +57,11 @@ Lembre-se das suas palavras-passe no Lockbox
 Obtenha a aplicação Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Não fique mais bloqueado no acesso às aplicações e sites. O Lockbox protege todas as palavras-passe que guardou no Firefox e oferece-lhe um acesso mais fácil em todos os seus dispositivos iOS.
 
@@ -86,11 +102,6 @@ As suas ideias e inspiração são protegidas e encriptadas com o Notes - e quan
 Digitalize o Código QR para transferir a aplicação do Pocket para o ​​seu dispositivo móvel.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Digitalize o Código QR para transferir a aplicação Lockbox para o ​​seu dispositivo Apple.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Digitalize o Código QR para transferir a aplicação Lockbox para o ​​seu dispositivo móvel.
 
@@ -133,5 +144,21 @@ Configurar Sync para iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Configurar o Sync no seu<br>dispositivo Android
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/qvi/firefox/accounts-2018.lang
+++ b/qvi/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/rm/firefox/accounts-2018.lang
+++ b/rm/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Va per in conto da Firefox – Mantegna tias datas privatas, segiras e sincronis
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Sincronisescha tes pleds-clav, segnapaginas e tabs a moda segira tranter tut tes apparats. Va ussa per in conto da Firefox – Ina annunzia – Prestaziun e protecziun da datas dapertut.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Ina annunzia. Prestaziun e protecziun da datas dapertut.
 
@@ -46,6 +57,11 @@ Memorisescha tes pleds-clav en Lockbox
 Va per l'app Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Mai pli esser sclaus dad apps e websites. Lockbox segirescha tut ils pleds-clav che ti has memorisà en Firefox e ta pussibilitescha in simpel access sin tut tes apparats dad iOS.
 
@@ -86,11 +102,6 @@ Tias ideas e tia inspiraziun èn segiradas e criptadas cun Notes – e sche ti e
 Scannescha il code QR per telechargiar l'app Pocket sin tes apparat mobil.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scannescha il code QR per telechargiar l'app Lockbox sin tes apparat dad Apple.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scannescha il code QR per telechargiar l'app Lockbox sin tes apparat mobil.
 
@@ -133,5 +144,21 @@ Configurar Sync per iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Configurar Sync sin tes <br>apparat cun Android
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/ro/firefox/accounts-2018.lang
+++ b/ro/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Obține un cont Firefox – Ține-ți datele private, în siguranță și sincro
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Sincronizează-ți în siguranță parolele, marcajele și filele pe toate dispozitivele. Obține acum un cont Firefox – o singură autentificare – putere și confidențialitate oriunde.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 O singură autentificare. Putere și confidențialitate oriunde.
 
@@ -46,6 +57,11 @@ Reține parolele în Lockbox
 Instalează aplicația Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Gata cu blocarea accesului la aplicații și pe site-uri web. Lockbox îți securizează toate parolele pe care le-ai salvat în Firefox și îți oferă accesul facil pe toate dispozitivele tale iOS.
 
@@ -86,11 +102,6 @@ Ideile și inspirația ta sunt securizate și criptate cu Notes - și când eșt
 Scanează codul QR pentru a descărca aplicația Pocket pe dispozitivul tău mobil.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scanează codul QR pentru a descărca aplicația Lockbox pe dispozitivul tău Apple.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scanează codul QR pentru a descărca aplicația Lockbox pe dispozitivul tău mobil.
 
@@ -133,5 +144,21 @@ Configurează Sync pentru iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Configurează Sync pe dispozitivul tău <br>Android
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/ru/firefox/accounts-2018.lang
+++ b/ru/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Безопасно синхронизируйте свои пароли, закладки и вкладки между всеми своими устройствами. Создайте Аккаунт Firefox сейчас – Один аккаунт – Мощь и приватность повсюду.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Один аккаунт. Мощь и приватность повсюду.
 
@@ -46,6 +57,11 @@
 Установите Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Вы никогда больше не потеряете доступ к вашим приложениям и веб-сайтам. Lockbox защищает все пароли, которые вы сохранили в Firefox, и даёт вам простой доступ к ним со всех ваших iOS-устройств.
 
@@ -86,11 +102,6 @@
 Отсканируйте QR-код, чтобы загрузить Pocket на своё мобильное устройство.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Отсканируйте QR-код, чтобы загрузить Lockbox на своё устройство Apple.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Отсканируйте QR-код, чтобы загрузить Lockbox на своё мобильное устройство.
 
@@ -133,5 +144,21 @@
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Настроить синхронизацию на вашем <br>Android-устройстве
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/si/firefox/accounts-2018.lang
+++ b/si/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/sk/firefox/accounts-2018.lang
+++ b/sk/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Vytvorte si účet Firefox - udržujte svoje údaje v bezpečí a synchronizovan
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Bezpečne si synchronizujte svoje heslá, záložky a karty medzi všetkými svojimi zariadeniami. Založte si účet Firefox hneď teraz – jedno prihlásenie – možnosti a súkromie všade.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Jedno prihlásenie. Možnosti a súkromie všade.
 
@@ -46,6 +57,11 @@ Použite Lockbox na správu svojich hesiel
 Prevezmite si Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Nenechajte sa vymknúť zo svojich aplikácií a webových stránok. Lockbox uchováva v bezpečí všetky heslá, ktoré ste si uložili vo Firefoxe a poskytuje vám k nim jednoduchý prístup na zariadeniach s iOS.
 
@@ -86,11 +102,6 @@ Vaše nápady sú chránené a šifrované v aplikácii Notes – a keď ste pri
 Naskenujte QR kód a prevezmite si aplikáciu Pocket do svojho mobilného zariadenia.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Naskenujte QR kód a prevezmite si aplikáciu Lockbox do svojho zariadenia od Applu.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Naskenujte QR kód a prevezmite si aplikáciu Lockbox do svojho mobilného zariadenia.
 
@@ -133,5 +144,21 @@ Nastavte si synchronizáciu pre iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Nastavte si synchronizáciu na svojom <br>zariadení s Androidom
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/sl/firefox/accounts-2018.lang
+++ b/sl/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Izberite Firefox Račun – Ohranite svoje podatke zasebne, varne in sinhronizir
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Varno sinhronizirajte gesla, zaznamke in zavihke med svojimi napravami. Izberite Firefox Račun zdaj – ena prijava, moč in zasebnost povsod.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Ena prijava. Moč in zasebnost povsod.
 
@@ -46,6 +57,11 @@ Shranite svoja gesla v Lockbox
 Prenesi Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Nič več pozabljenih gesel aplikacij in spletnih strani. Lockbox hrani vsa vaša gesla, ki ste jih shranili v Firefoxu, in vam omogoča preprost dostop na vseh vaših napravah iOS.
 
@@ -86,11 +102,6 @@ Vaše ideje in navdihi se varno in šifrirano shranjujejo v Notes – ko ste pri
 Preberite kodo QR za prenos aplikacije Pocket na mobilno napravo.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Preberite kodo QR za prenos aplikacije Lockbox na napravo Apple.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Preberite kodo QR za prenos aplikacije Lockbox na mobilno napravo.
 
@@ -133,5 +144,21 @@ Nastavite Sync za iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Nastavite Sync na svoji <br>napravi Android
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/son/firefox/accounts-2018.lang
+++ b/son/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/sq/firefox/accounts-2018.lang
+++ b/sq/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Merrni një Llogari Firefox - Mbajini të dhënat tuaja private, të sigurta dhe
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Njëkohësoni në mënyrë të sigurt fjalëkalimet, faqerojtësit dhe skedat tuaja nëpër krejt pajisjet tuaja. Merrni që tani një Llogari Firefox – Një hyrje – Fuqi dhe privatësi kudo.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Një hyrje. Fuqi dhe privatësi ngado.
 
@@ -46,6 +57,11 @@ Mbani mend fjalëkalimet tuaja, përmes Lockbox-it
 Merrni Aplikacionin Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 S’do të ngelni më jashtë aplikacionesh apo sajtesh. Lockbox i mbron të sigurt krejt fjalëkalimet që keni ruajtur në Firefox dhe ju jep hyrje të lehtë në krejt pajisjet tuaja iOS.
 
@@ -86,11 +102,6 @@ Idetë dhe frymëzimi juaj janë të siguruar dhe të fshehtëzuar në Notes –
 Skanoni kodin QR që të shkarkoni në pajisjen tuaj celulare aplikacionin Pocket.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Skanoni kodin QR që të shkarkoni në pajisjen tuaj Apple aplikacionin Lockbox.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Skanoni kodin QR që të shkarkoni në pajisjen tuaj celulare aplikacionin Lockbox.
 
@@ -133,5 +144,21 @@ Rregullojeni Sync-un për iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Rregullojeni Sync-un te <br>pajisja juaj Android
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/sr/firefox/accounts-2018.lang
+++ b/sr/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/sv-SE/firefox/accounts-2018.lang
+++ b/sv-SE/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Skaffa ett Firefox-konto – Håll dina data privata, säkra och synkroniserade
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Synkronisera säkert dina lösenord, bokmärken och flikar mellan alla dina enheter. Få ett Firefox-konto nu – En inloggning – Styrka och integritet överallt.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 En inloggning. Styrka och integritet överallt.
 
@@ -46,6 +57,11 @@ Kom ihåg dina lösenord i Lockbox
 Hämta appen Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Slut på att bli utelåst från appar och webbplatser. Lockbox säkrar alla lösenord som du har sparat i Firefox och ger dig enkel åtkomst mellan alla dina iOS-enheter.
 
@@ -86,11 +102,6 @@ Dina idéer och inspiration är säkra och krypterade med Notes – och när du 
 Skanna QR-koden för att ladda ner appen Pocket till din mobilenhet.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Skanna QR-koden för att ladda ner appen Lockbox till din Apple-enhet.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Skanna QR-koden för att ladda ner appen Lockbox till din mobilenhet.
 
@@ -133,5 +144,21 @@ Konfigurera Sync för iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Konfigurera Sync på din <br>Android-enhet
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/sw/firefox/accounts-2018.lang
+++ b/sw/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/ta/firefox/accounts-2018.lang
+++ b/ta/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/te/firefox/accounts-2018.lang
+++ b/te/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/th/firefox/accounts-2018.lang
+++ b/th/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 ซิงค์รหัสผ่าน ที่คั่นหน้า และแท็บของคุณในอุปกรณ์ทุกเครื่องของคุณอย่างปลอดภัย รับบัญชี Firefox เดี๋ยวนี้ และเข้าสู่ระบบเพียงครั้งเดียวเพื่อควบคุมและเป็นส่วนตัวได้ทุกที่
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 เข้าสู่ระบบเพียงครั้งเดียวเพื่อควบคุมและเป็นส่วนตัวได้ทุกที่
 
@@ -46,6 +57,11 @@
 รับแอป Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 ไม่ต้องกลัวแอปและเว็บไซต์ถูกล็อกอีกต่อไป Lockbox จะเก็บรหัสผ่านทั้งหมดที่คุณบันทึกไว้ใน Firefox อย่างปลอดภัยและให้คุณสามารถเข้าถึงรหัสผ่านเหล่านั้นผ่านอุปกรณ์ iOS ทุกเครื่องของคุณได้อย่างง่ายดาย
 
@@ -86,11 +102,6 @@
 สแกนคิวอาร์โค้ดเพื่อดาวน์โหลดแอพ Pocket บนอุปกรณ์ของคุณ
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-สแกนคิวอาร์โค้ดเพื่อดาวน์โหลดแอพ Lockbox บนอุปกรณ์ Apple ของคุณ
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 สแกนคิวอาร์โค้ดเพื่อดาวน์โหลดแอพ Lockbox บนอุปกรณ์มือถือของคุณ
 
@@ -133,5 +144,21 @@
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 ตั้งค่า Sync บนอุปกรณ์<br>Android ของคุณ
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/tl/firefox/accounts-2018.lang
+++ b/tl/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/tr/firefox/accounts-2018.lang
+++ b/tr/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Firefox Hesabı açın – Verilerinizi güvenle eşitleyin
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Parolalarınızı, yer imlerinizi ve sekmelerinizi tüm cihazlarınız arasında güvenle eşitleyin. Firefox Hesabınızı hemen açın: tek hesap, her yerde güç ve gizlilik.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Tek hesap, her yerde güç, her yerde gizlilik.
 
@@ -46,6 +57,11 @@ Parolalarınızı Lockbox hatırlasın
 Lockbox uygulamasını indir
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Uygulama ve web sitesi parolalarını unutmaya son. Lockbox, Firefox’ta kaydettiğiniz parolaları güvenle saklar ve tüm iOS cihazlarınızdan parolalara kolayca erişmenizi sağlar.
 
@@ -86,11 +102,6 @@ Notes ile fikirleriniz her yerde güvende. Hesabınıza giriş yaptığınızda 
 Pocket uygulamasını mobil cihazınıza indirmek için QR kodunu tarayın.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Lockbox uygulamasını Apple cihazınıza indirmek için QR kodunu tarayın.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Lockbox uygulamasını mobil cihazınıza indirmek için QR kodunu tarayın.
 
@@ -133,5 +144,21 @@ iOS için Sync’i kur
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Android cihazında <br>Sync’i kur
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/trs/firefox/accounts-2018.lang
+++ b/trs/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Girī 'ngō si kuendât ngà Firefox – Dugumîn nej nuguan' huā ahī 'iát, g
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Nagi'iaj nuguan'àn nej da'nga' huì huā 'iát, nej markador nī nej rakïj ñanj huā riña nej si agâ't. Girī 'ngo si Kuentat Firefox hìaj – 'Ngo log-in – Nùkua ni dugumîn yìtin ñû'.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 'Ngo log-in. Nùkua nī dugumîn yìtïn ñù'.
 
@@ -44,6 +55,11 @@ Nanu ruhuâ nej da'nga' huì nikājt ngà Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/uk/firefox/accounts-2018.lang
+++ b/uk/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Безпечно синхронізуйте свої паролі, закладки і вкладки на всіх своїх пристроях. Зареєструйте обліковий запис Firefox - Один вхід - Доступ і приватність усюди.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Один обліковий запис. Доступ і приватність усюди.
 
@@ -46,6 +57,11 @@
 Завантажити додаток Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Ви більше ніколи не втратите доступ до своїх додатків і веб-сайтів. Lockbox захищає всі паролі, збережені в Firefox, і дозволяє отримувати до них доступ з усіх пристроїв iOS.
 
@@ -86,11 +102,6 @@
 Скануйте QR-код для завантаження Pocket на свій мобільний пристрій.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Скануйте QR-код для завантаження додатка Lockbox на свій пристрій Apple.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Скануйте QR-код для завантаження Lockbox на свій мобільний пристрій.
 
@@ -133,5 +144,21 @@
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Налаштуйте синхронізацію на своєму <br>пристрої Android
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/ur/firefox/accounts-2018.lang
+++ b/ur/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 اپنے پاسورڈز، بک مارکس اور ٹیبز محفوظ طریقے سے اپنے تمام آلات میں مطابقت پذیر کریں۔ ابھی Firefox اکاؤنٹ حاصل کریں۔ ہر طرف کے لیے ایک لاگ-ان - طاقت اور رازداری۔
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 ہر طرف کے لیے ایک لاگ-ان - طاقت اور رازداری۔
 
@@ -44,6 +55,11 @@ Firefox اہپلیکیشن ڈاؤن لوڈ کریں
 Lockbox ایپلیکیشن کو حاصل کریں
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 ایپس اور ویب سائٹس سے کوئی بھی بند نہیں ہو رہا ہے. لاک باکس آپ فائر فاکس میں محفوظ کردہ تمام پاسورڈز کو محفوظ کرتا ہے اور آپ کے تمام iOS آلات پر آسان رسائی فراہم کرتا ہے.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 اپنے موبائل آلہ پر Pocket اپلیکیشن ڈاؤن لوڈ کرنے کے لئے QR کوڈ کو اسکین کریں۔
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-اپنے Apple آلہ پر Lockbox اپلیکیشن ڈاؤن لوڈ کرنے کے لئے QR کوڈ کو اسکین کریں.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 اپنے موبائل آلہ پر Lockbox اپلیکیشن ڈاؤن لوڈ کرنے کے لئے QR کوڈ کو اسکین کریں۔
 
@@ -131,5 +142,21 @@ iOS کے لئے مطابقت پذیری کا سیٹ اپ کریں
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 اپنے <br> اینڈرائیڈ آلہ پر مطابقت پذیری کا سیٹ اپ کریں
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/uz/firefox/accounts-2018.lang
+++ b/uz/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/vi/firefox/accounts-2018.lang
+++ b/vi/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@ Tạo một tài khoản Firefox - Giữ dữ liệu của bạn riêng tư, an 
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Đồng bộ hóa mật khẩu, dấu trang và tab của bạn một cách an toàn trên tất cả các thiết bị của bạn. Tạo tài khoản Firefox ngay bây giờ - Đăng nhập một lần - Hiệu suất và sự riêng tư ở khắp mọi nơi.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 Đăng nhập một lần. Hiệu suất và sự riêng tư ở khắp mọi nơi.
 
@@ -46,6 +57,11 @@ Nhớ mật khẩu của bạn trong Lockbox
 Tải ứng dụng Lockbox
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 Không còn bị khóa các ứng dụng và trang web nữa. Lockbox bảo vệ tất cả mật khẩu bạn đã lưu trong Firefox và cung cấp cho bạn quyền truy cập dễ dàng trên tất cả các thiết bị iOS của mình.
 
@@ -86,11 +102,6 @@ Tải ứng dụng Notes
 Quét mã QR để tải xuống ứng dụng Pocket trên thiết bị di động của bạn.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Quét mã QR để tải xuống ứng dụng Lockbox trên thiết bị Apple của bạn.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Quét mã QR để tải xuống ứng dụng Lockbox trên thiết bị di động của bạn.
 
@@ -133,5 +144,21 @@ Thiết lập Đồng bộ hóa cho iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Thiết lập đồng bộ hóa <br>trên thiết bị Android của bạn
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/wo/firefox/accounts-2018.lang
+++ b/wo/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/xh/firefox/accounts-2018.lang
+++ b/xh/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/zam/firefox/accounts-2018.lang
+++ b/zam/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/zh-CN/firefox/accounts-2018.lang
+++ b/zh-CN/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 安全地在不同设备间同步您的密码、书签与标签页。立即注册 Firefox 账号 — 一次登录，强大能力与隐私保护随身相伴。
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 一个账户，<br>威力与隐私带着走。
 
@@ -46,6 +57,11 @@
 获取 Lockbox 应用
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 不再因为忘记密码被锁在自己账户之外。 Lockbox 会将您放在 Firefox 的所有密码安全地存下，并可让您在 iOS 设备上轻松取得。
 
@@ -86,11 +102,6 @@
 扫描二维码下载 Pocket 到您的移动设备。
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-扫描二维码下载 Lockbox 到您的 Apple 设备。
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 扫描二维码下载 Lockbox 到您的移动设备。
 
@@ -133,5 +144,21 @@
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 在您的 Android 设备上<br>设置同步服务
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/zh-TW/firefox/accounts-2018.lang
+++ b/zh-TW/firefox/accounts-2018.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## accounts_2018_qrcodes ##
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -9,10 +9,21 @@
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 安全地在不同裝置間同步您的密碼、書籤與分頁。立即註冊 Firefox 帳號 - 一次登入，隨處都有強大威力與隱私保護功能。
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 一次登入，隨處都有強大威力與隱私保護功能。
 
@@ -46,6 +57,11 @@
 下載 Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 不再被鎖在應用程式或網站之外。Lockbox 會將您所有儲存到 Firefox 的密碼安全地儲存下來，讓您可簡單在 iOS 裝置上使用。
 
@@ -86,11 +102,6 @@
 掃描 QR Code 即可下載 Pocket App 到您的裝置上。
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-掃描 QR Code 即可下載 Lockbox App 到您的 Apple 裝置上。
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 掃描 QR Code 即可下載 Lockbox App 到您的裝置上。
 
@@ -133,5 +144,21 @@
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 在您的 Android 裝置<br>設定 Sync
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 

--- a/zu/firefox/accounts-2018.lang
+++ b/zu/firefox/accounts-2018.lang
@@ -1,4 +1,4 @@
-## NOTE: https://www-demo3.allizom.org/firefox/accounts/
+## NOTE: https://www-dev.allizom.org/firefox/accounts/
 
 
 # Used as part of HTML title
@@ -7,10 +7,21 @@ Get a Firefox Account – Keep your data private, safe and synced
 
 
 # Used as HTML description
+;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One login – Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
+# Used as HTML description
 ;Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 Securely sync your passwords, bookmarks and tabs across all your devices. Get a Firefox Account now – One log-in – Power and privacy everywhere.
 
 
+;One login. Power and privacy everywhere.
+One login. Power and privacy everywhere.
+
+
+# String is obsolete. Do not remove.
 ;One log-in. Power and privacy everywhere.
 One log-in. Power and privacy everywhere.
 
@@ -44,6 +55,11 @@ Remember your passwords in Lockbox
 Get the Lockbox App
 
 
+;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your Android and iOS devices.
+
+
+# String is obsolete. Do not remove.
 ;No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.
 
@@ -84,11 +100,6 @@ Your ideas and inspiration are secure and encrypted with Notes – and when you�
 Scan the QR Code to download the Pocket App on your mobile device.
 
 
-;Scan the QR Code to download the Lockbox App on your Apple device.
-Scan the QR Code to download the Lockbox App on your Apple device.
-
-
-# String is obsolete. Do not remove.
 ;Scan the QR Code to download the Lockbox App on your mobile device.
 Scan the QR Code to download the Lockbox App on your mobile device.
 
@@ -131,5 +142,21 @@ Set up Sync for iOS
 # https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android
 ;Set up Sync on your <br>Android device
 Set up Sync on your <br>Android device
+
+
+;Share files safely – and privately
+Share files safely – and privately
+
+
+;Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+Send docs and videos — anything up to 2.5 GB — with a private, encrypted link that ‘self-destructs’ when you say so. And since your large files get deleted from the cloud when you’re done sharing, your stuff doesn’t hang around online forever.
+
+
+;Try Firefox Send
+Try Firefox Send
+
+
+;Only in Firefox.
+Only in Firefox.
 
 


### PR DESCRIPTION
Copy changes made in https://github.com/mozilla/bedrock/pull/7069/ Did I get everything?

Uses the tag `firefox_send_20190420`

On dev at https://www-dev.allizom.org/en-US/firefox/accounts/

One oddity, which I hope will be OK: there was one old string that changed later with the tag `accounts_2018_qrcodes` and the original was marked obsolete, but now we've switched back to the original one and the newer tagged one is now obsolete instead... should I remove the `accounts_2018_qrcodes` tag? Is it safe to remove the tagged string entirely in this case?