### PR TITLE
Add new string with translations

### DIFF
--- a/de/firefox/products/lockwise.lang
+++ b/de/firefox/products/lockwise.lang
@@ -7,7 +7,7 @@
 Firefox Lockwise – Passwortmanager — Hab deine Passwörter überall parat.
 
 
-# Page discription
+# Page description
 ;Firefox Lockwise lets you securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser. Features 256-bit encryption and Face/Touch ID.
 Mit Firefox Lockwise hast du Passwörter, die du in Firefox speicherst auch überall außerhalb des Browsers parat — mit 256-Bit-Verschlüsselung und Face/Touch-ID.
 
@@ -17,7 +17,7 @@ Mit Firefox Lockwise hast du Passwörter, die du in Firefox speicherst auch übe
 Hab deine Passwörter immer parat
 
 
-# Discription under header
+# Description under header
 ;Securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser.
 Greife von überall aus sicher auf deine in Firefox gespeicherten Passwörter zu – auch außerhalb des Browsers.
 
@@ -39,6 +39,10 @@ Hol dir das Lockwise Add-On
 # CTA button
 ;Install for Firefox
 Für Firefox installieren
+
+
+;Open in Firefox
+In Firefox öffnen
 
 
 # Lockwise refers to Firefox Lockwise. Do not translate.

--- a/en-CA/firefox/products/lockwise.lang
+++ b/en-CA/firefox/products/lockwise.lang
@@ -7,7 +7,7 @@
 Firefox Lockwise — password manager — take your passwords everywhere {ok}
 
 
-# Page discription
+# Page description
 ;Firefox Lockwise lets you securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser. Features 256-bit encryption and Face/Touch ID.
 Firefox Lockwise lets you securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser. Features 256-bit encryption and Face/Touch ID. {ok}
 
@@ -17,7 +17,7 @@ Firefox Lockwise lets you securely access the passwords you’ve saved in Firefo
 Take your passwords everywhere {ok}
 
 
-# Discription under header
+# Description under header
 ;Securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser.
 Securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser. {ok}
 
@@ -39,6 +39,10 @@ Try the Lockwise add-on {ok}
 # CTA button
 ;Install for Firefox
 Install for Firefox {ok}
+
+
+;Open in Firefox
+Open in Firefox {ok}
 
 
 # Lockwise refers to Firefox Lockwise. Do not translate.

--- a/en-GB/firefox/products/lockwise.lang
+++ b/en-GB/firefox/products/lockwise.lang
@@ -7,7 +7,7 @@
 Firefox Lockwise — password manager — take your passwords everywhere {ok}
 
 
-# Page discription
+# Page description
 ;Firefox Lockwise lets you securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser. Features 256-bit encryption and Face/Touch ID.
 Firefox Lockwise lets you securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser. Features 256-bit encryption and Face/Touch ID. {ok}
 
@@ -17,7 +17,7 @@ Firefox Lockwise lets you securely access the passwords you’ve saved in Firefo
 Take your passwords everywhere {ok}
 
 
-# Discription under header
+# Description under header
 ;Securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser.
 Securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser. {ok}
 
@@ -39,6 +39,10 @@ Try the Lockwise add-on {ok}
 # CTA button
 ;Install for Firefox
 Install for Firefox {ok}
+
+
+;Open in Firefox
+Open in Firefox {ok}
 
 
 # Lockwise refers to Firefox Lockwise. Do not translate.

--- a/en-US/firefox/products/lockwise.lang
+++ b/en-US/firefox/products/lockwise.lang
@@ -7,7 +7,7 @@
 Firefox Lockwise — password manager — take your passwords everywhere
 
 
-# Page discription
+# Page description
 ;Firefox Lockwise lets you securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser. Features 256-bit encryption and Face/Touch ID.
 Firefox Lockwise lets you securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser. Features 256-bit encryption and Face/Touch ID.
 
@@ -17,7 +17,7 @@ Firefox Lockwise lets you securely access the passwords you’ve saved in Firefo
 Take your passwords everywhere
 
 
-# Discription under header
+# description under header
 ;Securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser.
 Securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser.
 
@@ -39,6 +39,9 @@ Try the Lockwise add-on
 # CTA button
 ;Install for Firefox
 Install for Firefox
+
+;Open in Firefox
+Open in Firefox
 
 
 # Lockwise refers to Firefox Lockwise. Do not translate.

--- a/es-ES/firefox/products/lockwise.lang
+++ b/es-ES/firefox/products/lockwise.lang
@@ -7,7 +7,7 @@
 Con el gestor de contraseñas Firefox Lockwise puedes llevar tus contraseñas siempre contigo
 
 
-# Page discription
+# Page description
 ;Firefox Lockwise lets you securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser. Features 256-bit encryption and Face/Touch ID.
 Firefox Lockwise te permite acceder de forma segura a las contraseñas que has guardado en Firefox desde cualquier lugar, incluso desde fuera del navegador. Cuenta con cifrado de 256 bits y Face/Touch ID.
 
@@ -17,7 +17,7 @@ Firefox Lockwise te permite acceder de forma segura a las contraseñas que has g
 Lleva tus contraseñas siempre contigo
 
 
-# Discription under header
+# Description under header
 ;Securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser.
 Accede de forma segura a las contraseñas que has guardado en Firefox desde cualquier lugar, incluso desde fuera del navegador.
 
@@ -39,6 +39,10 @@ Prueba el complemento Lockwise
 # CTA button
 ;Install for Firefox
 Instalar para Firefox
+
+
+;Open in Firefox
+Abrir en Firefox
 
 
 # Lockwise refers to Firefox Lockwise. Do not translate.

--- a/fr/firefox/products/lockwise.lang
+++ b/fr/firefox/products/lockwise.lang
@@ -7,7 +7,7 @@
 Firefox Lockwise — gestionnaire de mots de passe — emportez vos mots de passe partout
 
 
-# Page discription
+# Page description
 ;Firefox Lockwise lets you securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser. Features 256-bit encryption and Face/Touch ID.
 Firefox Lockwise vous permet d’accéder à tous les mots de passe que vous avez sauvegardés dans Firefox où que vous soyez — même en dehors du navigateur. Fonctionne avec le chiffrement à 256 bits et compatible avec Face/Touch ID.
 
@@ -17,7 +17,7 @@ Firefox Lockwise vous permet d’accéder à tous les mots de passe que vous ave
 Emportez vos mots de passe partout avec vous
 
 
-# Discription under header
+# Description under header
 ;Securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser.
 Accédez en toute sécurité aux mots de passe que vous avez sauvegardés dans Firefox où que vous soyez. Même en dehors du navigateur.
 
@@ -39,6 +39,10 @@ Essayer le module complémentaire Lockwise
 # CTA button
 ;Install for Firefox
 Installer sur Firefox
+
+
+;Open in Firefox
+Ouvrir dans Firefox
 
 
 # Lockwise refers to Firefox Lockwise. Do not translate.

--- a/it/firefox/products/lockwise.lang
+++ b/it/firefox/products/lockwise.lang
@@ -7,7 +7,7 @@
 Firefox Lockwise — gestione password — porta le tue password sempre con te
 
 
-# Page discription
+# Page description
 ;Firefox Lockwise lets you securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser. Features 256-bit encryption and Face/Touch ID.
 Firefox Lockwise, con crittografia a 256 bit e Face/Touch ID, consente di accedere in modo sicuro alle password salvate in Firefox dovunque, anche all’esterno del browser.
 
@@ -17,7 +17,7 @@ Firefox Lockwise, con crittografia a 256 bit e Face/Touch ID, consente di accede
 Porta le tue password sempre con te
 
 
-# Discription under header
+# Description under header
 ;Securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser.
 Accedi in tutta sicurezza alle password salvate in Firefox dovunque, anche all’esterno del browser.
 
@@ -39,6 +39,10 @@ Prova il componente aggiuntivo Lockwise
 # CTA button
 ;Install for Firefox
 Installa su Firefox
+
+
+;Open in Firefox
+Apri in Firefox
 
 
 # Lockwise refers to Firefox Lockwise. Do not translate.


### PR DESCRIPTION
Some how a string escaped when I added the file originally. I have added the string and translations found from another Mozilla page using it as a button in the same context.

The issue filed is here: https://github.com/mozilla/bedrock/issues/8097