### PR TITLE
Update mozilla/newsletter.lang

### DIFF
--- a/bg/mozorg/newsletters.lang
+++ b/bg/mozorg/newsletters.lang
@@ -88,13 +88,13 @@ Mozilla засяга широк кръг от важни теми.
 
 
 # Name for the newsletter in Newsletter subscription page
-;Firefox + You
-Firefox + вас
+;Firefox News
+Firefox News
 
 
-# Description for the newsletter in Newsletter subscription page (Firefox + You)
-;A monthly newsletter and special announcements giving you tips to improve your experience with Firefox on your desktop and Android device.
-Месечен бюлетин и известия за това как да извлечете максималното от вашия настолен Firefox или Firefox за Android.
+# Description for the newsletter in Newsletter subscription page (Firefox News)
+;Get how-tos, advice and news to make your Firefox experience work best for you.
+Get how-tos, advice and news to make your Firefox experience work best for you.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -148,8 +148,8 @@ Firefox OS + вас
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Developer Newsletter
-Бюлетин на разработчиците на Мозила
+;Developer Newsletter
+Developer Newsletter
 
 
 # Description for the newsletter in Newsletter subscription page (Mozilla Developer Newsletter)
@@ -232,13 +232,13 @@ Beta Новини
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Foundation
-Фондация Mozilla
+;Mozilla News
+Mozilla News
 
 
-# Description for the newsletter in Newsletter subscription page (Mozilla Foundation)
-;News and special updates about our work to promote openness, innovation and participation on the Internet, including ways for you to get involved.
-Новини и специални актуализации за работата ни за насърчаване на откритостта, нововъведенията и вземане на участие в Мрежата, както и начини как да се включите и вие.
+# Description for the newsletter in Newsletter subscription page (Mozilla News)
+;Regular updates to keep you informed and active in our fight for a better internet.
+Regular updates to keep you informed and active in our fight for a better internet.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -251,8 +251,64 @@ Beta Новини
 Новини и информация свързани със здравето на Мрежата.
 
 
-;About Addons
-Относно Добавки
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Community
+Mozilla Community
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Community)
+;Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Internet Health Report
+Internet Health Report
+
+
+# Description for the newsletter in Newsletter subscription page (Internet Health Report)
+;Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Knowledge is Power
+Knowledge is Power
+
+
+# Description for the newsletter in Newsletter subscription page (Knowledge is Power)
+;Get all the knowledge you need to stay safer and smarter online.
+Get all the knowledge you need to stay safer and smarter online.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Labs
+Mozilla Labs
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Labs)
+;We're building the technology of the future. Come explore with us.
+We're building the technology of the future. Come explore with us.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Take Action for the Internet
+Take Action for the Internet
+
+
+# Description for the newsletter in Newsletter subscription page (Take Action for the Internet)
+;Add your voice to petitions, events and initiatives that fight for the future of the web.
+Add your voice to petitions, events and initiatives that fight for the future of the web.
+
+
+# Name for the newsletter in Newsletter subscription page
+;New Product Testing
+New Product Testing
+
+
+# Description for the newsletter in Newsletter subscription page (New Product Testing)
+;Help us make a better Firefox for you by test-driving our latest products and features.
+Help us make a better Firefox for you by test-driving our latest products and features.
 
 
 ;Firefox OS
@@ -347,6 +403,10 @@ Firefox OS - новини, съвети, информация за влизан�
 Firefox {ok}
 
 
+;Desktop
+Desktop
+
+
 ;We’re sorry to see you go.
 Съжаляваме, че си тръгвате.
 
@@ -419,8 +479,8 @@ Firefox on iOS — Абонамент за актуализации по име�
 Готово! До вас е изпратено писмо, съдържащо препратка към страницата с настройки. Благодарим ви!
 
 
-;Remove me from all Mozilla emails
-Отписване от всички бюлетини на Mozilla
+;Remove me from all the subscriptions on this page
+Remove me from all the subscriptions on this page
 
 
 ;Thanks for telling us why you’re leaving.
@@ -441,10 +501,6 @@ Firefox on iOS — Абонамент за актуализации по име�
 
 ;%s is not a valid newsletter
 %s не е валиден бюлетин
-
-
-;English&nbsp;only
-Само&nbsp;на&nbsp;английски
 
 
 ;This is not a valid email address. Please check the spelling.
@@ -683,5 +739,25 @@ Firefox Marketplace за настолен компютър
 # Only localize "yourname". Do not touch @example.com.
 ;yourname@example.com
 yourname@example.com {ok}
+
+
+;Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+
+
+;Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+
+
+;Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+
+
+;To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+
+
+;There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
+There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
 
 

--- a/cs/mozorg/newsletters.lang
+++ b/cs/mozorg/newsletters.lang
@@ -88,13 +88,13 @@ Vaše přihlášení k odběru zpravodaje bylo potvrzeno.
 
 
 # Name for the newsletter in Newsletter subscription page
-;Firefox + You
-Firefox a vy
+;Firefox News
+Firefox News
 
 
-# Description for the newsletter in Newsletter subscription page (Firefox + You)
-;A monthly newsletter and special announcements giving you tips to improve your experience with Firefox on your desktop and Android device.
-Měsíčník o tom obsahující tipy pro zlepšení vašeho prožitku s Firefoxem na vašem počítači i zařízení s Androidem.
+# Description for the newsletter in Newsletter subscription page (Firefox News)
+;Get how-tos, advice and news to make your Firefox experience work best for you.
+Get how-tos, advice and news to make your Firefox experience work best for you.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -148,8 +148,8 @@ Měsíčník o novinkách v Partnerském programu Firefoxu.
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Developer Newsletter
-Zpravodaj Mozilly pro vývojáře
+;Developer Newsletter
+Developer Newsletter
 
 
 # Description for the newsletter in Newsletter subscription page (Mozilla Developer Newsletter)
@@ -232,13 +232,13 @@ Novinky o betaverzích
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Foundation
-Mozilla Foundation {ok}
+;Mozilla News
+Mozilla News
 
 
-# Description for the newsletter in Newsletter subscription page (Mozilla Foundation)
-;News and special updates about our work to promote openness, innovation and participation on the Internet, including ways for you to get involved.
-Novinky a zprávy o naší práci, podpoře otevřenosti, inovacích a spolupráci na internetu, včetně způsobů, jak se můžete zapojit.
+# Description for the newsletter in Newsletter subscription page (Mozilla News)
+;Regular updates to keep you informed and active in our fight for a better internet.
+Regular updates to keep you informed and active in our fight for a better internet.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -251,8 +251,64 @@ Stav webu
 Novinky a informace týkající se zdravého internetu.
 
 
-;About Addons
-O doplňcích
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Community
+Mozilla Community
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Community)
+;Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Internet Health Report
+Internet Health Report
+
+
+# Description for the newsletter in Newsletter subscription page (Internet Health Report)
+;Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Knowledge is Power
+Knowledge is Power
+
+
+# Description for the newsletter in Newsletter subscription page (Knowledge is Power)
+;Get all the knowledge you need to stay safer and smarter online.
+Get all the knowledge you need to stay safer and smarter online.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Labs
+Mozilla Labs
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Labs)
+;We're building the technology of the future. Come explore with us.
+We're building the technology of the future. Come explore with us.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Take Action for the Internet
+Take Action for the Internet
+
+
+# Description for the newsletter in Newsletter subscription page (Take Action for the Internet)
+;Add your voice to petitions, events and initiatives that fight for the future of the web.
+Add your voice to petitions, events and initiatives that fight for the future of the web.
+
+
+# Name for the newsletter in Newsletter subscription page
+;New Product Testing
+New Product Testing
+
+
+# Description for the newsletter in Newsletter subscription page (New Product Testing)
+;Help us make a better Firefox for you by test-driving our latest products and features.
+Help us make a better Firefox for you by test-driving our latest products and features.
 
 
 ;Firefox OS
@@ -347,6 +403,10 @@ Váš požadavek na zasílání informací je nejprve potřeba potvrdit. Nezapom
 Firefox {ok}
 
 
+;Desktop
+Desktop
+
+
 ;We’re sorry to see you go.
 Je nám líto, že odcházíte.
 
@@ -419,8 +479,8 @@ Jsem místo toho v kontaktu s Mozillou na Facebooku a Twitteru.
 Poslali jsme vám e-mail s odkazem na nastavení našeho zpravodaje. Děkujeme!
 
 
-;Remove me from all Mozilla emails
-Zrušit odběr všech e-mailů od Mozilly
+;Remove me from all the subscriptions on this page
+Remove me from all the subscriptions on this page
 
 
 ;Thanks for telling us why you’re leaving.
@@ -441,10 +501,6 @@ Přidané doplňky
 
 ;%s is not a valid newsletter
 %s není platný zpravodaj
-
-
-;English&nbsp;only
-Pouze&nbsp;anglicky
 
 
 ;This is not a valid email address. Please check the spelling.
@@ -683,5 +739,25 @@ Vaše e-mailová adresa
 # Only localize "yourname". Do not touch @example.com.
 ;yourname@example.com
 vase-adresa@example.com
+
+
+;Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+
+
+;Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+
+
+;Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+
+
+;To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+
+
+;There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
+There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
 
 

--- a/de/mozorg/newsletters.lang
+++ b/de/mozorg/newsletters.lang
@@ -88,13 +88,13 @@ Ihr Newsletter-Abonnement wurde bestätigt.
 
 
 # Name for the newsletter in Newsletter subscription page
-;Firefox + You
-Firefox & Du
+;Firefox News
+Firefox News
 
 
-# Description for the newsletter in Newsletter subscription page (Firefox + You)
-;A monthly newsletter and special announcements giving you tips to improve your experience with Firefox on your desktop and Android device.
-Ein monatlicher Newsletter und besondere Ankündigungen, mit Tipps zur Verbesserung Ihres Erlebnisses mit Firefox auf Ihrem Desktop-Rechner und Ihrem Android-Gerät.
+# Description for the newsletter in Newsletter subscription page (Firefox News)
+;Get how-tos, advice and news to make your Firefox experience work best for you.
+Get how-tos, advice and news to make your Firefox experience work best for you.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -148,8 +148,8 @@ Ein monatlicher Newsletter, um Ihnen die neuesten Informationen aus dem Firefox-
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Developer Newsletter
-Mozilla-Entwickler-Newsletter
+;Developer Newsletter
+Developer Newsletter
 
 
 # Description for the newsletter in Newsletter subscription page (Mozilla Developer Newsletter)
@@ -232,13 +232,13 @@ Beta-Nachrichten
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Foundation
-Mozilla Foundation {ok}
+;Mozilla News
+Mozilla News
 
 
-# Description for the newsletter in Newsletter subscription page (Mozilla Foundation)
-;News and special updates about our work to promote openness, innovation and participation on the Internet, including ways for you to get involved.
-Neuigkeiten und besondere Informationen über unsere Arbeit zur Förderung von Offenheit, Innovation und Mitarbeit im Internet, einschließlich Möglichkeiten zur Mitarbeit für Sie.
+# Description for the newsletter in Newsletter subscription page (Mozilla News)
+;Regular updates to keep you informed and active in our fight for a better internet.
+Regular updates to keep you informed and active in our fight for a better internet.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -251,8 +251,64 @@ Zustand des Internets
 Neuigkeiten und Informationen zum Zustand des Internets.
 
 
-;About Addons
-Über Add-ons
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Community
+Mozilla Community
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Community)
+;Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Internet Health Report
+Internet Health Report
+
+
+# Description for the newsletter in Newsletter subscription page (Internet Health Report)
+;Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Knowledge is Power
+Knowledge is Power
+
+
+# Description for the newsletter in Newsletter subscription page (Knowledge is Power)
+;Get all the knowledge you need to stay safer and smarter online.
+Get all the knowledge you need to stay safer and smarter online.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Labs
+Mozilla Labs
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Labs)
+;We're building the technology of the future. Come explore with us.
+We're building the technology of the future. Come explore with us.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Take Action for the Internet
+Take Action for the Internet
+
+
+# Description for the newsletter in Newsletter subscription page (Take Action for the Internet)
+;Add your voice to petitions, events and initiatives that fight for the future of the web.
+Add your voice to petitions, events and initiatives that fight for the future of the web.
+
+
+# Name for the newsletter in Newsletter subscription page
+;New Product Testing
+New Product Testing
+
+
+# Description for the newsletter in Newsletter subscription page (New Product Testing)
+;Help us make a better Firefox for you by test-driving our latest products and features.
+Help us make a better Firefox for you by test-driving our latest products and features.
 
 
 ;Firefox OS
@@ -347,6 +403,10 @@ Sehen Sie unbedingt in Ihren Posteingang, um Ihr Abonnement für Neuigkeiten zu 
 Firefox {ok}
 
 
+;Desktop
+Desktop
+
+
 ;We’re sorry to see you go.
 Es tut uns leid, Sie gehen zu sehen.
 
@@ -419,8 +479,8 @@ Ich bleibe lieber über Facebook und Twitter mit Mozilla in Verbindung.
 Geschafft! An Sie wurde eine E-Mail mit dem Einstellungs-Link verschickt. Danke!
 
 
-;Remove me from all Mozilla emails
-Trage mich aus allen Mozilla-E-Mail-Listen aus
+;Remove me from all the subscriptions on this page
+Remove me from all the subscriptions on this page
 
 
 ;Thanks for telling us why you’re leaving.
@@ -441,10 +501,6 @@ Weitere Extras
 
 ;%s is not a valid newsletter
 %s ist kein gültiger Newsletter
-
-
-;English&nbsp;only
-Nur&nbsp;Englisch
 
 
 ;This is not a valid email address. Please check the spelling.
@@ -683,5 +739,25 @@ Ihre E-Mail-Adresse
 # Only localize "yourname". Do not touch @example.com.
 ;yourname@example.com
 DeinName@Beispiel.com
+
+
+;Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+
+
+;Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+
+
+;Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+
+
+;To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+
+
+;There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
+There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
 
 

--- a/en-US/mozorg/newsletters.lang
+++ b/en-US/mozorg/newsletters.lang
@@ -94,13 +94,13 @@ Your newsletter subscription has been confirmed.
 
 
 # Name for the newsletter in Newsletter subscription page
-;Firefox + You
-Firefox + You
+;Firefox News
+Firefox News
 
 
-# Description for the newsletter in Newsletter subscription page (Firefox + You)
-;A monthly newsletter and special announcements giving you tips to improve your experience with Firefox on your desktop and Android device.
-A monthly newsletter and special announcements giving you tips to improve your experience with Firefox on your desktop and Android device.
+# Description for the newsletter in Newsletter subscription page (Firefox News)
+;Get how-tos, advice and news to make your Firefox experience work best for you.
+Get how-tos, advice and news to make your Firefox experience work best for you.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -156,8 +156,8 @@ A monthly newsletter to keep you up to date with the Firefox Affiliates program.
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Developer Newsletter
-Mozilla Developer Newsletter
+;Developer Newsletter
+Developer Newsletter
 
 
 # Description for the newsletter in Newsletter subscription page (Mozilla Developer Newsletter)
@@ -240,13 +240,13 @@ Beta News
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Foundation
-Mozilla Foundation
+;Mozilla News
+Mozilla News
 
 
-# Description for the newsletter in Newsletter subscription page (Mozilla Foundation)
-;News and special updates about our work to promote openness, innovation and participation on the Internet, including ways for you to get involved.
-News and special updates about our work to promote openness, innovation and participation on the Internet, including ways for you to get involved.
+# Description for the newsletter in Newsletter subscription page (Mozilla News)
+;Regular updates to keep you informed and active in our fight for a better internet.
+Regular updates to keep you informed and active in our fight for a better internet.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -259,8 +259,54 @@ Shape of the Web
 News and information related to the health of the web.
 
 
-;About Addons
-About Addons
+# Name for the newsletter in Newsletter subscription page
+;Internet Health Report
+Internet Health Report
+
+
+# Description for the newsletter in Newsletter subscription page (Internet Health Report)
+;Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Knowledge is Power
+Knowledge is Power
+
+
+# Description for the newsletter in Newsletter subscription page (Knowledge is Power)
+;Get all the knowledge you need to stay safer and smarter online.
+Get all the knowledge you need to stay safer and smarter online.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Labs
+Mozilla Labs
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Labs)
+;We're building the technology of the future. Come explore with us.
+We're building the technology of the future. Come explore with us.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Take Action for the Internet
+Take Action for the Internet
+
+
+# Description for the newsletter in Newsletter subscription page (Take Action for the Internet)
+;Add your voice to petitions, events and initiatives that fight for the future of the web.
+Add your voice to petitions, events and initiatives that fight for the future of the web.
+
+
+# Name for the newsletter in Newsletter subscription page
+;New Product Testing
+New Product Testing
+
+
+# Description for the newsletter in Newsletter subscription page (New Product Testing)
+;Help us make a better Firefox for you by test-driving our latest products and features.
+Help us make a better Firefox for you by test-driving our latest products and features.
 
 
 ;Firefox OS
@@ -428,8 +474,8 @@ I'm keeping in touch with Mozilla on Facebook and Twitter instead.
 Success! An email has been sent to you with your preference center link. Thanks!
 
 
-;Remove me from all Mozilla emails
-Remove me from all Mozilla emails
+;Remove me from all the subscriptions on this page
+Remove me from all the subscriptions on this page
 
 
 ;Thanks for telling us why you’re leaving.
@@ -450,10 +496,6 @@ Added extras
 
 ;%s is not a valid newsletter
 %s is not a valid newsletter
-
-
-;English&nbsp;only
-English&nbsp;only
 
 
 ;This is not a valid email address. Please check the spelling.
@@ -694,3 +736,23 @@ Your email address
 # Only localize "yourname". Do not touch @example.com.
 ;yourname@example.com
 yourname@example.com
+
+
+;Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+
+
+;Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+
+
+;Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+
+
+;To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+
+
+;There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
+There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.

--- a/en-US/mozorg/newsletters.lang
+++ b/en-US/mozorg/newsletters.lang
@@ -260,6 +260,16 @@ News and information related to the health of the web.
 
 
 # Name for the newsletter in Newsletter subscription page
+;Mozilla Community
+Mozilla Community
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Community)
+;Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+
+
+# Name for the newsletter in Newsletter subscription page
 ;Internet Health Report
 Internet Health Report
 
@@ -400,6 +410,10 @@ Don’t forget to check your inbox to confirm your request to get Firefox for iO
 
 ;Firefox
 Firefox
+
+
+;Desktop
+Desktop
 
 
 ;We’re sorry to see you go.

--- a/es-ES/mozorg/newsletters.lang
+++ b/es-ES/mozorg/newsletters.lang
@@ -88,13 +88,13 @@ Se ha confirmado tu suscripción al boletín.
 
 
 # Name for the newsletter in Newsletter subscription page
-;Firefox + You
-Firefox + Tú
+;Firefox News
+Firefox News
 
 
-# Description for the newsletter in Newsletter subscription page (Firefox + You)
-;A monthly newsletter and special announcements giving you tips to improve your experience with Firefox on your desktop and Android device.
-Un boletín mensual y anuncios especiales que te ofrecen consejos para mejorar tu experiencia con Firefox en tu escritorio y dispositivo Android.
+# Description for the newsletter in Newsletter subscription page (Firefox News)
+;Get how-tos, advice and news to make your Firefox experience work best for you.
+Get how-tos, advice and news to make your Firefox experience work best for you.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -148,8 +148,8 @@ Un boletín mensual para mantenerte al día sobre el programa Firefox Affiliates
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Developer Newsletter
-Boletín de Mozilla Developer
+;Developer Newsletter
+Developer Newsletter
 
 
 # Description for the newsletter in Newsletter subscription page (Mozilla Developer Newsletter)
@@ -232,13 +232,13 @@ Noticias Beta
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Foundation
-Fundación Mozilla
+;Mozilla News
+Mozilla News
 
 
-# Description for the newsletter in Newsletter subscription page (Mozilla Foundation)
-;News and special updates about our work to promote openness, innovation and participation on the Internet, including ways for you to get involved.
-Noticias y novedades especiales sobre nuestra labor en la promoción de la apertura, la innovación y la participación en Internet, además de oportunidades para involucrarte.
+# Description for the newsletter in Newsletter subscription page (Mozilla News)
+;Regular updates to keep you informed and active in our fight for a better internet.
+Regular updates to keep you informed and active in our fight for a better internet.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -251,8 +251,64 @@ Define la Web
 Noticias e información relacionadas con la integridad de la Web.
 
 
-;About Addons
-Acerca de complementos
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Community
+Mozilla Community
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Community)
+;Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Internet Health Report
+Internet Health Report
+
+
+# Description for the newsletter in Newsletter subscription page (Internet Health Report)
+;Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Knowledge is Power
+Knowledge is Power
+
+
+# Description for the newsletter in Newsletter subscription page (Knowledge is Power)
+;Get all the knowledge you need to stay safer and smarter online.
+Get all the knowledge you need to stay safer and smarter online.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Labs
+Mozilla Labs
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Labs)
+;We're building the technology of the future. Come explore with us.
+We're building the technology of the future. Come explore with us.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Take Action for the Internet
+Take Action for the Internet
+
+
+# Description for the newsletter in Newsletter subscription page (Take Action for the Internet)
+;Add your voice to petitions, events and initiatives that fight for the future of the web.
+Add your voice to petitions, events and initiatives that fight for the future of the web.
+
+
+# Name for the newsletter in Newsletter subscription page
+;New Product Testing
+New Product Testing
+
+
+# Description for the newsletter in Newsletter subscription page (New Product Testing)
+;Help us make a better Firefox for you by test-driving our latest products and features.
+Help us make a better Firefox for you by test-driving our latest products and features.
 
 
 ;Firefox OS
@@ -347,6 +403,10 @@ No olvides comprobar tu bandeja de entrada para confirmar tu solicitud y recibir
 Firefox {ok}
 
 
+;Desktop
+Desktop
+
+
 ;We’re sorry to see you go.
 Lamentamos que te vayas.
 
@@ -419,8 +479,8 @@ Prefiero seguir en contacto con Mozilla en Facebook y Twitter.
 ¡Éxito! Te hemos enviado un email con un enlace a tu centro de preferencias. ¡Gracias!
 
 
-;Remove me from all Mozilla emails
-Darme de baja de todos los emails de Mozilla
+;Remove me from all the subscriptions on this page
+Remove me from all the subscriptions on this page
 
 
 ;Thanks for telling us why you’re leaving.
@@ -441,10 +501,6 @@ Extras
 
 ;%s is not a valid newsletter
 %s no es un boletín válido
-
-
-;English&nbsp;only
-Solo en&nbsp;inglés
 
 
 ;This is not a valid email address. Please check the spelling.
@@ -683,5 +739,25 @@ Tu dirección de correo electrónico
 # Only localize "yourname". Do not touch @example.com.
 ;yourname@example.com
 tunombre@example.com
+
+
+;Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+
+
+;Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+
+
+;Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+
+
+;To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+
+
+;There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
+There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
 
 

--- a/fr/mozorg/newsletters.lang
+++ b/fr/mozorg/newsletters.lang
@@ -88,13 +88,13 @@ Votre inscription à la lettre d’information est maintenant confirmée.
 
 
 # Name for the newsletter in Newsletter subscription page
-;Firefox + You
-Firefox + Vous
+;Firefox News
+Firefox News
 
 
-# Description for the newsletter in Newsletter subscription page (Firefox + You)
-;A monthly newsletter and special announcements giving you tips to improve your experience with Firefox on your desktop and Android device.
-Une lettre d’information mensuelle contenant des annonces spéciales et des astuces pour améliorer votre utilisation de Firefox sur votre ordinateur et sur votre appareil Android.
+# Description for the newsletter in Newsletter subscription page (Firefox News)
+;Get how-tos, advice and news to make your Firefox experience work best for you.
+Get how-tos, advice and news to make your Firefox experience work best for you.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -148,8 +148,8 @@ Une lettre mensuelle sur l’actualité du programme Firefox Affiliates.
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Developer Newsletter
-Lettre d’information de Mozilla pour les développeurs
+;Developer Newsletter
+Developer Newsletter
 
 
 # Description for the newsletter in Newsletter subscription page (Mozilla Developer Newsletter)
@@ -232,13 +232,13 @@ Actualité des versions bêta
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Foundation
-Fondation Mozilla
+;Mozilla News
+Mozilla News
 
 
-# Description for the newsletter in Newsletter subscription page (Mozilla Foundation)
-;News and special updates about our work to promote openness, innovation and participation on the Internet, including ways for you to get involved.
-Nouvelles et mises à jour spéciales concernant notre travail de promotion de l’ouverture, de l’innovation et de la participation sur Internet, et les manières de vous y impliquer.
+# Description for the newsletter in Newsletter subscription page (Mozilla News)
+;Regular updates to keep you informed and active in our fight for a better internet.
+Regular updates to keep you informed and active in our fight for a better internet.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -251,8 +251,64 @@ Forme du Web
 Nouvelles et informations concernant la santé du Web.
 
 
-;About Addons
-À propos des modules
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Community
+Mozilla Community
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Community)
+;Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Internet Health Report
+Internet Health Report
+
+
+# Description for the newsletter in Newsletter subscription page (Internet Health Report)
+;Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Knowledge is Power
+Knowledge is Power
+
+
+# Description for the newsletter in Newsletter subscription page (Knowledge is Power)
+;Get all the knowledge you need to stay safer and smarter online.
+Get all the knowledge you need to stay safer and smarter online.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Labs
+Mozilla Labs
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Labs)
+;We're building the technology of the future. Come explore with us.
+We're building the technology of the future. Come explore with us.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Take Action for the Internet
+Take Action for the Internet
+
+
+# Description for the newsletter in Newsletter subscription page (Take Action for the Internet)
+;Add your voice to petitions, events and initiatives that fight for the future of the web.
+Add your voice to petitions, events and initiatives that fight for the future of the web.
+
+
+# Name for the newsletter in Newsletter subscription page
+;New Product Testing
+New Product Testing
+
+
+# Description for the newsletter in Newsletter subscription page (New Product Testing)
+;Help us make a better Firefox for you by test-driving our latest products and features.
+Help us make a better Firefox for you by test-driving our latest products and features.
 
 
 ;Firefox OS
@@ -347,6 +403,10 @@ N’oubliez pas de vérifier votre boîte de réception pour confirmer votre abo
 Firefox {ok}
 
 
+;Desktop
+Desktop
+
+
 ;We’re sorry to see you go.
 C’est triste de vous voir partir…
 
@@ -419,8 +479,8 @@ Je suis déjà les nouvelles concernant Mozilla sur Facebook et Twitter.
 Terminé ! Un courrier électronique vous a été envoyé avec un lien vers le centre des préférences. Merci !
 
 
-;Remove me from all Mozilla emails
-Me désinscrire de toutes les lettres d’information de Mozilla
+;Remove me from all the subscriptions on this page
+Remove me from all the subscriptions on this page
 
 
 ;Thanks for telling us why you’re leaving.
@@ -441,10 +501,6 @@ Fonctionnalités supplémentaires
 
 ;%s is not a valid newsletter
 %s n’est pas une lettre d’information valide
-
-
-;English&nbsp;only
-En anglais
 
 
 ;This is not a valid email address. Please check the spelling.
@@ -683,5 +739,25 @@ Votre adresse électronique
 # Only localize "yourname". Do not touch @example.com.
 ;yourname@example.com
 votrenom@example.com
+
+
+;Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+
+
+;Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+
+
+;Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+
+
+;To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+
+
+;There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
+There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
 
 

--- a/hu/mozorg/newsletters.lang
+++ b/hu/mozorg/newsletters.lang
@@ -88,13 +88,13 @@ A hírlevél-előfizetés jóváhagyása megtörtént.
 
 
 # Name for the newsletter in Newsletter subscription page
-;Firefox + You
-Firefox és én
+;Firefox News
+Firefox News
 
 
-# Description for the newsletter in Newsletter subscription page (Firefox + You)
-;A monthly newsletter and special announcements giving you tips to improve your experience with Firefox on your desktop and Android device.
-A havi hírlevél és a bejelentések segítségével tovább növelheti a Firefox felhasználói élményét a számítógépen és az Android eszközökön.
+# Description for the newsletter in Newsletter subscription page (Firefox News)
+;Get how-tos, advice and news to make your Firefox experience work best for you.
+Get how-tos, advice and news to make your Firefox experience work best for you.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -148,8 +148,8 @@ Havi hírlevél a Firefox Affiliates programról újdonságairól.
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Developer Newsletter
-Mozilla fejlesztői hírlevél
+;Developer Newsletter
+Developer Newsletter
 
 
 # Description for the newsletter in Newsletter subscription page (Mozilla Developer Newsletter)
@@ -232,13 +232,13 @@ Béta hírek
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Foundation
-Mozilla Alapítvány
+;Mozilla News
+Mozilla News
 
 
-# Description for the newsletter in Newsletter subscription page (Mozilla Foundation)
-;News and special updates about our work to promote openness, innovation and participation on the Internet, including ways for you to get involved.
-Hírek és különleges naprakész információk munkánkról, mellyel az nyitottságot, az innovációt és a részvételt támogatjuk az interneten, valamint hogy hogyan vehet ebben részt Ön is.
+# Description for the newsletter in Newsletter subscription page (Mozilla News)
+;Regular updates to keep you informed and active in our fight for a better internet.
+Regular updates to keep you informed and active in our fight for a better internet.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -251,8 +251,64 @@ A web állapota
 Hírek és információk a web „egészségi állapotáról”.
 
 
-;About Addons
-Kiegészítőkről
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Community
+Mozilla Community
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Community)
+;Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Internet Health Report
+Internet Health Report
+
+
+# Description for the newsletter in Newsletter subscription page (Internet Health Report)
+;Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Knowledge is Power
+Knowledge is Power
+
+
+# Description for the newsletter in Newsletter subscription page (Knowledge is Power)
+;Get all the knowledge you need to stay safer and smarter online.
+Get all the knowledge you need to stay safer and smarter online.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Labs
+Mozilla Labs
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Labs)
+;We're building the technology of the future. Come explore with us.
+We're building the technology of the future. Come explore with us.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Take Action for the Internet
+Take Action for the Internet
+
+
+# Description for the newsletter in Newsletter subscription page (Take Action for the Internet)
+;Add your voice to petitions, events and initiatives that fight for the future of the web.
+Add your voice to petitions, events and initiatives that fight for the future of the web.
+
+
+# Name for the newsletter in Newsletter subscription page
+;New Product Testing
+New Product Testing
+
+
+# Description for the newsletter in Newsletter subscription page (New Product Testing)
+;Help us make a better Firefox for you by test-driving our latest products and features.
+Help us make a better Firefox for you by test-driving our latest products and features.
 
 
 ;Firefox OS
@@ -347,6 +403,10 @@ Ne felejtse el ellenőrizni postaládáját és megerősíteni Firefox iOS friss
 Firefox {ok}
 
 
+;Desktop
+Desktop
+
+
 ;We’re sorry to see you go.
 Sajnáljuk, hogy leiratkozott.
 
@@ -419,8 +479,8 @@ Inkább a Facebookon és a Twitteren tartom a kapcsolatot a Mozillával.
 Sikerült! Egy emailt küldtünk az Ön beállítási központjára mutató hivatkozással. Köszönjük!
 
 
-;Remove me from all Mozilla emails
-Leiratkozás az összes Mozilla hírlevélről
+;Remove me from all the subscriptions on this page
+Remove me from all the subscriptions on this page
 
 
 ;Thanks for telling us why you’re leaving.
@@ -441,10 +501,6 @@ Extrák hozzáadása
 
 ;%s is not a valid newsletter
 %s nem érvényes hírlevél
-
-
-;English&nbsp;only
-Csak&nbsp;angolul
 
 
 ;This is not a valid email address. Please check the spelling.
@@ -683,5 +739,25 @@ E-mail cím
 # Only localize "yourname". Do not touch @example.com.
 ;yourname@example.com
 email@example.com
+
+
+;Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+
+
+;Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+
+
+;Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+
+
+;To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+
+
+;There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
+There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
 
 

--- a/id/mozorg/newsletters.lang
+++ b/id/mozorg/newsletters.lang
@@ -88,13 +88,13 @@ Langganan nawala Anda telah dikonfirmasi.
 
 
 # Name for the newsletter in Newsletter subscription page
-;Firefox + You
-Firefox + Anda
+;Firefox News
+Firefox News
 
 
-# Description for the newsletter in Newsletter subscription page (Firefox + You)
-;A monthly newsletter and special announcements giving you tips to improve your experience with Firefox on your desktop and Android device.
-Nawala bulanan dan pengumuman khusus yang memberikan Anda kiat meningkatkan pengalaman Anda bersama Firefox pada peranti desktop dan Android Anda.
+# Description for the newsletter in Newsletter subscription page (Firefox News)
+;Get how-tos, advice and news to make your Firefox experience work best for you.
+Get how-tos, advice and news to make your Firefox experience work best for you.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -148,8 +148,8 @@ Nawala bulanan agar Anda selalu mendapatkan kabar terbaru tentang program Firefo
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Developer Newsletter
-Nawala Pengembang Mozilla
+;Developer Newsletter
+Developer Newsletter
 
 
 # Description for the newsletter in Newsletter subscription page (Mozilla Developer Newsletter)
@@ -232,13 +232,13 @@ Berita Beta
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Foundation
-Mozilla Foundation {ok}
+;Mozilla News
+Mozilla News
 
 
-# Description for the newsletter in Newsletter subscription page (Mozilla Foundation)
-;News and special updates about our work to promote openness, innovation and participation on the Internet, including ways for you to get involved.
-Berita dan pemberitahuan khusus tentang kegiatan kami untuk mempromosikan keterbukaan, inovasi, dan partisipasi di Internet, termasuk cara Anda untuk berperan bersama.
+# Description for the newsletter in Newsletter subscription page (Mozilla News)
+;Regular updates to keep you informed and active in our fight for a better internet.
+Regular updates to keep you informed and active in our fight for a better internet.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -251,8 +251,64 @@ Mari Membentuk Dunia Web
 Berita dan informasi yang terkait dengan kesehatan Web.
 
 
-;About Addons
-Tentang Pengaya
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Community
+Mozilla Community
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Community)
+;Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Internet Health Report
+Internet Health Report
+
+
+# Description for the newsletter in Newsletter subscription page (Internet Health Report)
+;Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Knowledge is Power
+Knowledge is Power
+
+
+# Description for the newsletter in Newsletter subscription page (Knowledge is Power)
+;Get all the knowledge you need to stay safer and smarter online.
+Get all the knowledge you need to stay safer and smarter online.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Labs
+Mozilla Labs
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Labs)
+;We're building the technology of the future. Come explore with us.
+We're building the technology of the future. Come explore with us.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Take Action for the Internet
+Take Action for the Internet
+
+
+# Description for the newsletter in Newsletter subscription page (Take Action for the Internet)
+;Add your voice to petitions, events and initiatives that fight for the future of the web.
+Add your voice to petitions, events and initiatives that fight for the future of the web.
+
+
+# Name for the newsletter in Newsletter subscription page
+;New Product Testing
+New Product Testing
+
+
+# Description for the newsletter in Newsletter subscription page (New Product Testing)
+;Help us make a better Firefox for you by test-driving our latest products and features.
+Help us make a better Firefox for you by test-driving our latest products and features.
 
 
 ;Firefox OS
@@ -347,6 +403,10 @@ Jangan lupa memeriksa kotak masuk Anda untuk mengonfirmasi permintaan Anda untuk
 Firefox {ok}
 
 
+;Desktop
+Desktop
+
+
 ;We’re sorry to see you go.
 Kami sedih akan berpisah dengan Anda.
 
@@ -419,8 +479,8 @@ Cukup terhubung dengan Mozilla lewat Facebook dan Twitter saja.
 Berhasil! Surel telah dikirimkan kepada Anda yang berisi tautan ke pusat pengaturan Anda. Terima kasih!
 
 
-;Remove me from all Mozilla emails
-Hapus alamat saya dari semua langganan surel Mozilla
+;Remove me from all the subscriptions on this page
+Remove me from all the subscriptions on this page
 
 
 ;Thanks for telling us why you’re leaving.
@@ -441,10 +501,6 @@ Pernak-pernik ekstra
 
 ;%s is not a valid newsletter
 %s bukan nawala yang valid
-
-
-;English&nbsp;only
-Hanya dalam Bahasa Inggris
 
 
 ;This is not a valid email address. Please check the spelling.
@@ -683,5 +739,25 @@ Alamat surel Anda
 # Only localize "yourname". Do not touch @example.com.
 ;yourname@example.com
 yourname@example.com {ok}
+
+
+;Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+
+
+;Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+
+
+;Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+
+
+;To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+
+
+;There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
+There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
 
 

--- a/it/mozorg/newsletters.lang
+++ b/it/mozorg/newsletters.lang
@@ -88,13 +88,13 @@ La tua iscrizione alla newsletter è stata confermata.
 
 
 # Name for the newsletter in Newsletter subscription page
-;Firefox + You
-Firefox + You {ok}
+;Firefox News
+Firefox News
 
 
-# Description for the newsletter in Newsletter subscription page (Firefox + You)
-;A monthly newsletter and special announcements giving you tips to improve your experience with Firefox on your desktop and Android device.
-Una newsletter mensile e annunci esclusivi contenenti suggerimenti per consentirti di migliorare la tua esperienza con Firefox su desktop e dispositivi Android.
+# Description for the newsletter in Newsletter subscription page (Firefox News)
+;Get how-tos, advice and news to make your Firefox experience work best for you.
+Get how-tos, advice and news to make your Firefox experience work best for you.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -148,8 +148,8 @@ Una newsletter mensile per rimanere aggiornati sul programma di Firefox Affiliat
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Developer Newsletter
-Newsletter Mozilla Developer
+;Developer Newsletter
+Developer Newsletter
 
 
 # Description for the newsletter in Newsletter subscription page (Mozilla Developer Newsletter)
@@ -232,13 +232,13 @@ Beta News {ok}
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Foundation
-Mozilla Foundation {ok}
+;Mozilla News
+Mozilla News
 
 
-# Description for the newsletter in Newsletter subscription page (Mozilla Foundation)
-;News and special updates about our work to promote openness, innovation and participation on the Internet, including ways for you to get involved.
-Notizie e aggiornamenti esclusivi sul nostro lavoro per promuovere apertura, innovazione e partecipazione su Internet, incluse informazioni su come collaborare ai nostri progetti.
+# Description for the newsletter in Newsletter subscription page (Mozilla News)
+;Regular updates to keep you informed and active in our fight for a better internet.
+Regular updates to keep you informed and active in our fight for a better internet.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -251,8 +251,64 @@ Shape of the Web {ok}
 Novità e informazioni sullo stato di salute del Web.
 
 
-;About Addons
-About Addons {ok}
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Community
+Mozilla Community
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Community)
+;Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Internet Health Report
+Internet Health Report
+
+
+# Description for the newsletter in Newsletter subscription page (Internet Health Report)
+;Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Knowledge is Power
+Knowledge is Power
+
+
+# Description for the newsletter in Newsletter subscription page (Knowledge is Power)
+;Get all the knowledge you need to stay safer and smarter online.
+Get all the knowledge you need to stay safer and smarter online.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Labs
+Mozilla Labs
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Labs)
+;We're building the technology of the future. Come explore with us.
+We're building the technology of the future. Come explore with us.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Take Action for the Internet
+Take Action for the Internet
+
+
+# Description for the newsletter in Newsletter subscription page (Take Action for the Internet)
+;Add your voice to petitions, events and initiatives that fight for the future of the web.
+Add your voice to petitions, events and initiatives that fight for the future of the web.
+
+
+# Name for the newsletter in Newsletter subscription page
+;New Product Testing
+New Product Testing
+
+
+# Description for the newsletter in Newsletter subscription page (New Product Testing)
+;Help us make a better Firefox for you by test-driving our latest products and features.
+Help us make a better Firefox for you by test-driving our latest products and features.
 
 
 ;Firefox OS
@@ -347,6 +403,10 @@ Ricordati di controllare la casella di posta per confermare l’iscrizione e ric
 Firefox {ok}
 
 
+;Desktop
+Desktop
+
+
 ;We’re sorry to see you go.
 Ci dispiace per la tua decisione.
 
@@ -419,8 +479,8 @@ Preferisco seguire Mozilla su Facebook e Twitter.
 Operazione effettuata con successo. Ti abbiamo inviato una email con il link per accedere alla pagina delle tue preferenze.
 
 
-;Remove me from all Mozilla emails
-Rimuovimi da tutte le newsletter Mozilla
+;Remove me from all the subscriptions on this page
+Remove me from all the subscriptions on this page
 
 
 ;Thanks for telling us why you’re leaving.
@@ -441,10 +501,6 @@ Altre funzionalità aggiuntive
 
 ;%s is not a valid newsletter
 La newsletter “%s” non esiste
-
-
-;English&nbsp;only
-Solo&nbsp;in&nbsp;inglese
 
 
 ;This is not a valid email address. Please check the spelling.
@@ -683,5 +739,25 @@ Il tuo indirizzo email
 # Only localize "yourname". Do not touch @example.com.
 ;yourname@example.com
 iltuonome@example.com
+
+
+;Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+
+
+;Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+
+
+;Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+
+
+;To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+
+
+;There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
+There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
 
 

--- a/nl/mozorg/newsletters.lang
+++ b/nl/mozorg/newsletters.lang
@@ -88,13 +88,13 @@ Uw nieuwsbriefinschrijving is bevestigd.
 
 
 # Name for the newsletter in Newsletter subscription page
-;Firefox + You
-Firefox + u
+;Firefox News
+Firefox News
 
 
-# Description for the newsletter in Newsletter subscription page (Firefox + You)
-;A monthly newsletter and special announcements giving you tips to improve your experience with Firefox on your desktop and Android device.
-Een maandelijkse nieuwsbrief en speciale aankondigingen die u tips geven voor het verbeteren van uw beleving met Firefox op uw desktop en Android-apparaat.
+# Description for the newsletter in Newsletter subscription page (Firefox News)
+;Get how-tos, advice and news to make your Firefox experience work best for you.
+Get how-tos, advice and news to make your Firefox experience work best for you.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -148,8 +148,8 @@ Een maandelijkse nieuwsbrief die u op de hoogte houdt van het Firefox Affiliates
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Developer Newsletter
-Mozilla Developer-nieuwsbrief
+;Developer Newsletter
+Developer Newsletter
 
 
 # Description for the newsletter in Newsletter subscription page (Mozilla Developer Newsletter)
@@ -232,13 +232,13 @@ Bètanieuws
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Foundation
-Mozilla Foundation {ok}
+;Mozilla News
+Mozilla News
 
 
-# Description for the newsletter in Newsletter subscription page (Mozilla Foundation)
-;News and special updates about our work to promote openness, innovation and participation on the Internet, including ways for you to get involved.
-Nieuws en speciale updates over ons werk ter bevordering van openheid, innovatie en deelname op het internet, waaronder manieren voor u om mee te werken.
+# Description for the newsletter in Newsletter subscription page (Mozilla News)
+;Regular updates to keep you informed and active in our fight for a better internet.
+Regular updates to keep you informed and active in our fight for a better internet.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -251,8 +251,64 @@ Shape of the Web {ok}
 Nieuws en informatie gerelateerd aan het welzijn van het web.
 
 
-;About Addons
-Over add-ons
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Community
+Mozilla Community
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Community)
+;Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Internet Health Report
+Internet Health Report
+
+
+# Description for the newsletter in Newsletter subscription page (Internet Health Report)
+;Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Knowledge is Power
+Knowledge is Power
+
+
+# Description for the newsletter in Newsletter subscription page (Knowledge is Power)
+;Get all the knowledge you need to stay safer and smarter online.
+Get all the knowledge you need to stay safer and smarter online.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Labs
+Mozilla Labs
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Labs)
+;We're building the technology of the future. Come explore with us.
+We're building the technology of the future. Come explore with us.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Take Action for the Internet
+Take Action for the Internet
+
+
+# Description for the newsletter in Newsletter subscription page (Take Action for the Internet)
+;Add your voice to petitions, events and initiatives that fight for the future of the web.
+Add your voice to petitions, events and initiatives that fight for the future of the web.
+
+
+# Name for the newsletter in Newsletter subscription page
+;New Product Testing
+New Product Testing
+
+
+# Description for the newsletter in Newsletter subscription page (New Product Testing)
+;Help us make a better Firefox for you by test-driving our latest products and features.
+Help us make a better Firefox for you by test-driving our latest products and features.
 
 
 ;Firefox OS
@@ -347,6 +403,10 @@ Vergeet niet uw postvak IN te controleren om uw aanvraag voor updates over Firef
 Firefox {ok}
 
 
+;Desktop
+Desktop
+
+
 ;We’re sorry to see you go.
 We vinden het jammer dat u weggaat.
 
@@ -419,8 +479,8 @@ Ik houd in plaats hiervan contact met Mozilla via Facebook en Twitter.
 Gelukt! Er is een e-mailbericht met een koppeling naar uw voorkeurencentrum naar u verstuurd. Bedankt!
 
 
-;Remove me from all Mozilla emails
-Mij van alle e-mail van Mozilla verwijderen
+;Remove me from all the subscriptions on this page
+Remove me from all the subscriptions on this page
 
 
 ;Thanks for telling us why you’re leaving.
@@ -441,10 +501,6 @@ Toegevoegde extra’s
 
 ;%s is not a valid newsletter
 %s is geen geldige nieuwsbrief
-
-
-;English&nbsp;only
-Alleen&nbsp;Engels
 
 
 ;This is not a valid email address. Please check the spelling.
@@ -683,5 +739,25 @@ Uw e-mailadres
 # Only localize "yourname". Do not touch @example.com.
 ;yourname@example.com
 uwnaam@example.com
+
+
+;Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+
+
+;Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+
+
+;Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+
+
+;To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+
+
+;There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
+There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
 
 

--- a/pl/mozorg/newsletters.lang
+++ b/pl/mozorg/newsletters.lang
@@ -88,13 +88,13 @@ Subskrypcja została potwierdzona.
 
 
 # Name for the newsletter in Newsletter subscription page
-;Firefox + You
-Firefox i Ty
+;Firefox News
+Firefox News
 
 
-# Description for the newsletter in Newsletter subscription page (Firefox + You)
-;A monthly newsletter and special announcements giving you tips to improve your experience with Firefox on your desktop and Android device.
-Comiesięczny biuletyn i porady o tym, w jaki sposób w pełni wykorzystywać potencjał Firefoksa oraz Firefoksa na Androida.
+# Description for the newsletter in Newsletter subscription page (Firefox News)
+;Get how-tos, advice and news to make your Firefox experience work best for you.
+Get how-tos, advice and news to make your Firefox experience work best for you.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -148,8 +148,8 @@ Comiesięczny biuletyn, pozwalający być na bieżąco z programem Firefox Affi
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Developer Newsletter
-Biuletyn Mozilla Developer
+;Developer Newsletter
+Developer Newsletter
 
 
 # Description for the newsletter in Newsletter subscription page (Mozilla Developer Newsletter)
@@ -232,13 +232,13 @@ Nowości nt. bety
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Foundation
-Fundacja Mozilli
+;Mozilla News
+Mozilla News
 
 
-# Description for the newsletter in Newsletter subscription page (Mozilla Foundation)
-;News and special updates about our work to promote openness, innovation and participation on the Internet, including ways for you to get involved.
-Wiadomości i informacje na temat naszych wysiłków promujących otwartość, innowacyjność i dostępność Internetu oraz możliwości pomocy nam w tych zadaniach.
+# Description for the newsletter in Newsletter subscription page (Mozilla News)
+;Regular updates to keep you informed and active in our fight for a better internet.
+Regular updates to keep you informed and active in our fight for a better internet.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -251,8 +251,64 @@ Kształt sieci
 Wiadomości i informacje dotyczące stanu sieci.
 
 
-;About Addons
-O dodatkach
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Community
+Mozilla Community
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Community)
+;Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Internet Health Report
+Internet Health Report
+
+
+# Description for the newsletter in Newsletter subscription page (Internet Health Report)
+;Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Knowledge is Power
+Knowledge is Power
+
+
+# Description for the newsletter in Newsletter subscription page (Knowledge is Power)
+;Get all the knowledge you need to stay safer and smarter online.
+Get all the knowledge you need to stay safer and smarter online.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Labs
+Mozilla Labs
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Labs)
+;We're building the technology of the future. Come explore with us.
+We're building the technology of the future. Come explore with us.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Take Action for the Internet
+Take Action for the Internet
+
+
+# Description for the newsletter in Newsletter subscription page (Take Action for the Internet)
+;Add your voice to petitions, events and initiatives that fight for the future of the web.
+Add your voice to petitions, events and initiatives that fight for the future of the web.
+
+
+# Name for the newsletter in Newsletter subscription page
+;New Product Testing
+New Product Testing
+
+
+# Description for the newsletter in Newsletter subscription page (New Product Testing)
+;Help us make a better Firefox for you by test-driving our latest products and features.
+Help us make a better Firefox for you by test-driving our latest products and features.
 
 
 ;Firefox OS
@@ -347,6 +403,10 @@ Nie zapomnij sprawdzić swojej skrzynki pocztowej, aby potwierdzić subskrypcję
 Firefox {ok}
 
 
+;Desktop
+Desktop
+
+
 ;We’re sorry to see you go.
 Przykro nam, że odchodzisz.
 
@@ -419,8 +479,8 @@ Wolę śledzić Mozillę na Twitterze i Facebooku.
 Sukces! Wiadomość z odnośnikiem do panelu ustawień subskrypcji została wysyłana.
 
 
-;Remove me from all Mozilla emails
-Usuń wszystkie subskrypcje Mozilli
+;Remove me from all the subscriptions on this page
+Remove me from all the subscriptions on this page
 
 
 ;Thanks for telling us why you’re leaving.
@@ -441,10 +501,6 @@ Dodatki
 
 ;%s is not a valid newsletter
 „%s” nie jest prawidłowym biuletynem
-
-
-;English&nbsp;only
-Tylko po angielsku
 
 
 ;This is not a valid email address. Please check the spelling.
@@ -683,5 +739,25 @@ Adres e-mail
 # Only localize "yourname". Do not touch @example.com.
 ;yourname@example.com
 e-mail@example.com
+
+
+;Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+
+
+;Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+
+
+;Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+
+
+;To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+
+
+;There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
+There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
 
 

--- a/pt-BR/mozorg/newsletters.lang
+++ b/pt-BR/mozorg/newsletters.lang
@@ -88,13 +88,13 @@ A sua assinatura do boletim informativo foi confirmada.
 
 
 # Name for the newsletter in Newsletter subscription page
-;Firefox + You
-Firefox + você
+;Firefox News
+Firefox News
 
 
-# Description for the newsletter in Newsletter subscription page (Firefox + You)
-;A monthly newsletter and special announcements giving you tips to improve your experience with Firefox on your desktop and Android device.
-Um boletim informativo mensal com dicas e novidades que te ajudarão a tirar o melhor proveito do seu Firefox no computador ou no seu aparelho Android.
+# Description for the newsletter in Newsletter subscription page (Firefox News)
+;Get how-tos, advice and news to make your Firefox experience work best for you.
+Get how-tos, advice and news to make your Firefox experience work best for you.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -148,8 +148,8 @@ Um boletim informativo mensal para mante-lo atualizado com o programa afiliados 
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Developer Newsletter
-Mozilla Developer Newsletter {ok}
+;Developer Newsletter
+Developer Newsletter
 
 
 # Description for the newsletter in Newsletter subscription page (Mozilla Developer Newsletter)
@@ -232,13 +232,13 @@ Novidades do Beta
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Foundation
-Fundação Mozilla
+;Mozilla News
+Mozilla News
 
 
-# Description for the newsletter in Newsletter subscription page (Mozilla Foundation)
-;News and special updates about our work to promote openness, innovation and participation on the Internet, including ways for you to get involved.
-Notícias e atualizações especiais sobre o nosso trabalho promovendo a abertura, inovação e participação na Internet, incluindo maneiras de se envolver.
+# Description for the newsletter in Newsletter subscription page (Mozilla News)
+;Regular updates to keep you informed and active in our fight for a better internet.
+Regular updates to keep you informed and active in our fight for a better internet.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -251,8 +251,64 @@ Forma da Web
 Notícias e informações relacionadas com a saúde da web.
 
 
-;About Addons
-Sobre extensões
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Community
+Mozilla Community
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Community)
+;Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Internet Health Report
+Internet Health Report
+
+
+# Description for the newsletter in Newsletter subscription page (Internet Health Report)
+;Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Knowledge is Power
+Knowledge is Power
+
+
+# Description for the newsletter in Newsletter subscription page (Knowledge is Power)
+;Get all the knowledge you need to stay safer and smarter online.
+Get all the knowledge you need to stay safer and smarter online.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Labs
+Mozilla Labs
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Labs)
+;We're building the technology of the future. Come explore with us.
+We're building the technology of the future. Come explore with us.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Take Action for the Internet
+Take Action for the Internet
+
+
+# Description for the newsletter in Newsletter subscription page (Take Action for the Internet)
+;Add your voice to petitions, events and initiatives that fight for the future of the web.
+Add your voice to petitions, events and initiatives that fight for the future of the web.
+
+
+# Name for the newsletter in Newsletter subscription page
+;New Product Testing
+New Product Testing
+
+
+# Description for the newsletter in Newsletter subscription page (New Product Testing)
+;Help us make a better Firefox for you by test-driving our latest products and features.
+Help us make a better Firefox for you by test-driving our latest products and features.
 
 
 ;Firefox OS
@@ -347,6 +403,10 @@ Não se esqueça de verificar sua caixa de entrada para confirmar seu pedido par
 Firefox {ok}
 
 
+;Desktop
+Desktop
+
+
 ;We’re sorry to see you go.
 Ficamos triste em te ver partir.
 
@@ -419,8 +479,8 @@ Vou acompanhar a Mozilla no Facebook e no Twitter somente.
 Sucesso! Um e-mail foi enviado para você com o seu link do centro de preferência. Obrigado!
 
 
-;Remove me from all Mozilla emails
-Me descadastre de todas as novidades da Mozilla
+;Remove me from all the subscriptions on this page
+Remove me from all the subscriptions on this page
 
 
 ;Thanks for telling us why you’re leaving.
@@ -441,10 +501,6 @@ Extensões
 
 ;%s is not a valid newsletter
 %s não é um boletim informativo valido
-
-
-;English&nbsp;only
-Somente em Inglês
 
 
 ;This is not a valid email address. Please check the spelling.
@@ -683,5 +739,25 @@ Seu endereço de e-mail
 # Only localize "yourname". Do not touch @example.com.
 ;yourname@example.com
 seunome@example.com
+
+
+;Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+
+
+;Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+
+
+;Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+
+
+;To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+
+
+;There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
+There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
 
 

--- a/ru/mozorg/newsletters.lang
+++ b/ru/mozorg/newsletters.lang
@@ -88,13 +88,13 @@ Mozilla занимается множеством важным проблем.
 
 
 # Name for the newsletter in Newsletter subscription page
-;Firefox + You
-Firefox и Вы
+;Firefox News
+Firefox News
 
 
-# Description for the newsletter in Newsletter subscription page (Firefox + You)
-;A monthly newsletter and special announcements giving you tips to improve your experience with Firefox on your desktop and Android device.
-Ежемесячная новостная рассылка и объявления, с советами по улучшению работы с Firefox на вашем компьтере и устройстве Android.
+# Description for the newsletter in Newsletter subscription page (Firefox News)
+;Get how-tos, advice and news to make your Firefox experience work best for you.
+Get how-tos, advice and news to make your Firefox experience work best for you.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -148,8 +148,8 @@ Firefox Affiliates {ok}
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Developer Newsletter
-Рассылка для разработчиков от Mozilla
+;Developer Newsletter
+Developer Newsletter
 
 
 # Description for the newsletter in Newsletter subscription page (Mozilla Developer Newsletter)
@@ -232,13 +232,13 @@ Firefox Flicks {ok}
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Foundation
-Mozilla Foundation {ok}
+;Mozilla News
+Mozilla News
 
 
-# Description for the newsletter in Newsletter subscription page (Mozilla Foundation)
-;News and special updates about our work to promote openness, innovation and participation on the Internet, including ways for you to get involved.
-Новости о продвижении открытости, внедрении инноваций и участии в развитии Интернета, а также о том, как принять участие в наших проектах.
+# Description for the newsletter in Newsletter subscription page (Mozilla News)
+;Regular updates to keep you informed and active in our fight for a better internet.
+Regular updates to keep you informed and active in our fight for a better internet.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -251,8 +251,64 @@ Mozilla Foundation {ok}
 Новости и информация о здоровье Интернета.
 
 
-;About Addons
-О дополнениях
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Community
+Mozilla Community
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Community)
+;Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Internet Health Report
+Internet Health Report
+
+
+# Description for the newsletter in Newsletter subscription page (Internet Health Report)
+;Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Knowledge is Power
+Knowledge is Power
+
+
+# Description for the newsletter in Newsletter subscription page (Knowledge is Power)
+;Get all the knowledge you need to stay safer and smarter online.
+Get all the knowledge you need to stay safer and smarter online.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Labs
+Mozilla Labs
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Labs)
+;We're building the technology of the future. Come explore with us.
+We're building the technology of the future. Come explore with us.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Take Action for the Internet
+Take Action for the Internet
+
+
+# Description for the newsletter in Newsletter subscription page (Take Action for the Internet)
+;Add your voice to petitions, events and initiatives that fight for the future of the web.
+Add your voice to petitions, events and initiatives that fight for the future of the web.
+
+
+# Name for the newsletter in Newsletter subscription page
+;New Product Testing
+New Product Testing
+
+
+# Description for the newsletter in Newsletter subscription page (New Product Testing)
+;Help us make a better Firefox for you by test-driving our latest products and features.
+Help us make a better Firefox for you by test-driving our latest products and features.
 
 
 ;Firefox OS
@@ -347,6 +403,10 @@ Firefox OS: Новости, советы, информация по запуск
 Firefox {ok}
 
 
+;Desktop
+Desktop
+
+
 ;We’re sorry to see you go.
 Нам жаль, что вы уходите.
 
@@ -419,8 +479,8 @@ Firefox на iOS — Подпишитесь на обновления по эл.
 Успех! Вам отправлено письмо со ссылкой на страницу настроек. Спасибо!
 
 
-;Remove me from all Mozilla emails
-Отписаться от всех рассылок Mozilla
+;Remove me from all the subscriptions on this page
+Remove me from all the subscriptions on this page
 
 
 ;Thanks for telling us why you’re leaving.
@@ -441,10 +501,6 @@ Firefox на iOS — Подпишитесь на обновления по эл.
 
 ;%s is not a valid newsletter
 %s не является корректной новостной рассылкой
-
-
-;English&nbsp;only
-Только на английском
 
 
 ;This is not a valid email address. Please check the spelling.
@@ -683,5 +739,25 @@ Firefox Marketplace для компьютера
 # Only localize "yourname". Do not touch @example.com.
 ;yourname@example.com
 вы@example.com
+
+
+;Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+
+
+;Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+
+
+;Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+
+
+;To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+
+
+;There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
+There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
 
 

--- a/zh-TW/mozorg/newsletters.lang
+++ b/zh-TW/mozorg/newsletters.lang
@@ -88,13 +88,13 @@ Mozilla 關注不同的重大議題。
 
 
 # Name for the newsletter in Newsletter subscription page
-;Firefox + You
-Firefox + You {ok}
+;Firefox News
+Firefox News
 
 
-# Description for the newsletter in Newsletter subscription page (Firefox + You)
-;A monthly newsletter and special announcements giving you tips to improve your experience with Firefox on your desktop and Android device.
-本電子報每月寄出，可讓您改善桌面版與 Android 版 Firefox 的使用體驗。
+# Description for the newsletter in Newsletter subscription page (Firefox News)
+;Get how-tos, advice and news to make your Firefox experience work best for you.
+Get how-tos, advice and news to make your Firefox experience work best for you.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -148,8 +148,8 @@ Firefox 夥伴計畫
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Developer Newsletter
-Mozilla 開發者電子報
+;Developer Newsletter
+Developer Newsletter
 
 
 # Description for the newsletter in Newsletter subscription page (Mozilla Developer Newsletter)
@@ -232,13 +232,13 @@ Beta 測試版消息
 
 
 # Name for the newsletter in Newsletter subscription page
-;Mozilla Foundation
-Mozilla 基金會
+;Mozilla News
+Mozilla News
 
 
-# Description for the newsletter in Newsletter subscription page (Mozilla Foundation)
-;News and special updates about our work to promote openness, innovation and participation on the Internet, including ways for you to get involved.
-關於我們如何推廣網際網路上的開放、創新、參與，以及您可如何參與的方式。
+# Description for the newsletter in Newsletter subscription page (Mozilla News)
+;Regular updates to keep you informed and active in our fight for a better internet.
+Regular updates to keep you informed and active in our fight for a better internet.
 
 
 # Name for the newsletter in Newsletter subscription page
@@ -251,8 +251,64 @@ Shape of the Web {ok}
 與 Web 的生態相關的新聞與資訊。
 
 
-;About Addons
-About Addons {ok}
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Community
+Mozilla Community
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Community)
+;Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Internet Health Report
+Internet Health Report
+
+
+# Description for the newsletter in Newsletter subscription page (Internet Health Report)
+;Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Knowledge is Power
+Knowledge is Power
+
+
+# Description for the newsletter in Newsletter subscription page (Knowledge is Power)
+;Get all the knowledge you need to stay safer and smarter online.
+Get all the knowledge you need to stay safer and smarter online.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Mozilla Labs
+Mozilla Labs
+
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Labs)
+;We're building the technology of the future. Come explore with us.
+We're building the technology of the future. Come explore with us.
+
+
+# Name for the newsletter in Newsletter subscription page
+;Take Action for the Internet
+Take Action for the Internet
+
+
+# Description for the newsletter in Newsletter subscription page (Take Action for the Internet)
+;Add your voice to petitions, events and initiatives that fight for the future of the web.
+Add your voice to petitions, events and initiatives that fight for the future of the web.
+
+
+# Name for the newsletter in Newsletter subscription page
+;New Product Testing
+New Product Testing
+
+
+# Description for the newsletter in Newsletter subscription page (New Product Testing)
+;Help us make a better Firefox for you by test-driving our latest products and features.
+Help us make a better Firefox for you by test-driving our latest products and features.
 
 
 ;Firefox OS
@@ -347,6 +403,10 @@ Mozilla 都在幹什麼？
 Firefox {ok}
 
 
+;Desktop
+Desktop
+
+
 ;We’re sorry to see you go.
 很抱歉您要離開。
 
@@ -419,8 +479,8 @@ Firefox iOS 版 — 訂閱最新消息電子報 — Mozilla
 成功！已經將偏好中心的鏈結寄出給您，多謝了！
 
 
-;Remove me from all Mozilla emails
-我要退訂所有來自 Mozilla 的郵件
+;Remove me from all the subscriptions on this page
+Remove me from all the subscriptions on this page
 
 
 ;Thanks for telling us why you’re leaving.
@@ -441,10 +501,6 @@ Firefox iOS 版 — 訂閱最新消息電子報 — Mozilla
 
 ;%s is not a valid newsletter
 %s 不是有效的電子報
-
-
-;English&nbsp;only
-僅有英文版
 
 
 ;This is not a valid email address. Please check the spelling.
@@ -683,5 +739,25 @@ Firefox Marketplace 桌面版
 # Only localize "yourname". Do not touch @example.com.
 ;yourname@example.com
 yourname@example.com {ok}
+
+
+;Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+
+
+;Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+
+
+;Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href="%s">account management support page</a>.
+
+
+;To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href="%s">here</a>.
+
+
+;There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
+There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href="%s">community pages</a>.
 
 


### PR DESCRIPTION
Bedrock PR for reference: https://github.com/mozilla/bedrock/pull/7198

Priority locales are: EN, DE, FR, ES, ID, pt-BR, RU, PL, zh-TW + BG, CS, HU, IT, HU, NL

Some notes:

- I could only extract strings from the HTML template using `l10n_extract`, so I had to manually copy & paste the string changes from `views.py`. Please double-check carefully that I did everything right.
- I have been told there is no need for l10n tags here, and it is OK for strings to default to English if untranslated.
- Until now `newsletter.lang` used the email title strings `Firefox + You` and `Mozilla Foundation`, however in bedrock the titles were just `Firefox` and `Mozilla`. They have now changed to `Firefox News` and `Mozilla News` respectively.
- I've removed the strings `About Addons` and `English&nbsp;only`, as the only place they are used appeared to be the preferences page.