### PR TITLE
Add whatsnew_74

### DIFF
--- a/en-US/firefox/whatsnew_74.lang
+++ b/en-US/firefox/whatsnew_74.lang
@@ -1,5 +1,5 @@
 ## NOTE: Demo page at https://www-demo3.allizom.org/firefox/74.0/whatsnew/all/
-## URL: https://www-dev.allizom.org/%LOCALE%/firefox/74.0/whatsnew/all/
+## URL: https://www-demo3.allizom.org/%LOCALE%/firefox/74.0/whatsnew/all/
 
 
 # HTML page title
@@ -17,8 +17,8 @@ It’s okay to like Facebook
 
 
 # "Facebook Container" is a product name and shouldn't be translated.
-;If you still kinda like Facebook but don’t trust them, then try Firefox’s Facebook Container extension and make it harder for them to track you around the web.
-If you still kinda like Facebook but don’t trust them, then try Firefox’s Facebook Container extension and make it harder for them to track you around the web.
+;If you still kinda like Facebook but don’t trust them, then try the Facebook Container extension by Firefox and make it harder for them to track you around the web.
+If you still kinda like Facebook but don’t trust them, then try the Facebook Container extension by Firefox and make it harder for them to track you around the web.
 
 
 # "Facebook Container" is a product name and shouldn't be translated.
@@ -45,8 +45,8 @@ Make them unfollow you
 That sneaky little button
 
 
-;Those innocent-looking F buttons from Facebook track your web activity, even if you don’t have an account. Facebook Container blocks ‘em.
-Those innocent-looking F buttons from Facebook track your web activity, even if you don’t have an account. Facebook Container blocks ‘em.
+;Those innocent-looking F buttons from Facebook track your web activity, even if you don’t have an account. Facebook Container blocks them.
+Those innocent-looking F buttons from Facebook track your web activity, even if you don’t have an account. Facebook Container blocks them.
 
 
 ;Stay ahead of hackers

--- a/en-US/firefox/whatsnew_74.lang
+++ b/en-US/firefox/whatsnew_74.lang
@@ -1,0 +1,67 @@
+## NOTE: Demo page at https://www-demo3.allizom.org/firefox/74.0/whatsnew/all/
+## URL: https://www-dev.allizom.org/%LOCALE%/firefox/74.0/whatsnew/all/
+
+
+# HTML page title
+;What’s new with Firefox - Make it harder for Facebook to track you
+What’s new with Firefox - Make it harder for Facebook to track you
+
+
+;Congrats! You’re using the latest version of Firefox.
+Congrats! You’re using the latest version of Firefox.
+
+
+# Main title
+;It’s okay to like Facebook
+It’s okay to like Facebook
+
+
+# "Facebook Container" is a product name and shouldn't be translated.
+;If you still kinda like Facebook but don’t trust them, then try Firefox’s Facebook Container extension and make it harder for them to track you around the web.
+If you still kinda like Facebook but don’t trust them, then try Firefox’s Facebook Container extension and make it harder for them to track you around the web.
+
+
+# "Facebook Container" is a product name and shouldn't be translated.
+;Get Facebook Container
+Get Facebook Container
+
+
+# "Do it for the 'Gram" is a slang phrase used when people do things in life just so they can take pictures to post on Instagram. Alternative: "It works on Instagram"
+;Do it for the ’Gram
+Do it for the ’Gram
+
+
+# "Facebook Container", "Instagram", "Facebook Messenger" and "Workplace" are proper names that shouldn't be translated.
+;Facebook Container also works on other Facebook owned sites like Instagram, Facebook Messenger and Workplace.
+Facebook Container also works on other Facebook owned sites like Instagram, Facebook Messenger and Workplace.
+
+
+# CTA link
+;Make them unfollow you
+Make them unfollow you
+
+
+;That sneaky little button
+That sneaky little button
+
+
+;Those innocent-looking F buttons from Facebook track your web activity, even if you don’t have an account. Facebook Container blocks ‘em.
+Those innocent-looking F buttons from Facebook track your web activity, even if you don’t have an account. Facebook Container blocks ‘em.
+
+
+;Stay ahead of hackers
+Stay ahead of hackers
+
+
+# "Firefox Monitor" is a product name that shouldn't be translated.
+;Firefox Monitor lets you find out what hackers might already know about you and helps you stay a step ahead of them. (And it’s free.)
+Firefox Monitor lets you find out what hackers might already know about you and helps you stay a step ahead of them. (And it’s free.)
+
+
+# CTA link
+;Get Firefox Monitor
+Get Firefox Monitor
+
+
+;Read the <a href="%(notes)s">Release Notes</a> to know more about what’s new in your Firefox Browser.
+Read the <a href="%(notes)s">Release Notes</a> to know more about what’s new in your Firefox Browser.


### PR DESCRIPTION
Added to sources in https://github.com/mozilla-l10n/langchecker/pull/963

Demo: https://www-demo3.allizom.org/firefox/74.0/whatsnew/all/

Some content on the page is hard-coded behind locale-specific conditionals (there's an English-only blurb, a German-only blurb, and a French-only blurb).