### PR TITLE
Update the legacy whatsnew page

### DIFF
--- a/ach/firefox/whatsnew.lang
+++ b/ach/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@ Gam Firefox pi Android ki iOS
 Your Firefox is up to date.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Cwal Firefox i cim mamegi<br> ka i gony intanet mamegi.

--- a/af/firefox/whatsnew.lang
+++ b/af/firefox/whatsnew.lang
@@ -1,5 +1,5 @@
 ## active ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -11,10 +11,21 @@ Laai Firefox af vir Android en iOS
 Firefox is op datum.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Stuur Firefox na 'n foon<br> en stel die Internet vry.

--- a/am/firefox/whatsnew.lang
+++ b/am/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@ Download Firefox for Android and iOS
 Your Firefox is up to date.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.

--- a/an/firefox/whatsnew.lang
+++ b/an/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Descarga lo Firefox pa Android y iOS
 O tuyo Firefox ye esviellau.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Lo nuevo <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Ninvia lo Firefox a lo tuyo mobil<br> y libera la tuya internet.

--- a/ar/firefox/whatsnew.lang
+++ b/ar/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@
 مُتصفح فَيَرفُكس لديك مُحدّث
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 <strong>فَيَرفُكس</strong> الجديد
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 حمّل فَيَرفُكس على هاتفك<br> وتمتّع بحرّيتك على الإنترنت.

--- a/ast/firefox/whatsnew.lang
+++ b/ast/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Baxa Firefox p'Android ya iOS
 El to Firefox ta anováu.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 El <strong>Firefox</strong> nuevu
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Unvia Firefox al to teléfonu<br> y llibera'l to internet.

--- a/az/firefox/whatsnew.lang
+++ b/az/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Android və iOS üçün Firefox endir
 Firefoxunuz güncəldir.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Yeni <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Firefox-u telefonuna göndər<br> və internetini azad et.

--- a/azz/firefox/whatsnew.lang
+++ b/azz/firefox/whatsnew.lang
@@ -1,5 +1,5 @@
 ## active ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -11,10 +11,21 @@ Xikontemoui Firefox ika Android uan iOS
 Senkis kiyankuilijkejya moFirefox
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Xikonpanoltili moteléfono Firefox <br> uan xikonajchiuili moInternet teposcadenas.

--- a/be/firefox/whatsnew.lang
+++ b/be/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@
 У вас апошняя версія Firefox.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Новы <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Усталюйце Firefox на свой тэлефон<br> і раскрыйце ўвесь патэнцыял Інтэрнэту.

--- a/bg/firefox/whatsnew.lang
+++ b/bg/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@
 Вашия Firefox е актуализиран до последна версия.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Новият <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Изпратете Firefox на телефона си<br>и освободете своя интернет.

--- a/bn/firefox/whatsnew.lang
+++ b/bn/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Android এবং iOS এর জন্য Firefox ডাউনলোড কর�
 আপনার Firefox হালনাগাদ রয়েছে
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 নতুন <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 আপনার ফোনে Firefox পাঠান<br> এবং আপনার ইন্টারনেটকে উন্মোচন করুন।

--- a/br/firefox/whatsnew.lang
+++ b/br/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@ Download Firefox for Android and iOS
 Hizivaet eo ho Firefox.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.

--- a/bs/firefox/whatsnew.lang
+++ b/bs/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Preuzmite Firefox za Android i iOS
 Imate najnoviji Firefox.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Novi <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Pošaljite Firefox na vaš telefon<br> i oslobodite vaš internet.

--- a/ca/firefox/whatsnew.lang
+++ b/ca/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Baixeu el Firefox per l'Android i iOS
 El vostre Firefox està actualitzat.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 El nou <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Envieu el Firefox al telèfon<br> i doneu curs a Internet.

--- a/cak/firefox/whatsnew.lang
+++ b/cak/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Taqasaj Firefox richin Android chuqa' richin iOS
 K'exon chi ri aFirefox.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Ri k'ak'a' <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Tataqa' ri Firefox pan awoyonib'al<br> richin nachäp nawokisaj Ak'amaya'l.

--- a/crh/firefox/whatsnew.lang
+++ b/crh/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@ Download Firefox for Android and iOS
 Your Firefox is up to date.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.

--- a/cs/firefox/whatsnew.lang
+++ b/cs/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Stáhněte si Firefox pro Android a iOS
 Váš Firefox je aktuální.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Nový <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Chcete soukromí na každém zařízení?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+Máte ho mít. Firefox pro mobilní telefony.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Nechte si poslat Firefox do svého telefonu<br> a popusťte uzdu internetu.

--- a/cy/firefox/whatsnew.lang
+++ b/cy/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Llwytho i Lawr Firefox Android ac iOS
 Mae eich Firefox yn gyfredol.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Y <strong>Firefox</strong> newydd
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Anfonwch Firefox i'ch ffôn<br> ac agor eich Rhyngrwyd.

--- a/da/firefox/whatsnew.lang
+++ b/da/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Hent Firefox til Android eller iOS
 Din Firefox er opdateret.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Den nye <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox til din telefon<br> og slip nettet løs.

--- a/de/firefox/whatsnew.lang
+++ b/de/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Lade jetzt Firefox für Android und iOS herunter
 Dein Firefox ist aktuell.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Der neue <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Firefox auf's Handy senden <br>und grenzenlos surfen.

--- a/dsb/firefox/whatsnew.lang
+++ b/dsb/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Ześěgniśo Firefox za Android a iOS
 Waš Firefox jo aktualny.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Nowy <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Sćelśo Firefox na swój telefon<br> a wulichujśo internet z pytow.

--- a/el/firefox/whatsnew.lang
+++ b/el/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@
 Το Firefox σας είναι ενημερωμένο.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Το νέο <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Στείλτε το Firefox στο τηλέφωνό σας<br> και απελευθερώστε το διαδίκτυό σας.

--- a/en-CA/firefox/whatsnew.lang
+++ b/en-CA/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Download Firefox for Android and iOS {ok}
 Your Firefox is up to date. {ok}
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong> {ok}
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet. {ok}

--- a/en-GB/firefox/whatsnew.lang
+++ b/en-GB/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Download Firefox for Android and iOS {ok}
 Your Firefox is up to date. {ok}
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong> {ok}
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet. {ok}

--- a/en-US/firefox/whatsnew.lang
+++ b/en-US/firefox/whatsnew.lang
@@ -1,6 +1,7 @@
+## whatsnew_headline_04112019 ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
-## URL: https://www-dev.allizom.org/%LOCALE%/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
+## URL: https://www-dev.allizom.org/%LOCALE%/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -13,10 +14,23 @@ Your Firefox is up to date.
 
 
 ## TAG: whatsnew_rebranding
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+## TAG: whatsnew_headline_04112019
+;Want privacy on every device?
+Want privacy on every device?
+
+
+## TAG: whatsnew_headline_04112019
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.

--- a/eo/firefox/whatsnew.lang
+++ b/eo/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Elŝutu Firefox por Android kaj iOS
 Via Firefox estas ĝisdata.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 La nova <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Sendi Firefox al via telefono<br> kaj senbridigu vian interreton.

--- a/es-AR/firefox/whatsnew.lang
+++ b/es-AR/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Descargá Firefox para Android e iOS
 Tu Firefox está actualizado.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 El nuevo<strong>Firefox</strong>
 
 
+;Want privacy on every device?
+¿Querés privacidad en todos tus dispositivos?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+Usá Firefox para móviles, ¡y listo!
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Enviá Firefox a tu teléfono<br> y da rienda suelta a tu Internet.

--- a/es-CL/firefox/whatsnew.lang
+++ b/es-CL/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Descarga Firefox para Android e iOS
 Tu Firefox está al día.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 El nuevo <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Envía Firefox a tu teléfono<br> y libera tu Internet.

--- a/es-ES/firefox/whatsnew.lang
+++ b/es-ES/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Descarga Firefox para Android e iOS
 Tu Firefox está al día.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 El nuevo <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+¿Quieres privacidad en todos tus dispositivos?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+Ningún problema. Usa Firefox para dispositivos móviles.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Envía Firefox a tu teléfono<br> y da rienda suelta a tu Internet.

--- a/es-MX/firefox/whatsnew.lang
+++ b/es-MX/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Descarga Firefox para Android e iOS
 Tu Firefox está actualizado.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 El nuevo <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+¿Privacidad en todos tus dispositivos?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+¡Fácil! Baja Firefox para dispositivos móviles.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Consigue Firefox para tu teléfono<br> y libera tu Internet.

--- a/et/firefox/whatsnew.lang
+++ b/et/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Firefoxi allalaadimine Androidile ja iOS-ile
 Sinu Firefox on uuendatud.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Uus <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Saada Firefox telefoni<br> ning päästa internet valla.

--- a/eu/firefox/whatsnew.lang
+++ b/eu/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Deskargatu Firefox Android eta iOSerako
 Firefox egunean dago.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 <strong>Firefox</strong> berria
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Bidali Firefox mugikorrera<br> eta askatu zure Interneta.

--- a/fa/firefox/whatsnew.lang
+++ b/fa/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@
 فایرفاکس شما بروز است.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 <strong>Firefox</strong> جدید
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 فایرفاکس را به تلفن خود بفرستید<br> و اینترنت‌تان را از بند برهانید.

--- a/ff/firefox/whatsnew.lang
+++ b/ff/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Aawto Firefox ngam Android kam e iOS
 Firefox maa kena hesɗiti.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 <strong>Firefox</strong> Keso pul
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Neldu Firefox e cinndel maa <br> etee ɗaccit Enternet maa.

--- a/fi/firefox/whatsnew.lang
+++ b/fi/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Lataa Firefox Androidille ja iOS:lle
 Firefox on ajan tasalla.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Uusi <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Lähetä Firefox puhelimeesi<br> ja vapauta internetisi.

--- a/fr/firefox/whatsnew.lang
+++ b/fr/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Télécharger Firefox pour Android et iOS
 Votre version de Firefox est à jour.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Le nouveau <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Ajoutez Firefox à votre téléphone et libérez le potentiel d’Internet.

--- a/fy-NL/firefox/whatsnew.lang
+++ b/fy-NL/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Download Firefox foar Android en iOS
 Jo Firefox is by-de-tiid.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 De nije <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Stjoer Firefox nei jo telefoan<br> en iepenje jo ynternet.

--- a/ga-IE/firefox/whatsnew.lang
+++ b/ga-IE/firefox/whatsnew.lang
@@ -1,5 +1,5 @@
 ## active ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -11,10 +11,21 @@
 Tá Firefox cothrom le dáta.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Seol Firefox chuig do ghuthán póca<br> agus scaoil cumhacht an Idirlín.

--- a/gd/firefox/whatsnew.lang
+++ b/gd/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@ Download Firefox for Android and iOS
 Tha am Firefox agad cho ùr 's a ghabhas.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.

--- a/gl/firefox/whatsnew.lang
+++ b/gl/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Descargue Firefox para Android e iOS
 O seu Firefox está actualizado.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 O novo <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Instale Firefox no seu teléfono e libere o potencial de Internet.

--- a/gn/firefox/whatsnew.lang
+++ b/gn/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Emboguejy Firefox Android ha iOS peg̃uarã
 Firefox oñembohekopyahúma.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Ipyahúva <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Emondo Firefox ne pumbyrýpe<br> ha eipuru ñanduti ejaposeháicha.

--- a/gu-IN/firefox/whatsnew.lang
+++ b/gu-IN/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@
 તમારુ Firefox અદ્યતન છે.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 નવું <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Firefoxને તમારા ફોન પર મોકલો <br> તમારી ઇન્ટરનેટને દોરી છોડી દો.

--- a/he/firefox/whatsnew.lang
+++ b/he/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@
 גרסת Firefox שלך עדכנית.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 ה־<strong>Firefox</strong> החדש
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 שליחת Firefox לטלפון שלך<br> תפתח בפניך את האינטרנט בצורה שלא הכרת.

--- a/hi-IN/firefox/whatsnew.lang
+++ b/hi-IN/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Android और iOS के लिए Firefox डाउनलोड करें
 आपका Firefox का अद्यतन हो चुका है.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 नया <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Firefox को अपने फोन पर भेजें<br>और अपने इंटरनेट को उन्मुक्त करें.

--- a/hr/firefox/whatsnew.lang
+++ b/hr/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Preuzmi Firefox za Android i iOS
 Vaš je Firefox ažuran.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Novi <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Pošalji Firefox na tvoj mobitel<br> i uživaj u internetu.

--- a/hsb/firefox/whatsnew.lang
+++ b/hsb/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Sćehńće Firefox za Android a iOS
 Waš Firefox je aktualny.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Nowy <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Sćelće Firefox na swój telefon<br> a wuswobodźće internet z putow.

--- a/hu/firefox/whatsnew.lang
+++ b/hu/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Töltse a Firefoxot Androidra és iOS-re
 A Firefoxa naprakész.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Az új <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Adatbiztonság minden készüléken?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+Mi tudjuk a választ: Firefox mobileszközre.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Küldje a Firefoxt a telefonjára,<br> és engedje szabadjára az Internetét.

--- a/hy-AM/firefox/whatsnew.lang
+++ b/hy-AM/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@
 Դուք օգտագործում եք Firefox-ի վերջին տարբերակը:
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Նոր <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Ուղարկել Firefox-ը ձեր հեռախոսին<br> և բացահայտեք համացանցի հզորությունը:

--- a/ia/firefox/whatsnew.lang
+++ b/ia/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Discarga Firefox pro Android e iOS
 Tu Firefox es actualisate.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Le nove <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Invia Firefox a tu telephono intelligente<br> e discatena tu internet.

--- a/id/firefox/whatsnew.lang
+++ b/id/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Unduh Firefox untuk Android dan iOS
 Firefox Anda sudah yang terbaru.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 <strong>Firefox</strong> baru
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Kirim Firefox ke ponsel Anda<br> dan lancarkan Internet Anda.

--- a/is/firefox/whatsnew.lang
+++ b/is/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Halaðu niður Firefox fyrir Android og iOS
 Firefox hjá þér er með nýjustu útgáfuna.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Nýjasti og sterkasti <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Settu Firefox á símann þinn<br> og opnaðu fyrir flóðgáttir Internetsins.

--- a/it/firefox/whatsnew.lang
+++ b/it/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Scarica Firefox per Android e iOS
 Firefox è aggiornato.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Il nuovo <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Serve privacy su tutti i tuoi dispositivi?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+Semplice, basta scaricare Firefox per dispositivi portatili.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Invia Firefox al tuo smarphone<br> e porta il “tuo” Internet sempre con te.

--- a/ja/firefox/whatsnew.lang
+++ b/ja/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Android/iOS 版 Firefox をダウンロード
 お使いの Firefox は最新です。
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 新しい <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Firefox をスマホに送って<br>インターネットをもっと活用しよう。

--- a/ka/firefox/whatsnew.lang
+++ b/ka/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@
 თქვენი Firefox განახლებულია.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 ახალი <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 გააგზავნეთ Firefox თქვენს ტელეფონზე<br> ინტერნეტში მოხერხებულად სამოგზაუროდ.

--- a/kab/firefox/whatsnew.lang
+++ b/kab/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Sider Firefox i Android akked iOS
 Firefox inek yettwalqem.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Firefox<strong>amaynut</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Azen Firefox ar tiliɣri-ik <br> sakin serreḥ i Internet-ik.

--- a/kk/firefox/whatsnew.lang
+++ b/kk/firefox/whatsnew.lang
@@ -1,5 +1,5 @@
 ## active ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -11,10 +11,21 @@ Android және iOS үшін Firefox қолданбасын жүктеп алы
 Сіздің Firefox нұсқасы ескірмеген.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Firefox қолданбасын өз телефоныңызға жіберіп,<br> Интернетіңізді босатыңыз.

--- a/km/firefox/whatsnew.lang
+++ b/km/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@ Download Firefox for Android and iOS
 Firefox របស់​អ្នក​គឺ​ទាន់​សម័យ​ហើយ។
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.

--- a/kn/firefox/whatsnew.lang
+++ b/kn/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@
 ನಿಮ್ಮ ಫೈರ್ಫಾಕ್ಸ್ ಅಪ್‌ಟು ಡೇಟ್ ಆಗಿದೆ.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.

--- a/ko/firefox/whatsnew.lang
+++ b/ko/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Firefox 안드로이드 및 iOS 버전 다운로드
 Firefox가 최신 버전 입니다.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 새로운 <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 스마트폰용 Firefox<br> 지금 사용하세요.

--- a/lij/firefox/whatsnew.lang
+++ b/lij/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Descarega Firefox pe Android e iOS
 O teu Firefox o l'é agiornou.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 O neuvo <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Manda Firefox a-o teu telefonin<br> e portite derê o teu internet.

--- a/lo/firefox/whatsnew.lang
+++ b/lo/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@
 Firefox ຂອງທ່ານເປັນເວີຊັ່ນລ່າສຸດແລ້ວ.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 <strong>Firefox</strong> ໃຫມ່
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 ເພີ່ມ Firefox ໃນໂທລະສັບຂອງທ່ານ<br> ແລະ ເປິດສູ່ອິນເຕີເນັດ.

--- a/lt/firefox/whatsnew.lang
+++ b/lt/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Parsisiųskite „Firefox“ „Android“ ir „iOS“ įrenginiams
 Jūs naudojatės paskiausia „Firefox“ naršyklės laida.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Naujoji <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Nusiųskite „Firefox“ į savo telefoną<br> ir išlaisvinkite savo internetą.

--- a/ltg/firefox/whatsnew.lang
+++ b/ltg/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@ Download Firefox for Android and iOS
 Your Firefox is up to date.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.

--- a/lv/firefox/whatsnew.lang
+++ b/lv/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@ Download Firefox for Android and iOS
 Jums ir jaunākais Firefox.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.

--- a/mk/firefox/whatsnew.lang
+++ b/mk/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@ Download Firefox for Android and iOS
 Your Firefox is up to date.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.

--- a/ml/firefox/whatsnew.lang
+++ b/ml/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ iOS-നും ആൻഡ്രോയിഡിനും വേണ്ടി ഫ�
 നിങ്ങളുടെ ഫയർഫോക്സ് കാലികമാണ്.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 പുതിയ <strong>ഫയര്‍ഫോക്സ്</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 നിങ്ങളുടെ ഫോണിലേക്ക് ഫയർ ഫോക്സ് അയയ്ക്കുക <br> നിങ്ങളുടെ ഇന്റർനെറ്റിനെ അഴിച്ചുവിടുക.

--- a/mr/firefox/whatsnew.lang
+++ b/mr/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Android आणि iOS साठी फायरफॉक्स डाउनल�
 आपला Firefox अद्ययावत आहे.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 नवीन <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Firefox आपल्या फोन वॉर पाठवा<br> आणि आपले इंटरनेट पाशमुक्त करा.

--- a/ms/firefox/whatsnew.lang
+++ b/ms/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Muat turun Firefox untuk Android dan iOS
 Firefox anda ini yang terkini.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 <span>Firefox</span> serba baru
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Dapatkan Firefox dalam telefon anda<br> dan nikmati internet anda.

--- a/my/firefox/whatsnew.lang
+++ b/my/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Android နှင့် iOS အတွက် Firefox အားဒေါင်း�
 သင့် Firefox သည် နောက်ဆုံးပေါ် ဖြစ်သည်။
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 ဆန်းသစ်သော <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 သင့်ဖုန်းသို့ Firefox အား ပေးပို့ပြီး <br> အင်တာနက်ကိုသုံးကြည့်ပါ

--- a/nb-NO/firefox/whatsnew.lang
+++ b/nb-NO/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Last ned Firefox for Android og iOS
 Firefox er oppdatert.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Den nye <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox til telefonen din<br> og slipp nettet løs.

--- a/ne-NP/firefox/whatsnew.lang
+++ b/ne-NP/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@ Download Firefox for Android and iOS
 तपाईँको Firefox नयाँ संस्करणमा छ।
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.

--- a/nl/firefox/whatsnew.lang
+++ b/nl/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Download Firefox voor Android en iOS
 Uw Firefox is up-to-date.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 De nieuwe <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Privacy op elk apparaat?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+Dat kan. Download Firefox voor mobiele apparaten.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Stuur Firefox naar uw telefoon<br> en bevrijd uw internet.

--- a/nn-NO/firefox/whatsnew.lang
+++ b/nn-NO/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Last ned Firefox for Android og iOS
 Firefox er oppdatert.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Nye <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox til telefonen din<br> og slepp nettet laus.

--- a/nv/firefox/whatsnew.lang
+++ b/nv/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@ Download Firefox for Android and iOS
 Your Firefox is up to date.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.

--- a/oc/firefox/whatsnew.lang
+++ b/oc/firefox/whatsnew.lang
@@ -1,5 +1,5 @@
 ## active ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -11,10 +11,21 @@ Telecargar Firefox per Android e iOS
 Vòstre Firefox es a jorn.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Telecargatz Firefox sus vòstre mobil<br> e liberatz vòstre Internet.

--- a/pa-IN/firefox/whatsnew.lang
+++ b/pa-IN/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@
 ਤੁਹਾਡਾ ਫਾਇਰਫਾਕਸ ਨਵਾਂ ਨਕੋਰ ਹੈ।
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 ਨਵਾਂ <strong>ਫਾਇਰਫਾਕਸ</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 ਫਾਇਰਫਾਕਸ ਨੂੰ ਆਪਣੇ ਫ਼ੋਨ<br>'ਤੇ ਭੇਜੋ ਅਤੇ ਆਪਣੇ ਇੰਟਰਫੇਸ ਨੂੰ ਫਾਇਦਾ ਲਵੋ।

--- a/pai/firefox/whatsnew.lang
+++ b/pai/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@ Download Firefox for Android and iOS
 Your Firefox is up to date.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.

--- a/pl/firefox/whatsnew.lang
+++ b/pl/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Pobierz Firefoksa na Androida i iOS
 Twój Firefox jest aktualny.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Nowy <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Chcesz ochrony prywatności na każdym urządzeniu?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+Nie ma sprawy! Pobierz Firefoksa na telefon
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Wyślij Firefoksa na telefon<br> i uwolnij swój Internet.

--- a/ppl/firefox/whatsnew.lang
+++ b/ppl/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@ Download Firefox for Android and iOS
 Your Firefox is up to date.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.

--- a/pt-BR/firefox/whatsnew.lang
+++ b/pt-BR/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Baixe o Firefox para Android e iOS
 O seu Firefox está atualizado.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 O novo <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Quer privacidade em todos os seus dispositivos?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+Sem problema. Baixe o Firefox versão mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Envie o Firefox para o seu telefone<br> e liberte a sua Internet.

--- a/pt-PT/firefox/whatsnew.lang
+++ b/pt-PT/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Transfira o Firefox para Android e iOS
 O seu Firefox está atualizado.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 O novo <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Envie o Firefox para o seu telemóvel<br> e solte a sua Internet.

--- a/rm/firefox/whatsnew.lang
+++ b/rm/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Telechargiar Firefox per Android ed iOS
 Tes Firefox è actual.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Il nov <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Trametta Firefox a tes telefonin<br> e navighescha senza cunfins.

--- a/ro/firefox/whatsnew.lang
+++ b/ro/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Descarcă Firefox pentru Android și iOS
 Firefox a fost actualizat.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Noul <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Trimite Firefox pe telefon<br> și descătușează internetul.

--- a/ru/firefox/whatsnew.lang
+++ b/ru/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@
 Вы используете актуальную версию Firefox.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Новый <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Нужна приватность на всех устройствах?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+Не проблема. Загрузи мобильный Firefox.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Отправьте Firefox на ваш телефон<br> и раскройте всю мощь Интернета.

--- a/si/firefox/whatsnew.lang
+++ b/si/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@ Download Firefox for Android and iOS
 ඔබගේ Firefox යාවත්කාලීනයි.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.

--- a/sk/firefox/whatsnew.lang
+++ b/sk/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Prevezmite si Firefox pre Android a iOS
 Váš Firefox je aktuálny.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Nový <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Chcete súkromie na akomkoľvek zariadení?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+Máte ho mať. Firefox pre mobilné telefóny.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Majte Firefox vo svojom telefóne<br> a popustite uzdu internetu.

--- a/sl/firefox/whatsnew.lang
+++ b/sl/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Prenesite Firefox za Android in iOS
 Vaš Firefox je posodobljen.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Novi <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Pošljite si Firefox na telefon<br> in spustite internet z verige.

--- a/son/firefox/whatsnew.lang
+++ b/son/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@ Download Firefox for Android and iOS
 War Firefox n' ka taagandi.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.

--- a/sq/firefox/whatsnew.lang
+++ b/sq/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Shkarkoni Firefox-in për Android dhe iOS
 Firefox-i juaj është i përditësuar.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 <strong>Firefox</strong>-i i Ri
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Dërgojeni Firefox-in te telefoni juaj<br> dhe hiqini frerët Internetit.

--- a/sr/firefox/whatsnew.lang
+++ b/sr/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@
 Имате најновији Firefox.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Нови <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Пошаљите Firefox на ваш телефон<br> и ослободите ваш интернет.

--- a/sv-SE/firefox/whatsnew.lang
+++ b/sv-SE/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Ladda ner Firefox för Android och iOS
 Du har den senaste versionen av Firefox.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Nya <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Personlig integritet på alla dina enheter?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+Det får du. Hämta Firefox för mobil och surfplatta.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Skicka Firefox till din telefon<br> och släpp lös Internet.

--- a/sw/firefox/whatsnew.lang
+++ b/sw/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@ Download Firefox for Android and iOS
 Your Firefox is up to date.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.

--- a/ta/firefox/whatsnew.lang
+++ b/ta/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Android, iOS கருவிகளுக்கான பயர்பாக்ச
 உங்கள் பயர்பாக்சு புத்தம் புதுசா இருக்கு.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 புதிய <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Firefox உலாவியை உங்கள் கைபேசிக்கு அனுப்பி<br> உங்கள் இணையத்தைக் கட்டவிழுங்கள்.

--- a/te/firefox/whatsnew.lang
+++ b/te/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Androidమరియు iOSల కొరకు Firefoxని దించుక�
 మీ Firefox తాజాగా ఉంది.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 సరికొత్త <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 మీ ఫోన్‌కి Firefoxను పంపండి <br> మరియు మీ అంతర్జాలాన్ని వదలండి.

--- a/th/firefox/whatsnew.lang
+++ b/th/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@
 Firefox ของคุณเป็นรุ่นล่าสุดแล้ว
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 <strong>Firefox</strong> ใหม่
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 เพิ่ม Firefox ในโทรศัพท์ของคุณ<br>และเปิดสู่อินเทอร์เน็ต

--- a/tl/firefox/whatsnew.lang
+++ b/tl/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@ Download Firefox for Android and iOS
 Your Firefox is up to date.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.

--- a/tr/firefox/whatsnew.lang
+++ b/tr/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Android ve iOS için Firefox’u indir
 Firefox’unuz güncel.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Yeni <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Tüm cihazlarınızda gizlilik mi istiyorsunuz?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+O zaman hemen mobil için Firefox’u indirin.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Firefox’u telefonuna gönder,<br>internetini özgür bırak.

--- a/uk/firefox/whatsnew.lang
+++ b/uk/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@
 Ваш Firefox оновлений.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Новий <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Відправте Firefox на свій телефон<br> та звільніть Інтернет.

--- a/ur/firefox/whatsnew.lang
+++ b/ur/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@ Android اور iOS کے Firefox ڈاؤن لوڈ کریں
 آپ کا Firefox تازہ ترین ہے۔
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.

--- a/uz/firefox/whatsnew.lang
+++ b/uz/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Firefox brauzerini Android va iOS uchun yuklab oling
 Firefox yap-yangi.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Yangi <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Firefox brauzerini telefoningizga yuboring<br> va internetning kuchini kashf eting.

--- a/vi/firefox/whatsnew.lang
+++ b/vi/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@ Tải xuống Firefox cho Android và iOS
 Firefox của bạn đã được cập nhật.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 Trình duyệt <strong>Firefox</strong> mới
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Gửi Firefox đến điện thoại của bạn<br> và giải phóng Internet.

--- a/xh/firefox/whatsnew.lang
+++ b/xh/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@ Download Firefox for Android and iOS
 IFirefox yakho ihlaziyiwe.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.

--- a/zam/firefox/whatsnew.lang
+++ b/zam/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@ Download Firefox for Android and iOS
 Your Firefox is up to date.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.

--- a/zh-CN/firefox/whatsnew.lang
+++ b/zh-CN/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@
 您的 Firefox 已是最新版本。
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 崭新的 <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+希望每台设备都拥有隐私保障？
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+没问题。立即获取Firefox移动版。
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 发送 Firefox 到您的手机<br>，向互联网进发！

--- a/zh-TW/firefox/whatsnew.lang
+++ b/zh-TW/firefox/whatsnew.lang
@@ -1,6 +1,6 @@
 ## active ##
 ## whatsnew_rebranding ##
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -12,10 +12,21 @@
 Firefox 更新完成。
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 全新 <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+想妥善保護所有裝置的隱私嗎？
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+沒問題，讓 Firefox 的行動瀏覽器幫您搞定！
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 把 Firefox 傳到手機，<br>釋放 Internet 的威力。

--- a/zu/firefox/whatsnew.lang
+++ b/zu/firefox/whatsnew.lang
@@ -1,4 +1,4 @@
-## NOTE: Demo page at https://www-dev.allizom.org/firefox/53.0/whatsnew/
+## NOTE: Demo page at https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/
 
 
 # HTML page title
@@ -10,10 +10,21 @@ Download Firefox for Android and iOS
 Your Firefox is up to date.
 
 
+# Obsolete string, do not remove
 ;The new <strong>Firefox</strong>
 The new <strong>Firefox</strong>
 
 
+;Want privacy on every device?
+Want privacy on every device?
+
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+;You got it. Get Firefox for mobile.
+You got it. Get Firefox for mobile.
+
+
+# Obsolete string, do not remove
 # Line break below for visual formatting only
 ;Send Firefox to your phone<br> and unleash your Internet.
 Send Firefox to your phone<br> and unleash your Internet.


### PR DESCRIPTION
Two new strings using the tag `whatsnew_headline_04112019`

I believe we're getting translations from Mother Tongue early next week so we shouldn't send this to production until then.

Bedrock issue: https://github.com/mozilla/bedrock/issues/8064
Demo: https://bedrock-demos-pr-8067.herokuapp.com/firefox/66.0/whatsnew/all/