### PR TITLE
Remove redundant strings from welcome/page7.lang

### DIFF
--- a/ach/firefox/welcome/page7.lang
+++ b/ach/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/af/firefox/welcome/page7.lang
+++ b/af/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/am/firefox/welcome/page7.lang
+++ b/am/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/an/firefox/welcome/page7.lang
+++ b/an/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/ar/firefox/welcome/page7.lang
+++ b/ar/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/ast/firefox/welcome/page7.lang
+++ b/ast/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/az/firefox/welcome/page7.lang
+++ b/az/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/azz/firefox/welcome/page7.lang
+++ b/azz/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/be/firefox/welcome/page7.lang
+++ b/be/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/bg/firefox/welcome/page7.lang
+++ b/bg/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/bn/firefox/welcome/page7.lang
+++ b/bn/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/br/firefox/welcome/page7.lang
+++ b/br/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/bs/firefox/welcome/page7.lang
+++ b/bs/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/ca/firefox/welcome/page7.lang
+++ b/ca/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/cak/firefox/welcome/page7.lang
+++ b/cak/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/crh/firefox/welcome/page7.lang
+++ b/crh/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/cs/firefox/welcome/page7.lang
+++ b/cs/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/cy/firefox/welcome/page7.lang
+++ b/cy/firefox/welcome/page7.lang
@@ -37,18 +37,6 @@ Mae Facebook Container hefyd yn gweithio ar wefannau eraill sy'n perthyn i Faceb
 Gwneud iddyn nhw roi gorau i'ch dilyn chi
 
 
-;Listen to this
-Gwrandewch ar hyn
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Pam mae cwmnïau fel Google a Facebook yn gwneud popeth o fewn eu gallu i ragweld eich ymddygiad?
-
-
-;Listen to our IRL podcast
-Gwrandewch ar ein podlediad IRL
-
-
 ;That sneaky little button
 Y botwm bach slei yna
 

--- a/da/firefox/welcome/page7.lang
+++ b/da/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/de/firefox/welcome/page7.lang
+++ b/de/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/dsb/firefox/welcome/page7.lang
+++ b/dsb/firefox/welcome/page7.lang
@@ -37,18 +37,6 @@ Facebook Container teke na drugich sedłach funkcioněrujo, kótarež k Facebook
 Zajźujśo, až wam slěduju
 
 
-;Listen to this
-Słuchajśo na to
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Cogodla pśedewześa ako Google a Facebook wšykno cynje, aby wašo zaźaržanje pśedpowěźeli?
-
-
-;Listen to our IRL podcast
-Słuchajśo na IRL-podkast
-
-
 ;That sneaky little button
 Toś ten njesromny tłocašk
 

--- a/el/firefox/welcome/page7.lang
+++ b/el/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/en-CA/firefox/welcome/page7.lang
+++ b/en-CA/firefox/welcome/page7.lang
@@ -37,18 +37,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you {ok}
 
 
-;Listen to this
-Listen to this {ok}
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behaviour?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast {ok}
-
-
 ;That sneaky little button
 That sneaky little button {ok}
 

--- a/en-GB/firefox/welcome/page7.lang
+++ b/en-GB/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/en-US/firefox/welcome/page7.lang
+++ b/en-US/firefox/welcome/page7.lang
@@ -37,18 +37,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/eo/firefox/welcome/page7.lang
+++ b/eo/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/es-AR/firefox/welcome/page7.lang
+++ b/es-AR/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/es-CL/firefox/welcome/page7.lang
+++ b/es-CL/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/es-ES/firefox/welcome/page7.lang
+++ b/es-ES/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/es-MX/firefox/welcome/page7.lang
+++ b/es-MX/firefox/welcome/page7.lang
@@ -37,18 +37,6 @@ Facebook Container también funciona en otros sitios propiedad de Facebook como 
 Haz que dejen de seguirte
 
 
-;Listen to this
-Escucha esto
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-¿Por qué las empresas como Google y Facebook están haciendo todo lo posible para predecir tu comportamiento?
-
-
-;Listen to our IRL podcast
-Escucha nuestro podcast IRL
-
-
 ;That sneaky little button
 Ese pequeño botón furtivo
 

--- a/et/firefox/welcome/page7.lang
+++ b/et/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/eu/firefox/welcome/page7.lang
+++ b/eu/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/fa/firefox/welcome/page7.lang
+++ b/fa/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/ff/firefox/welcome/page7.lang
+++ b/ff/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/fi/firefox/welcome/page7.lang
+++ b/fi/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/fr/firefox/welcome/page7.lang
+++ b/fr/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/fy-NL/firefox/welcome/page7.lang
+++ b/fy-NL/firefox/welcome/page7.lang
@@ -37,18 +37,6 @@ Facebook Container wurket ek op oare sites dy't eigendom binne fan Facebook, lyk
 Lit se jo net mear folgje
 
 
-;Listen to this
-Harkje hjirnei
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Wêrom dogge bedriuwen lykas Google en Facebook der alles oan om jo gedrach te foarsizzen?
-
-
-;Listen to our IRL podcast
-Harkje nei ús IRL-podcast
-
-
 ;That sneaky little button
 Dat stikeme knopke
 

--- a/ga-IE/firefox/welcome/page7.lang
+++ b/ga-IE/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/gd/firefox/welcome/page7.lang
+++ b/gd/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/gl/firefox/welcome/page7.lang
+++ b/gl/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/gn/firefox/welcome/page7.lang
+++ b/gn/firefox/welcome/page7.lang
@@ -37,18 +37,6 @@ Facebook Container avei oiko ambue tenda Facebook mba’évape, ãva ha’e Inst
 Anive hag̃ua ejehapykueho
 
 
-;Listen to this
-Ehendu kóva
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-¿Mba’ére mba’apohaguasu Google ha Facebook omba’apo tapiaite omyesakã hag̃ua haperã?
-
-
-;Listen to our IRL podcast
-Ehendu ore IRL podcast
-
-
 ;That sneaky little button
 Pe votõ kañygua michĩva
 

--- a/gu-IN/firefox/welcome/page7.lang
+++ b/gu-IN/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/he/firefox/welcome/page7.lang
+++ b/he/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/hi-IN/firefox/welcome/page7.lang
+++ b/hi-IN/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/hr/firefox/welcome/page7.lang
+++ b/hr/firefox/welcome/page7.lang
@@ -37,18 +37,6 @@ Facebook Container radi i na ostalim web stranicama u Facebookovom vlasništvu, 
 Onemogući im praćenje
 
 
-;Listen to this
-Poslušaj ovo
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Zašto tvrtke poput Google i Facebook rade sve što mogu kako bi predvidjele vaše ponašanje?
-
-
-;Listen to our IRL podcast
-Poslušajte naš IRL podcast
-
-
 ;That sneaky little button
 Taj lukavi mali gumb
 

--- a/hsb/firefox/welcome/page7.lang
+++ b/hsb/firefox/welcome/page7.lang
@@ -37,18 +37,6 @@ Facebook Container tež na druhich sydłach funguje, kotrež k Facebook słušej
 Zadźěwajće, zo wam slěduja
 
 
-;Listen to this
-Poskajće na to
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Čehodla předewzaća kaž Google a Facebook wšitko činja, zo bychu waše zadźerženje předpowědali?
-
-
-;Listen to our IRL podcast
-Poskajće na IRL-podkast
-
-
 ;That sneaky little button
 Tute lestne małe tłóčatko
 

--- a/hto/firefox/welcome/page7.lang
+++ b/hto/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/hu/firefox/welcome/page7.lang
+++ b/hu/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/hy-AM/firefox/welcome/page7.lang
+++ b/hy-AM/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/ia/firefox/welcome/page7.lang
+++ b/ia/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/id/firefox/welcome/page7.lang
+++ b/id/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/is/firefox/welcome/page7.lang
+++ b/is/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/it/firefox/welcome/page7.lang
+++ b/it/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/ja/firefox/welcome/page7.lang
+++ b/ja/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/ka/firefox/welcome/page7.lang
+++ b/ka/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/kab/firefox/welcome/page7.lang
+++ b/kab/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/kk/firefox/welcome/page7.lang
+++ b/kk/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/km/firefox/welcome/page7.lang
+++ b/km/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/kn/firefox/welcome/page7.lang
+++ b/kn/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/ko/firefox/welcome/page7.lang
+++ b/ko/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/lij/firefox/welcome/page7.lang
+++ b/lij/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/lo/firefox/welcome/page7.lang
+++ b/lo/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/lt/firefox/welcome/page7.lang
+++ b/lt/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/ltg/firefox/welcome/page7.lang
+++ b/ltg/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/lv/firefox/welcome/page7.lang
+++ b/lv/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/mk/firefox/welcome/page7.lang
+++ b/mk/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/ml/firefox/welcome/page7.lang
+++ b/ml/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/mr/firefox/welcome/page7.lang
+++ b/mr/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/ms/firefox/welcome/page7.lang
+++ b/ms/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/my/firefox/welcome/page7.lang
+++ b/my/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/nb-NO/firefox/welcome/page7.lang
+++ b/nb-NO/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/ne-NP/firefox/welcome/page7.lang
+++ b/ne-NP/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/nl/firefox/welcome/page7.lang
+++ b/nl/firefox/welcome/page7.lang
@@ -37,18 +37,6 @@ Facebook Container werkt ook op andere sites die eigendom zijn van Facebook, zoa
 Laat ze u niet meer volgen
 
 
-;Listen to this
-Luister hiernaar
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Waarom doen bedrijven als Google en Facebook er alles aan om uw gedrag te voorspellen?
-
-
-;Listen to our IRL podcast
-Luister naar onze IRL-podcast
-
-
 ;That sneaky little button
 Dat stiekeme knopje
 

--- a/nn-NO/firefox/welcome/page7.lang
+++ b/nn-NO/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/nv/firefox/welcome/page7.lang
+++ b/nv/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/oc/firefox/welcome/page7.lang
+++ b/oc/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/pa-IN/firefox/welcome/page7.lang
+++ b/pa-IN/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/pai/firefox/welcome/page7.lang
+++ b/pai/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/pbb/firefox/welcome/page7.lang
+++ b/pbb/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/pl/firefox/welcome/page7.lang
+++ b/pl/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/ppl/firefox/welcome/page7.lang
+++ b/ppl/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/pt-BR/firefox/welcome/page7.lang
+++ b/pt-BR/firefox/welcome/page7.lang
@@ -37,18 +37,6 @@ O Facebook Container também funciona em outros sites de propriedade do Facebook
 Faça-os deixar de seguir você
 
 
-;Listen to this
-Escute isso
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Por que empresas como Google e Facebook estão fazendo todo o possível para prever seu comportamento?
-
-
-;Listen to our IRL podcast
-Ouça nosso podcast da IRL
-
-
 ;That sneaky little button
 Aquele botãozinho sorrateiro
 

--- a/pt-PT/firefox/welcome/page7.lang
+++ b/pt-PT/firefox/welcome/page7.lang
@@ -37,18 +37,6 @@ O Facebook Container também funciona noutros sites do Facebook como o Instagram
 Faça com que deixem de o seguir
 
 
-;Listen to this
-Ouça isto
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Porque é que empresas, como o Google e Facebook, estão a fazer todo o possível para prever o seu comportamento?
-
-
-;Listen to our IRL podcast
-Ouça o nosso podcast IRL
-
-
 ;That sneaky little button
 Aquele pequeno botão matreiro
 

--- a/qvi/firefox/welcome/page7.lang
+++ b/qvi/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/rm/firefox/welcome/page7.lang
+++ b/rm/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/ro/firefox/welcome/page7.lang
+++ b/ro/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/ru/firefox/welcome/page7.lang
+++ b/ru/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/si/firefox/welcome/page7.lang
+++ b/si/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/sk/firefox/welcome/page7.lang
+++ b/sk/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/sl/firefox/welcome/page7.lang
+++ b/sl/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container deluje tudi na drugih spletnih mestih v lasti Facebooka, kot 
 Naj vam ne sledijo
 
 
-;Listen to this
-Poslušajte to
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Zakaj podjetja, kot sta Google in Facebook, delajo vse, kar je v njihovi moči, da napovedo vaše vedenje?
-
-
-;Listen to our IRL podcast
-Poslušajte našo poddajo IRL
-
-
 ;That sneaky little button
 Ta mali zahrbtni gumb
 

--- a/son/firefox/welcome/page7.lang
+++ b/son/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/sq/firefox/welcome/page7.lang
+++ b/sq/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container funksionon gjithashtu në sajte të tjerë pronë e Facebook-
 Bëjini të reshtin së ndjekuri ju
 
 
-;Listen to this
-Dëgjojeni
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Pse bëjnë gjithçka mundin për të parashikuar sjelljen tuaj shoqëri të tilla si Google dhe Facebook?
-
-
-;Listen to our IRL podcast
-Dëgjoni podkastin tonë IRL
-
-
 ;That sneaky little button
 Ai butoni i vogël i prapë
 

--- a/sr/firefox/welcome/page7.lang
+++ b/sr/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/sv-SE/firefox/welcome/page7.lang
+++ b/sv-SE/firefox/welcome/page7.lang
@@ -37,18 +37,6 @@ Facebook Container fungerar också på andra Facebook-ägda webbplatser som Inst
 Låt dem inte följa dig igen
 
 
-;Listen to this
-Lyssna på detta
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Varför gör företag som Google och Facebook allt de kan för att förutsäga ditt beteende?
-
-
-;Listen to our IRL podcast
-Lyssna på vår IRL-podcast
-
-
 ;That sneaky little button
 Den lömska lilla knappen
 

--- a/sw/firefox/welcome/page7.lang
+++ b/sw/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/ta/firefox/welcome/page7.lang
+++ b/ta/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/te/firefox/welcome/page7.lang
+++ b/te/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/th/firefox/welcome/page7.lang
+++ b/th/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/tl/firefox/welcome/page7.lang
+++ b/tl/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/tr/firefox/welcome/page7.lang
+++ b/tr/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/trs/firefox/welcome/page7.lang
+++ b/trs/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/uk/firefox/welcome/page7.lang
+++ b/uk/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/ur/firefox/welcome/page7.lang
+++ b/ur/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/uz/firefox/welcome/page7.lang
+++ b/uz/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/vi/firefox/welcome/page7.lang
+++ b/vi/firefox/welcome/page7.lang
@@ -37,18 +37,6 @@ Facebook Container cũng hoạt động trên các trang web thuộc sở hữu 
 Làm cho họ bỏ theo dõi bạn
 
 
-;Listen to this
-Nghe này
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Tại sao các công ty như Google và Facebook làm mọi thứ có thể để dự đoán hành vi của bạn?
-
-
-;Listen to our IRL podcast
-Nghe podcast IRL của chúng tôi
-
-
 ;That sneaky little button
 Cái nút nhỏ lén lút đó
 

--- a/wo/firefox/welcome/page7.lang
+++ b/wo/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/xh/firefox/welcome/page7.lang
+++ b/xh/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/zam/firefox/welcome/page7.lang
+++ b/zam/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 

--- a/zh-CN/firefox/welcome/page7.lang
+++ b/zh-CN/firefox/welcome/page7.lang
@@ -37,18 +37,6 @@ Facebook Container 也对 Facebook 的其他网站－Instagram、Facebook Messen
 让它们无法跟踪您
 
 
-;Listen to this
-听听这个
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-为什么像 Google 和 Facebook 这样的公司要不择手段地预测您的行为？
-
-
-;Listen to our IRL podcast
-收听我们的 IRL 播客
-
-
 ;That sneaky little button
 那个狡猾的小按钮
 

--- a/zh-TW/firefox/welcome/page7.lang
+++ b/zh-TW/firefox/welcome/page7.lang
@@ -37,18 +37,6 @@ Facebook Container 也對 Facebook 的其他網站，包含 Instagram、Facebook
 讓他們不再追蹤您
 
 
-;Listen to this
-聽聽這個
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-為什麼像 Google 和 Facebook 這樣的要公司竭盡所能預測您的行為？
-
-
-;Listen to our IRL podcast
-收聽我們的 IRL podcast
-
-
 ;That sneaky little button
 偷偷摸摸的小按鈕
 

--- a/zu/firefox/welcome/page7.lang
+++ b/zu/firefox/welcome/page7.lang
@@ -36,18 +36,6 @@ Facebook Container also works on other Facebook owned sites like Instagram, Face
 Make them unfollow you
 
 
-;Listen to this
-Listen to this
-
-
-;Why are companies like Google and Facebook doing everything they can to predict your behavior?
-Why are companies like Google and Facebook doing everything they can to predict your behavior?
-
-
-;Listen to our IRL podcast
-Listen to our IRL podcast
-
-
 ;That sneaky little button
 That sneaky little button
 


### PR DESCRIPTION
These strings are only shown to English and don't need to be translated. Though normally there wouldn't be a problem with that, these three strings are currently preventing us from activating the page in French and German (which they really want to do ASAP).