### PR TITLE
Add lifecycle "welcome" page 1

### DIFF
--- a/de/firefox/welcome/page1.lang
+++ b/de/firefox/welcome/page1.lang
@@ -1,0 +1,57 @@
+## NOTE: Demo https://bedrock-demo-craigcook.oregon-b.moz.works/firefox/welcome/1/
+
+
+# HTML page title
+;More than a browser - Firefox products protect your life online
+More than a browser - Firefox products protect your life online
+
+
+# HTML page description
+# "Firefox Monitor" is a product name and shouldn't be translated.
+;Use Firefox Monitor to see if your info was compromised in another company’s data breach — and get automatically signed up for future alerts.
+Use Firefox Monitor to see if your info was compromised in another company’s data breach — and get automatically signed up for future alerts.
+
+
+;You’re on track to stay protected
+You’re on track to stay protected
+
+
+# A "lookout" is someone who watches for danger and alerts you when it's coming.
+;You’ve got the web browser that protects your privacy — now it’s time to get a lookout for hackers.
+You’ve got the web browser that protects your privacy — now it’s time to get a lookout for hackers.
+
+
+# "Firefox Monitor" is a product name and shouldn't be translated.
+;Firefox Monitor shows you if your information has been leaked in a known data breach, and alerts you in case it happens in the future.
+Firefox Monitor shows you if your information has been leaked in a known data breach, and alerts you in case it happens in the future.
+
+
+# CTA button
+;Check Your Breach Report
+Check Your Breach Report
+
+
+;Stay ahead of hackers
+Stay ahead of hackers
+
+
+;Find ways to protect your info with <a href="%(security_tips)s">Monitor Security Tips</a>.
+Find ways to protect your info with <a href="%(security_tips)s">Monitor Security Tips</a>.
+
+
+# To stay "in the know" means to stay informed, be up-to-date.
+;Stay in the know
+Stay in the know
+
+
+# "Evite" is a proper name and shouldn't be translated.
+# "party" is in quotes for sarcasm; this major data breach was not a party at all.
+;Were you one of 100,985,047 invited to the <a href="%(evite_breach)s">Evite data breach “party”</a>?
+Were you one of 100,985,047 invited to the <a href="%(evite_breach)s">Evite data breach “party”</a>?
+
+
+# Link to SUMO
+;Why am I seeing this?
+Why am I seeing this?
+
+

--- a/en-CA/firefox/welcome/page1.lang
+++ b/en-CA/firefox/welcome/page1.lang
@@ -1,0 +1,57 @@
+## NOTE: Demo https://bedrock-demo-craigcook.oregon-b.moz.works/firefox/welcome/1/
+
+
+# HTML page title
+;More than a browser - Firefox products protect your life online
+More than a browser - Firefox products protect your life online
+
+
+# HTML page description
+# "Firefox Monitor" is a product name and shouldn't be translated.
+;Use Firefox Monitor to see if your info was compromised in another company’s data breach — and get automatically signed up for future alerts.
+Use Firefox Monitor to see if your info was compromised in another company’s data breach — and get automatically signed up for future alerts.
+
+
+;You’re on track to stay protected
+You’re on track to stay protected
+
+
+# A "lookout" is someone who watches for danger and alerts you when it's coming.
+;You’ve got the web browser that protects your privacy — now it’s time to get a lookout for hackers.
+You’ve got the web browser that protects your privacy — now it’s time to get a lookout for hackers.
+
+
+# "Firefox Monitor" is a product name and shouldn't be translated.
+;Firefox Monitor shows you if your information has been leaked in a known data breach, and alerts you in case it happens in the future.
+Firefox Monitor shows you if your information has been leaked in a known data breach, and alerts you in case it happens in the future.
+
+
+# CTA button
+;Check Your Breach Report
+Check Your Breach Report
+
+
+;Stay ahead of hackers
+Stay ahead of hackers
+
+
+;Find ways to protect your info with <a href="%(security_tips)s">Monitor Security Tips</a>.
+Find ways to protect your info with <a href="%(security_tips)s">Monitor Security Tips</a>.
+
+
+# To stay "in the know" means to stay informed, be up-to-date.
+;Stay in the know
+Stay in the know
+
+
+# "Evite" is a proper name and shouldn't be translated.
+# "party" is in quotes for sarcasm; this major data breach was not a party at all.
+;Were you one of 100,985,047 invited to the <a href="%(evite_breach)s">Evite data breach “party”</a>?
+Were you one of 100,985,047 invited to the <a href="%(evite_breach)s">Evite data breach “party”</a>?
+
+
+# Link to SUMO
+;Why am I seeing this?
+Why am I seeing this?
+
+

--- a/en-GB/firefox/welcome/page1.lang
+++ b/en-GB/firefox/welcome/page1.lang
@@ -1,0 +1,57 @@
+## NOTE: Demo https://bedrock-demo-craigcook.oregon-b.moz.works/firefox/welcome/1/
+
+
+# HTML page title
+;More than a browser - Firefox products protect your life online
+More than a browser - Firefox products protect your life online
+
+
+# HTML page description
+# "Firefox Monitor" is a product name and shouldn't be translated.
+;Use Firefox Monitor to see if your info was compromised in another company’s data breach — and get automatically signed up for future alerts.
+Use Firefox Monitor to see if your info was compromised in another company’s data breach — and get automatically signed up for future alerts.
+
+
+;You’re on track to stay protected
+You’re on track to stay protected
+
+
+# A "lookout" is someone who watches for danger and alerts you when it's coming.
+;You’ve got the web browser that protects your privacy — now it’s time to get a lookout for hackers.
+You’ve got the web browser that protects your privacy — now it’s time to get a lookout for hackers.
+
+
+# "Firefox Monitor" is a product name and shouldn't be translated.
+;Firefox Monitor shows you if your information has been leaked in a known data breach, and alerts you in case it happens in the future.
+Firefox Monitor shows you if your information has been leaked in a known data breach, and alerts you in case it happens in the future.
+
+
+# CTA button
+;Check Your Breach Report
+Check Your Breach Report
+
+
+;Stay ahead of hackers
+Stay ahead of hackers
+
+
+;Find ways to protect your info with <a href="%(security_tips)s">Monitor Security Tips</a>.
+Find ways to protect your info with <a href="%(security_tips)s">Monitor Security Tips</a>.
+
+
+# To stay "in the know" means to stay informed, be up-to-date.
+;Stay in the know
+Stay in the know
+
+
+# "Evite" is a proper name and shouldn't be translated.
+# "party" is in quotes for sarcasm; this major data breach was not a party at all.
+;Were you one of 100,985,047 invited to the <a href="%(evite_breach)s">Evite data breach “party”</a>?
+Were you one of 100,985,047 invited to the <a href="%(evite_breach)s">Evite data breach “party”</a>?
+
+
+# Link to SUMO
+;Why am I seeing this?
+Why am I seeing this?
+
+

--- a/en-US/firefox/welcome/page1.lang
+++ b/en-US/firefox/welcome/page1.lang
@@ -8,6 +8,7 @@ More than a browser - Firefox products protect your life online
 
 
 # HTML page description
+# "Firefox Monitor" is a product name and shouldn't be translated.
 ;Use Firefox Monitor to see if your info was compromised in another company’s data breach — and get automatically signed up for future alerts.
 Use Firefox Monitor to see if your info was compromised in another company’s data breach — and get automatically signed up for future alerts.
 
@@ -16,6 +17,7 @@ Use Firefox Monitor to see if your info was compromised in another company’s d
 You’re on track to stay protected
 
 
+# A "lookout" is someone who watches for danger and alerts you when it's coming.
 ;You’ve got the web browser that protects your privacy — now it’s time to get a lookout for hackers.
 You’ve got the web browser that protects your privacy — now it’s time to get a lookout for hackers.
 
@@ -38,11 +40,13 @@ Stay ahead of hackers
 Find ways to protect your info with <a href="%(security_tips)s">Monitor Security Tips</a>.
 
 
+# To stay "in the know" means to stay informed, be up-to-date.
 ;Stay in the know
 Stay in the know
 
 
 # "Evite" is a proper name and shouldn't be translated.
+# "party" is in quotes for sarcasm; this major data breach was not a party at all.
 ;Were you one of 100,985,047 invited to the <a href="%(evite_breach)s">Evite data breach “party”</a>?
 Were you one of 100,985,047 invited to the <a href="%(evite_breach)s">Evite data breach “party”</a>?
 

--- a/en-US/firefox/welcome/page1.lang
+++ b/en-US/firefox/welcome/page1.lang
@@ -1,0 +1,52 @@
+## NOTE: Demo https://bedrock-demo-craigcook.oregon-b.moz.works/firefox/welcome/1/
+## URL: https://www-dev.allizom.org/%LOCALE%/firefox/welcome/1/
+
+
+# HTML page title
+;More than a browser - Firefox products protect your life online
+More than a browser - Firefox products protect your life online
+
+
+# HTML page description
+;Use Firefox Monitor to see if your info was compromised in another company’s data breach — and get automatically signed up for future alerts.
+Use Firefox Monitor to see if your info was compromised in another company’s data breach — and get automatically signed up for future alerts.
+
+
+;You’re on track to stay protected
+You’re on track to stay protected
+
+
+;You’ve got the web browser that protects your privacy — now it’s time to get a lookout for hackers.
+You’ve got the web browser that protects your privacy — now it’s time to get a lookout for hackers.
+
+
+# "Firefox Monitor" is a product name and shouldn't be translated.
+;Firefox Monitor shows you if your information has been leaked in a known data breach, and alerts you in case it happens in the future.
+Firefox Monitor shows you if your information has been leaked in a known data breach, and alerts you in case it happens in the future.
+
+
+# CTA button
+;Check Your Breach Report
+Check Your Breach Report
+
+
+;Stay ahead of hackers
+Stay ahead of hackers
+
+
+;Find ways to protect your info with <a href="%(security_tips)s">Monitor Security Tips</a>.
+Find ways to protect your info with <a href="%(security_tips)s">Monitor Security Tips</a>.
+
+
+;Stay in the know
+Stay in the know
+
+
+# "Evite" is a proper name and shouldn't be translated.
+;Were you one of 100,985,047 invited to the <a href="%(evite_breach)s">Evite data breach “party”</a>?
+Were you one of 100,985,047 invited to the <a href="%(evite_breach)s">Evite data breach “party”</a>?
+
+
+# Link to SUMO
+;Why am I seeing this?
+Why am I seeing this?

--- a/es-ES/firefox/welcome/page1.lang
+++ b/es-ES/firefox/welcome/page1.lang
@@ -1,0 +1,57 @@
+## NOTE: Demo https://bedrock-demo-craigcook.oregon-b.moz.works/firefox/welcome/1/
+
+
+# HTML page title
+;More than a browser - Firefox products protect your life online
+More than a browser - Firefox products protect your life online
+
+
+# HTML page description
+# "Firefox Monitor" is a product name and shouldn't be translated.
+;Use Firefox Monitor to see if your info was compromised in another company’s data breach — and get automatically signed up for future alerts.
+Use Firefox Monitor to see if your info was compromised in another company’s data breach — and get automatically signed up for future alerts.
+
+
+;You’re on track to stay protected
+You’re on track to stay protected
+
+
+# A "lookout" is someone who watches for danger and alerts you when it's coming.
+;You’ve got the web browser that protects your privacy — now it’s time to get a lookout for hackers.
+You’ve got the web browser that protects your privacy — now it’s time to get a lookout for hackers.
+
+
+# "Firefox Monitor" is a product name and shouldn't be translated.
+;Firefox Monitor shows you if your information has been leaked in a known data breach, and alerts you in case it happens in the future.
+Firefox Monitor shows you if your information has been leaked in a known data breach, and alerts you in case it happens in the future.
+
+
+# CTA button
+;Check Your Breach Report
+Check Your Breach Report
+
+
+;Stay ahead of hackers
+Stay ahead of hackers
+
+
+;Find ways to protect your info with <a href="%(security_tips)s">Monitor Security Tips</a>.
+Find ways to protect your info with <a href="%(security_tips)s">Monitor Security Tips</a>.
+
+
+# To stay "in the know" means to stay informed, be up-to-date.
+;Stay in the know
+Stay in the know
+
+
+# "Evite" is a proper name and shouldn't be translated.
+# "party" is in quotes for sarcasm; this major data breach was not a party at all.
+;Were you one of 100,985,047 invited to the <a href="%(evite_breach)s">Evite data breach “party”</a>?
+Were you one of 100,985,047 invited to the <a href="%(evite_breach)s">Evite data breach “party”</a>?
+
+
+# Link to SUMO
+;Why am I seeing this?
+Why am I seeing this?
+
+

--- a/fr/firefox/welcome/page1.lang
+++ b/fr/firefox/welcome/page1.lang
@@ -1,0 +1,57 @@
+## NOTE: Demo https://bedrock-demo-craigcook.oregon-b.moz.works/firefox/welcome/1/
+
+
+# HTML page title
+;More than a browser - Firefox products protect your life online
+More than a browser - Firefox products protect your life online
+
+
+# HTML page description
+# "Firefox Monitor" is a product name and shouldn't be translated.
+;Use Firefox Monitor to see if your info was compromised in another company’s data breach — and get automatically signed up for future alerts.
+Use Firefox Monitor to see if your info was compromised in another company’s data breach — and get automatically signed up for future alerts.
+
+
+;You’re on track to stay protected
+You’re on track to stay protected
+
+
+# A "lookout" is someone who watches for danger and alerts you when it's coming.
+;You’ve got the web browser that protects your privacy — now it’s time to get a lookout for hackers.
+You’ve got the web browser that protects your privacy — now it’s time to get a lookout for hackers.
+
+
+# "Firefox Monitor" is a product name and shouldn't be translated.
+;Firefox Monitor shows you if your information has been leaked in a known data breach, and alerts you in case it happens in the future.
+Firefox Monitor shows you if your information has been leaked in a known data breach, and alerts you in case it happens in the future.
+
+
+# CTA button
+;Check Your Breach Report
+Check Your Breach Report
+
+
+;Stay ahead of hackers
+Stay ahead of hackers
+
+
+;Find ways to protect your info with <a href="%(security_tips)s">Monitor Security Tips</a>.
+Find ways to protect your info with <a href="%(security_tips)s">Monitor Security Tips</a>.
+
+
+# To stay "in the know" means to stay informed, be up-to-date.
+;Stay in the know
+Stay in the know
+
+
+# "Evite" is a proper name and shouldn't be translated.
+# "party" is in quotes for sarcasm; this major data breach was not a party at all.
+;Were you one of 100,985,047 invited to the <a href="%(evite_breach)s">Evite data breach “party”</a>?
+Were you one of 100,985,047 invited to the <a href="%(evite_breach)s">Evite data breach “party”</a>?
+
+
+# Link to SUMO
+;Why am I seeing this?
+Why am I seeing this?
+
+


### PR DESCRIPTION
A page automatically shown to new Firefox users a short period of time after they installed. Demo at https://bedrock-demo-craigcook.oregon-b.moz.works/firefox/welcome/1/

Initially limited to English, French, and German and we may expand to more if it performs well.

Compare to template: https://github.com/mozilla/bedrock/blob/13cb3cc4146f7ee03956cc1064cc0bffcb9323cf/bedrock/firefox/templates/firefox/welcome/page1.html

Langchecker PR https://github.com/mozilla-l10n/langchecker/pull/917