### PR TITLE
Add "country or region" to newsletters

### DIFF
--- a/bg/mozorg/newsletters.lang
+++ b/bg/mozorg/newsletters.lang
@@ -14,10 +14,20 @@
 Език:
 
 
+;Select country or region
+Select country or region
+
+
+# Obsolete string, do not remove
 ;Select country
 Изберете държава
 
 
+;Country or region:
+Country or region:
+
+
+# Obsolete string, do not remove
 ;Country:
 Държава:
 

--- a/cs/mozorg/newsletters.lang
+++ b/cs/mozorg/newsletters.lang
@@ -14,10 +14,20 @@ Vaše e-mailová adresa:
 Jazyk:
 
 
+;Select country or region
+Select country or region
+
+
+# Obsolete string, do not remove
 ;Select country
 Vyberte zemi
 
 
+;Country or region:
+Country or region:
+
+
+# Obsolete string, do not remove
 ;Country:
 Země:
 

--- a/de/mozorg/newsletters.lang
+++ b/de/mozorg/newsletters.lang
@@ -14,10 +14,20 @@ Deine E-Mail-Adresse:
 Sprache:
 
 
+;Select country or region
+Select country or region
+
+
+# Obsolete string, do not remove
 ;Select country
 Land auswählen
 
 
+;Country or region:
+Country or region:
+
+
+# Obsolete string, do not remove
 ;Country:
 Land:
 

--- a/en-US/mozorg/newsletters.lang
+++ b/en-US/mozorg/newsletters.lang
@@ -1,3 +1,4 @@
+## country_region_122019 ##
 ## developer_page_desc_082018 ##
 ## mozilla_newsletter_2017 ##
 ## newsletter_confirm_2016 ##
@@ -13,10 +14,22 @@ Your email address:
 Language:
 
 
+## TAG: country_region_122019
+;Select country or region
+Select country or region
+
+
+# Obsolete string, do not remove
 ;Select country
 Select country
 
 
+## TAG: country_region_122019
+;Country or region:
+Country or region:
+
+
+# Obsolete string, do not remove
 ;Country:
 Country:
 

--- a/es-ES/mozorg/newsletters.lang
+++ b/es-ES/mozorg/newsletters.lang
@@ -14,10 +14,20 @@ Tu dirección de email:
 Idioma:
 
 
+;Select country or region
+Select country or region
+
+
+# Obsolete string, do not remove
 ;Select country
 Elige un país
 
 
+;Country or region:
+Country or region:
+
+
+# Obsolete string, do not remove
 ;Country:
 País:
 

--- a/fr/mozorg/newsletters.lang
+++ b/fr/mozorg/newsletters.lang
@@ -14,10 +14,20 @@ Votre courriel :
 Langue :
 
 
+;Select country or region
+Select country or region
+
+
+# Obsolete string, do not remove
 ;Select country
 Sélectionnez votre pays
 
 
+;Country or region:
+Country or region:
+
+
+# Obsolete string, do not remove
 ;Country:
 Pays :
 

--- a/hu/mozorg/newsletters.lang
+++ b/hu/mozorg/newsletters.lang
@@ -14,10 +14,20 @@ E-mail cím:
 Nyelv:
 
 
+;Select country or region
+Select country or region
+
+
+# Obsolete string, do not remove
 ;Select country
 Válasszon országot
 
 
+;Country or region:
+Country or region:
+
+
+# Obsolete string, do not remove
 ;Country:
 Ország:
 

--- a/id/mozorg/newsletters.lang
+++ b/id/mozorg/newsletters.lang
@@ -14,10 +14,20 @@ Alamat Surel Anda:
 Bahasa:
 
 
+;Select country or region
+Select country or region
+
+
+# Obsolete string, do not remove
 ;Select country
 Pilih negara
 
 
+;Country or region:
+Country or region:
+
+
+# Obsolete string, do not remove
 ;Country:
 Negara:
 

--- a/it/mozorg/newsletters.lang
+++ b/it/mozorg/newsletters.lang
@@ -14,10 +14,20 @@ Indirizzo email:
 Lingua:
 
 
+;Select country or region
+Select country or region
+
+
+# Obsolete string, do not remove
 ;Select country
 Scegli la nazione
 
 
+;Country or region:
+Country or region:
+
+
+# Obsolete string, do not remove
 ;Country:
 Nazione:
 

--- a/nl/mozorg/newsletters.lang
+++ b/nl/mozorg/newsletters.lang
@@ -14,10 +14,20 @@ Uw e-mailadres:
 Taal:
 
 
+;Select country or region
+Select country or region
+
+
+# Obsolete string, do not remove
 ;Select country
 Land selecteren
 
 
+;Country or region:
+Country or region:
+
+
+# Obsolete string, do not remove
 ;Country:
 Land:
 

--- a/pl/mozorg/newsletters.lang
+++ b/pl/mozorg/newsletters.lang
@@ -14,10 +14,20 @@ Twój adres e-mail:
 Język:
 
 
+;Select country or region
+Select country or region
+
+
+# Obsolete string, do not remove
 ;Select country
 Wybór państwa
 
 
+;Country or region:
+Country or region:
+
+
+# Obsolete string, do not remove
 ;Country:
 Państwo:
 

--- a/pt-BR/mozorg/newsletters.lang
+++ b/pt-BR/mozorg/newsletters.lang
@@ -14,10 +14,20 @@ Seu endereço de e-mail:
 Idioma:
 
 
+;Select country or region
+Select country or region
+
+
+# Obsolete string, do not remove
 ;Select country
 Escolha o país
 
 
+;Country or region:
+Country or region:
+
+
+# Obsolete string, do not remove
 ;Country:
 País:
 

--- a/ru/mozorg/newsletters.lang
+++ b/ru/mozorg/newsletters.lang
@@ -14,10 +14,20 @@
 Язык:
 
 
+;Select country or region
+Select country or region
+
+
+# Obsolete string, do not remove
 ;Select country
 Выберите страну
 
 
+;Country or region:
+Country or region:
+
+
+# Obsolete string, do not remove
 ;Country:
 Страна:
 

--- a/zh-TW/mozorg/newsletters.lang
+++ b/zh-TW/mozorg/newsletters.lang
@@ -14,10 +14,20 @@
 語言:
 
 
+;Select country or region
+Select country or region
+
+
+# Obsolete string, do not remove
 ;Select country
 選擇國家
 
 
+;Country or region:
+Country or region:
+
+
+# Obsolete string, do not remove
 ;Country:
 國家:
 


### PR DESCRIPTION
Updates two strings in mozorg/newsletters.lang using the tag `country_region_122019`

Bedrock issue: https://github.com/mozilla/bedrock/issues/8223